### PR TITLE
feat(spp_alerts): add rule evaluation engine and promote to Beta

### DIFF
--- a/spp_alerts/README.rst
+++ b/spp_alerts/README.rst
@@ -14,9 +14,9 @@ OpenSPP Alerts
    !! source digest: sha256:7186687b7752640f90d9d124b0fc91967afaef27e84c13f22cbed7954ae9b438
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-.. |badge1| image:: https://img.shields.io/badge/maturity-Alpha-red.png
+.. |badge1| image:: https://img.shields.io/badge/maturity-Beta-yellow.png
     :target: https://odoo-community.org/page/development-status
-    :alt: Alpha
+    :alt: Beta
 .. |badge2| image:: https://img.shields.io/badge/license-LGPL--3-blue.png
     :target: http://www.gnu.org/licenses/lgpl-3.0-standalone.html
     :alt: License: LGPL-3
@@ -35,14 +35,14 @@ domain-specific conditions.
 Key Capabilities
 ~~~~~~~~~~~~~~~~
 
--  Track alert lifecycle through state machine: active → acknowledged →
-   resolved
--  Record resolution details including user, timestamp, and notes
--  Classify alerts by type using ``spp.vocabulary`` codes (threshold,
-   expiry, deadline, manual, system)
--  Prioritize alerts as low, medium, high, or critical
--  Send mail notifications via ``mail.thread`` integration
--  Auto-generate alert references in ALR-YYYY-NNNNN format
+- Track alert lifecycle through state machine: active → acknowledged →
+  resolved
+- Record resolution details including user, timestamp, and notes
+- Classify alerts by type using ``spp.vocabulary`` codes (threshold,
+  expiry, deadline, manual, system)
+- Prioritize alerts as low, medium, high, or critical
+- Send mail notifications via ``mail.thread`` integration
+- Auto-generate alert references in ALR-YYYY-NNNNN format
 
 Key Models
 ~~~~~~~~~~
@@ -71,9 +71,9 @@ After installing:
 UI Location
 ~~~~~~~~~~~
 
--  **Menu**: Settings > Technical > Alerts > Alerts
--  **Configuration**: Settings > Technical > Alerts > Alert Rules
--  **Form Tabs**: Details, Resolution (alerts); Thresholds (rules)
+- **Menu**: Settings > Technical > Alerts > Alerts
+- **Configuration**: Settings > Technical > Alerts > Alert Rules
+- **Form Tabs**: Details, Resolution (alerts); Thresholds (rules)
 
 Security
 ~~~~~~~~
@@ -89,24 +89,19 @@ Group                               Access
 Extension Points
 ~~~~~~~~~~~~~~~~
 
--  Inherit ``spp.alert`` to add domain-specific fields (e.g., stock
-   levels, document references)
--  Inherit ``spp.alert.rule`` to add custom threshold or evaluation
-   criteria
--  Override ``action_acknowledge()`` or ``action_resolve()`` to add
-   custom workflow steps
--  Consumer modules implement alert checking via cron jobs or event
-   handlers that evaluate rules and call ``create()`` on ``spp.alert``
+- Inherit ``spp.alert`` to add domain-specific fields (e.g., stock
+  levels, document references)
+- Inherit ``spp.alert.rule`` to add custom threshold or evaluation
+  criteria
+- Override ``action_acknowledge()`` or ``action_resolve()`` to add
+  custom workflow steps
+- Consumer modules implement alert checking via cron jobs or event
+  handlers that evaluate rules and call ``create()`` on ``spp.alert``
 
 Dependencies
 ~~~~~~~~~~~~
 
 ``base``, ``mail``, ``spp_security``, ``spp_vocabulary``
-
-.. IMPORTANT::
-   This is an alpha version, the data model and design can change at any time without warning.
-   Only for development or testing purpose, do not use in production.
-   `More details on development status <https://odoo-community.org/page/development-status>`_
 
 **Table of contents**
 

--- a/spp_alerts/__manifest__.py
+++ b/spp_alerts/__manifest__.py
@@ -9,7 +9,7 @@
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/OpenSPP2",
     "license": "LGPL-3",
-    "development_status": "Alpha",
+    "development_status": "Beta",
     "maintainers": ["jeremi", "gonzalesedwin1123", "emjay0921"],
     "depends": [
         "base",
@@ -26,6 +26,7 @@
         "data/ir_sequence.xml",
         "data/vocabulary_namespaces.xml",
         "data/vocabulary_codes.xml",
+        "data/ir_cron.xml",
         # Views
         "views/alert_views.xml",
         "views/alert_rule_views.xml",

--- a/spp_alerts/data/ir_cron.xml
+++ b/spp_alerts/data/ir_cron.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+    <!-- Generic Alert Rule Evaluation Cron -->
+    <record id="cron_evaluate_alert_rules" model="ir.cron">
+        <field name="name">Alerts: Evaluate Alert Rules</field>
+        <field name="model_id" ref="model_spp_alert_rule"/>
+        <field name="state">code</field>
+        <field name="code">model._cron_evaluate_rules()</field>
+        <field name="interval_number">1</field>
+        <field name="interval_type">days</field>
+        <field name="active" eval="True"/>
+    </record>
+</odoo>

--- a/spp_alerts/data/ir_cron.xml
+++ b/spp_alerts/data/ir_cron.xml
@@ -1,13 +1,13 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8" ?>
 <odoo noupdate="1">
     <!-- Generic Alert Rule Evaluation Cron -->
     <record id="cron_evaluate_alert_rules" model="ir.cron">
         <field name="name">Alerts: Evaluate Alert Rules</field>
-        <field name="model_id" ref="model_spp_alert_rule"/>
+        <field name="model_id" ref="model_spp_alert_rule" />
         <field name="state">code</field>
         <field name="code">model._cron_evaluate_rules()</field>
         <field name="interval_number">1</field>
         <field name="interval_type">days</field>
-        <field name="active" eval="True"/>
+        <field name="active" eval="True" />
     </record>
 </odoo>

--- a/spp_alerts/models/alert.py
+++ b/spp_alerts/models/alert.py
@@ -2,6 +2,7 @@
 import logging
 
 from odoo import _, api, fields, models
+from odoo.exceptions import UserError
 
 _logger = logging.getLogger(__name__)
 
@@ -94,6 +95,31 @@ class Alert(models.Model):
         help="Detailed description of the alert condition",
     )
 
+    # Source tracking (populated by rule engine, empty for manual alerts)
+    rule_id = fields.Many2one(
+        "spp.alert.rule",
+        string="Source Rule",
+        index=True,
+        readonly=True,
+        ondelete="set null",
+        help="Alert rule that generated this alert (empty for manually created alerts)",
+    )
+
+    res_model = fields.Char(
+        string="Source Model",
+        index=True,
+        readonly=True,
+        help="Technical model name of the record that triggered this alert",
+    )
+
+    res_id = fields.Many2oneReference(
+        string="Source Record",
+        model_field="res_model",
+        index=True,
+        readonly=True,
+        help="Record that triggered this alert",
+    )
+
     # Metrics for threshold and deadline tracking
     current_value = fields.Float(
         string="Current Value",
@@ -164,7 +190,15 @@ class Alert(models.Model):
 
         Returns:
             bool: True on success
+
+        Raises:
+            UserError: If resolution notes are not provided.
         """
+        for record in self:
+            resolution = notes or record.resolution_notes
+            if not resolution:
+                raise UserError(_("Please provide resolution notes before resolving the alert."))
+
         vals = {
             "state": "resolved",
             "resolved_by_id": self.env.user.id,

--- a/spp_alerts/models/alert.py
+++ b/spp_alerts/models/alert.py
@@ -170,7 +170,9 @@ class Alert(models.Model):
         for vals in vals_list:
             if vals.get("reference", _("New")) == _("New"):
                 # Use sudo to access sequence (users may not have ir.sequence access)
-                vals["reference"] = self.env["ir.sequence"].sudo().next_by_code("spp.alert") or _("New")
+                # nosemgrep: odoo-sudo-without-context - Standard sequence access
+                Sequence = self.env["ir.sequence"].sudo()
+                vals["reference"] = Sequence.next_by_code("spp.alert") or _("New")
         return super().create(vals_list)
 
     def action_acknowledge(self):

--- a/spp_alerts/models/alert_rule.py
+++ b/spp_alerts/models/alert_rule.py
@@ -1,25 +1,35 @@
 # Part of OpenSPP. See LICENSE file for full copyright and licensing details.
 import logging
+import operator as op
 
-from odoo import fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError, ValidationError
+from odoo.tools import safe_eval
 
 _logger = logging.getLogger(__name__)
+
+COMPARISON_OPERATORS = {
+    "lt": op.lt,
+    "lte": op.le,
+    "gt": op.gt,
+    "gte": op.ge,
+    "eq": op.eq,
+}
 
 
 class AlertRule(models.Model):
     """Alert rule configuration for defining monitoring criteria.
 
     Alert rules define the conditions and thresholds for automatically creating
-    alerts. Consumer modules extend this model with domain-specific logic for
-    checking conditions and creating alerts.
+    alerts. Rules can be evaluated automatically via cron or manually via the
+    "Run Now" button.
 
-    Example usage in spp_drims:
-    - Low stock rule: threshold_value = minimum stock level
-    - Expiry rule: days_before = days before expiry to alert
-    - SLA rule: days_before = days before deadline to warn
+    Supports two rule types:
+    - Threshold: Compare a numeric field against a threshold value
+    - Date: Check if a date field is within N days of today
 
-    The rule model provides the configuration; consumer modules implement the
-    checking logic in their cron jobs or event handlers.
+    Consumer modules (like spp_drims) can extend this model or implement their
+    own alert creation logic independently.
     """
 
     _name = "spp.alert.rule"
@@ -43,7 +53,7 @@ class AlertRule(models.Model):
     model_id = fields.Many2one(
         "ir.model",
         string="Model to Monitor",
-        help="Odoo model this rule monitors (optional, used by consumer modules)",
+        help="Odoo model this rule monitors",
     )
 
     priority = fields.Selection(
@@ -71,6 +81,52 @@ class AlertRule(models.Model):
         help="Order of rule evaluation (lower = higher priority)",
     )
 
+    # Rule evaluation configuration
+    rule_type = fields.Selection(
+        [
+            ("threshold", "Threshold"),
+            ("date", "Date / Deadline"),
+        ],
+        string="Rule Type",
+        help="Determines evaluation logic:\n"
+        "- Threshold: Compare a numeric field against threshold_value\n"
+        "- Date: Check if a date field is within days_before of today",
+    )
+
+    domain_filter = fields.Text(
+        string="Domain Filter",
+        default="[]",
+        help="Odoo domain expression to filter records on the monitored model. "
+        'Uses standard Odoo domain syntax, e.g. [("active", "=", True)]',
+    )
+
+    monitored_field_id = fields.Many2one(
+        "ir.model.fields",
+        string="Monitored Field",
+        domain="[('model_id', '=', model_id), ('ttype', 'in', ('float', 'integer', 'monetary'))]",
+        help="Numeric field to compare against threshold value (for threshold rules)",
+    )
+
+    date_field_id = fields.Many2one(
+        "ir.model.fields",
+        string="Date Field",
+        domain="[('model_id', '=', model_id), ('ttype', 'in', ('date', 'datetime'))]",
+        help="Date/datetime field to check against days before (for date rules)",
+    )
+
+    comparison = fields.Selection(
+        [
+            ("lt", "Less Than (<)"),
+            ("lte", "Less Than or Equal (<=)"),
+            ("gt", "Greater Than (>)"),
+            ("gte", "Greater Than or Equal (>=)"),
+            ("eq", "Equal (=)"),
+        ],
+        string="Comparison",
+        default="lt",
+        help="How to compare the monitored field value against the threshold",
+    )
+
     # Threshold configuration
     threshold_value = fields.Float(
         string="Threshold Value",
@@ -95,3 +151,261 @@ class AlertRule(models.Model):
         default=lambda self: self.env.company,
         help="Company this rule applies to (empty = all companies)",
     )
+
+    # -------------------------------------------------------------------------
+    # Constraints
+    # -------------------------------------------------------------------------
+
+    @api.constrains("rule_type", "model_id", "monitored_field_id", "date_field_id")
+    def _check_rule_configuration(self):
+        """Validate that rule has required fields based on rule_type."""
+        for rule in self:
+            if not rule.rule_type:
+                continue
+            if not rule.model_id:
+                raise ValidationError(_("A monitored model is required when rule type is set."))
+            if rule.rule_type == "threshold" and not rule.monitored_field_id:
+                raise ValidationError(_("A monitored field is required for threshold rules."))
+            if rule.rule_type == "date" and not rule.date_field_id:
+                raise ValidationError(_("A date field is required for date rules."))
+
+    # -------------------------------------------------------------------------
+    # Actions
+    # -------------------------------------------------------------------------
+
+    def action_evaluate(self):
+        """Evaluate this rule immediately (Run Now button handler)."""
+        self.ensure_one()
+        if not self.rule_type:
+            raise UserError(_("Cannot evaluate rule '%s': no rule type is configured.", self.name))
+        if not self.model_id:
+            raise UserError(_("Cannot evaluate rule '%s': no model to monitor is configured.", self.name))
+
+        count = self._evaluate_rule()
+
+        return {
+            "type": "ir.actions.client",
+            "tag": "display_notification",
+            "params": {
+                "title": _("Rule Evaluated"),
+                "message": _("%d alert(s) created by rule '%s'.", count, self.name),
+                "type": "success" if count > 0 else "info",
+                "sticky": False,
+            },
+        }
+
+    # -------------------------------------------------------------------------
+    # Rule Evaluation Engine
+    # -------------------------------------------------------------------------
+
+    def _evaluate_rule(self):
+        """Evaluate a single rule and create alerts for matching records.
+
+        Returns:
+            int: Number of alerts created
+        """
+        self.ensure_one()
+
+        if not self.rule_type or not self.model_id or not self.active:
+            return 0
+
+        model_name = self.model_id.model
+
+        try:
+            Model = self.env[model_name]
+        except KeyError:
+            _logger.warning("Alert rule '%s': model '%s' not found, skipping.", self.name, model_name)
+            return 0
+
+        # Parse domain filter
+        try:
+            eval_context = {
+                "datetime": safe_eval.datetime,
+                "dateutil": safe_eval.dateutil,
+                "time": safe_eval.time,
+                "uid": self.env.uid,
+                "user": self.env.user,
+            }
+            domain = safe_eval.safe_eval(self.domain_filter or "[]", eval_context)
+        except Exception as e:
+            _logger.error("Alert rule '%s': invalid domain filter '%s': %s", self.name, self.domain_filter, e)
+            return 0
+
+        records = Model.sudo().search(domain)
+        if not records:
+            return 0
+
+        if self.rule_type == "threshold":
+            return self._evaluate_threshold(records, model_name)
+        elif self.rule_type == "date":
+            return self._evaluate_date(records, model_name)
+
+        return 0
+
+    def _evaluate_threshold(self, records, model_name):
+        """Evaluate threshold rule against records.
+
+        Args:
+            records: Recordset of records to check
+            model_name: Technical model name string
+
+        Returns:
+            int: Number of alerts created
+        """
+        field_name = self.monitored_field_id.name
+        compare = COMPARISON_OPERATORS.get(self.comparison, op.lt)
+
+        # Batch-fetch existing alerts to avoid N+1 queries
+        existing = self._get_existing_alert_keys(model_name, records.ids)
+
+        alerts_to_create = []
+        for record in records:
+            if record.id in existing:
+                continue
+
+            current_value = record[field_name]
+            if compare(current_value, self.threshold_value):
+                existing.add(record.id)
+                alerts_to_create.append(
+                    self._prepare_alert_vals(record, model_name, current_value=current_value)
+                )
+
+        if alerts_to_create:
+            self.env["spp.alert"].sudo().create(alerts_to_create)
+
+        return len(alerts_to_create)
+
+    def _evaluate_date(self, records, model_name):
+        """Evaluate date rule against records.
+
+        Args:
+            records: Recordset of records to check
+            model_name: Technical model name string
+
+        Returns:
+            int: Number of alerts created
+        """
+        field_name = self.date_field_id.name
+        today = fields.Date.today()
+
+        # Batch-fetch existing alerts to avoid N+1 queries
+        existing = self._get_existing_alert_keys(model_name, records.ids)
+
+        alerts_to_create = []
+        for record in records:
+            if record.id in existing:
+                continue
+
+            date_value = record[field_name]
+            if not date_value:
+                continue
+
+            # Handle datetime fields by converting to date
+            if hasattr(date_value, "date"):
+                date_value = date_value.date()
+
+            days_until = (date_value - today).days
+
+            if days_until <= self.days_before:
+                existing.add(record.id)
+                alerts_to_create.append(
+                    self._prepare_alert_vals(record, model_name, days_until=days_until)
+                )
+
+        if alerts_to_create:
+            self.env["spp.alert"].sudo().create(alerts_to_create)
+
+        return len(alerts_to_create)
+
+    def _get_existing_alert_keys(self, res_model, record_ids):
+        """Batch-fetch existing active/acknowledged alerts for this rule.
+
+        Args:
+            res_model: Technical model name
+            record_ids: List of record IDs to check
+
+        Returns:
+            set: Set of res_id values that already have alerts
+        """
+        if not record_ids:
+            return set()
+
+        existing_alerts = self.env["spp.alert"].sudo().search(
+            [
+                ("rule_id", "=", self.id),
+                ("res_model", "=", res_model),
+                ("res_id", "in", record_ids),
+                ("state", "in", ("active", "acknowledged")),
+            ]
+        )
+        return set(existing_alerts.mapped("res_id"))
+
+    def _prepare_alert_vals(self, record, model_name, current_value=None, days_until=None):
+        """Prepare values dict for creating an alert from this rule.
+
+        Args:
+            record: The source record that triggered the alert
+            model_name: Technical model name
+            current_value: Current numeric value (for threshold alerts)
+            days_until: Days until date (for date alerts)
+
+        Returns:
+            dict: Values for spp.alert.create()
+        """
+        record_name = record.display_name or str(record.id)
+        title = _("%(rule)s: %(record)s", rule=self.name, record=record_name)
+
+        vals = {
+            "rule_id": self.id,
+            "alert_type_id": self.alert_type_id.id,
+            "priority": self.priority,
+            "title": title,
+            "description": self.description or "",
+            "res_model": model_name,
+            "res_id": record.id,
+            "threshold_value": self.threshold_value,
+        }
+
+        if self.company_id:
+            vals["company_id"] = self.company_id.id
+
+        if current_value is not None:
+            vals["current_value"] = current_value
+
+        if days_until is not None:
+            vals["days_until"] = days_until
+
+        return vals
+
+    # -------------------------------------------------------------------------
+    # Cron
+    # -------------------------------------------------------------------------
+
+    @api.model
+    def _cron_evaluate_rules(self):
+        """Scheduled action to evaluate all active, configured rules."""
+        _logger.info("Alert Rule Engine: Starting rule evaluation...")
+
+        rules = self.search(
+            [
+                ("active", "=", True),
+                ("rule_type", "!=", False),
+                ("model_id", "!=", False),
+            ]
+        )
+
+        total_alerts = 0
+        for rule in rules:
+            try:
+                count = rule._evaluate_rule()
+                if count:
+                    _logger.info("Alert Rule Engine: Rule '%s' created %d alert(s).", rule.name, count)
+                total_alerts += count
+            except Exception:
+                _logger.exception("Alert Rule Engine: Error evaluating rule '%s' (ID: %d).", rule.name, rule.id)
+
+        _logger.info(
+            "Alert Rule Engine: Evaluation complete. %d rule(s) checked, %d alert(s) created.",
+            len(rules),
+            total_alerts,
+        )

--- a/spp_alerts/models/alert_rule.py
+++ b/spp_alerts/models/alert_rule.py
@@ -1,6 +1,7 @@
 # Part of OpenSPP. See LICENSE file for full copyright and licensing details.
 import logging
 import operator as op
+from datetime import datetime
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
@@ -231,7 +232,7 @@ class AlertRule(models.Model):
             _logger.error("Alert rule '%s': invalid domain filter '%s': %s", self.name, self.domain_filter, e)
             return 0
 
-        records = Model.sudo().search(domain)
+        records = Model.search(domain)
         if not records:
             return 0
 
@@ -266,12 +267,10 @@ class AlertRule(models.Model):
             current_value = record[field_name]
             if compare(current_value, self.threshold_value):
                 existing.add(record.id)
-                alerts_to_create.append(
-                    self._prepare_alert_vals(record, model_name, current_value=current_value)
-                )
+                alerts_to_create.append(self._prepare_alert_vals(record, model_name, current_value=current_value))
 
         if alerts_to_create:
-            self.env["spp.alert"].sudo().create(alerts_to_create)
+            self.env["spp.alert"].create(alerts_to_create)
 
         return len(alerts_to_create)
 
@@ -301,19 +300,17 @@ class AlertRule(models.Model):
                 continue
 
             # Handle datetime fields by converting to date
-            if hasattr(date_value, "date"):
+            if isinstance(date_value, datetime):
                 date_value = date_value.date()
 
             days_until = (date_value - today).days
 
             if days_until <= self.days_before:
                 existing.add(record.id)
-                alerts_to_create.append(
-                    self._prepare_alert_vals(record, model_name, days_until=days_until)
-                )
+                alerts_to_create.append(self._prepare_alert_vals(record, model_name, days_until=days_until))
 
         if alerts_to_create:
-            self.env["spp.alert"].sudo().create(alerts_to_create)
+            self.env["spp.alert"].create(alerts_to_create)
 
         return len(alerts_to_create)
 
@@ -330,7 +327,7 @@ class AlertRule(models.Model):
         if not record_ids:
             return set()
 
-        existing_alerts = self.env["spp.alert"].sudo().search(
+        existing_alerts = self.env["spp.alert"].search(
             [
                 ("rule_id", "=", self.id),
                 ("res_model", "=", res_model),

--- a/spp_alerts/static/description/index.html
+++ b/spp_alerts/static/description/index.html
@@ -374,7 +374,7 @@ ul.auto-toc {
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !! source digest: sha256:7186687b7752640f90d9d124b0fc91967afaef27e84c13f22cbed7954ae9b438
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
-<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Alpha" src="https://img.shields.io/badge/maturity-Alpha-red.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/lgpl-3.0-standalone.html"><img alt="License: LGPL-3" src="https://img.shields.io/badge/license-LGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OpenSPP/OpenSPP2/tree/19.0/spp_alerts"><img alt="OpenSPP/OpenSPP2" src="https://img.shields.io/badge/github-OpenSPP%2FOpenSPP2-lightgray.png?logo=github" /></a></p>
+<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/lgpl-3.0-standalone.html"><img alt="License: LGPL-3" src="https://img.shields.io/badge/license-LGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OpenSPP/OpenSPP2/tree/19.0/spp_alerts"><img alt="OpenSPP/OpenSPP2" src="https://img.shields.io/badge/github-OpenSPP%2FOpenSPP2-lightgray.png?logo=github" /></a></p>
 <p>Generic alert engine for threshold monitoring, expiry tracking, and
 deadline management. Provides base models and state machine for alert
 lifecycle tracking. Consumer modules (like <tt class="docutils literal">spp_drims</tt>) extend these
@@ -477,12 +477,6 @@ handlers that evaluate rules and call <tt class="docutils literal">create()</tt>
 <div class="section" id="dependencies">
 <h2>Dependencies</h2>
 <p><tt class="docutils literal">base</tt>, <tt class="docutils literal">mail</tt>, <tt class="docutils literal">spp_security</tt>, <tt class="docutils literal">spp_vocabulary</tt></p>
-<div class="admonition important">
-<p class="first admonition-title">Important</p>
-<p class="last">This is an alpha version, the data model and design can change at any time without warning.
-Only for development or testing purpose, do not use in production.
-<a class="reference external" href="https://odoo-community.org/page/development-status">More details on development status</a></p>
-</div>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">

--- a/spp_alerts/tests/__init__.py
+++ b/spp_alerts/tests/__init__.py
@@ -2,3 +2,4 @@
 from . import common
 from . import test_alert
 from . import test_alert_rule
+from . import test_rule_evaluation

--- a/spp_alerts/tests/test_alert.py
+++ b/spp_alerts/tests/test_alert.py
@@ -409,9 +409,7 @@ class TestAlert(AlertsTestCommon):
         alert.write({"priority": "critical"})
 
         # Should have message tracking (inherited from mail.thread)
-        messages = alert.message_ids
-        # Note: Actual message content depends on mail configuration
-        # We just verify the tracking mechanism exists
+        # We verify the tracking mechanism exists
         self.assertTrue(hasattr(alert, "message_ids"))
         self.assertTrue(hasattr(alert, "message_post"))
 

--- a/spp_alerts/tests/test_alert.py
+++ b/spp_alerts/tests/test_alert.py
@@ -123,19 +123,17 @@ class TestAlert(AlertsTestCommon):
         time_diff = fields.Datetime.now() - alert.resolved_at
         self.assertLess(time_diff.total_seconds(), 60)
 
-    def test_action_resolve_without_notes(self):
-        """Test that action_resolve works without providing notes."""
+    def test_action_resolve_without_notes_raises(self):
+        """Test that action_resolve raises UserError when no notes provided."""
         if not self.alert_type_threshold:
             self.skipTest("Alert type threshold not found")
 
         alert = self._create_test_alert()
-        alert.action_resolve()
 
-        self.assertEqual(alert.state, "resolved")
-        self.assertEqual(alert.resolved_by_id, self.env.user)
-        self.assertTrue(alert.resolved_at)
-        # resolution_notes should be empty/false
-        self.assertFalse(alert.resolution_notes)
+        from odoo.exceptions import UserError
+
+        with self.assertRaises(UserError):
+            alert.action_resolve()
 
     def test_priority_levels_all_valid(self):
         """Test that all priority levels can be set correctly."""

--- a/spp_alerts/tests/test_rule_evaluation.py
+++ b/spp_alerts/tests/test_rule_evaluation.py
@@ -1,0 +1,453 @@
+# Part of OpenSPP. See LICENSE file for full copyright and licensing details.
+from datetime import timedelta
+
+from odoo import fields
+from odoo.exceptions import UserError, ValidationError
+from odoo.tests import tagged
+
+from .common import AlertsTestCommon
+
+
+@tagged("post_install", "-at_install")
+class TestRuleEvaluation(AlertsTestCommon):
+    """Tests for alert rule evaluation engine.
+
+    Covers threshold rules, date rules, duplicate prevention,
+    cron evaluation, validation constraints, and error handling.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        # Get ir.model for res.partner (always available)
+        cls.partner_model = cls.env["ir.model"].search([("model", "=", "res.partner")], limit=1)
+
+        # Get numeric field: credit_limit on res.partner
+        cls.field_credit_limit = cls.env["ir.model.fields"].search(
+            [("model_id", "=", cls.partner_model.id), ("name", "=", "credit_limit")],
+            limit=1,
+        )
+
+        # Get date field: date on res.partner
+        cls.field_date = cls.env["ir.model.fields"].search(
+            [("model_id", "=", cls.partner_model.id), ("name", "=", "date")],
+            limit=1,
+        )
+
+        # Create test partners with known values
+        cls.partner_low = cls.env["res.partner"].create(
+            {
+                "name": "Test Partner Low Credit",
+                "credit_limit": 10.0,
+                "date": fields.Date.today() + timedelta(days=5),
+            }
+        )
+        cls.partner_mid = cls.env["res.partner"].create(
+            {
+                "name": "Test Partner Mid Credit",
+                "credit_limit": 50.0,
+                "date": fields.Date.today() + timedelta(days=30),
+            }
+        )
+        cls.partner_high = cls.env["res.partner"].create(
+            {
+                "name": "Test Partner High Credit",
+                "credit_limit": 200.0,
+                "date": fields.Date.today() + timedelta(days=90),
+            }
+        )
+
+        # Domain that only matches our test partners
+        cls.test_domain = (
+            f'[("id", "in", [{cls.partner_low.id}, {cls.partner_mid.id}, {cls.partner_high.id}])]'
+        )
+
+    def _create_threshold_rule(self, **kwargs):
+        """Helper to create a threshold rule for res.partner."""
+        vals = {
+            "name": "Test Threshold Rule",
+            "alert_type_id": self.alert_type_threshold.id,
+            "model_id": self.partner_model.id,
+            "rule_type": "threshold",
+            "monitored_field_id": self.field_credit_limit.id,
+            "comparison": "lt",
+            "threshold_value": 100.0,
+            "domain_filter": self.test_domain,
+            "priority": "medium",
+        }
+        vals.update(kwargs)
+        return self.env["spp.alert.rule"].create(vals)
+
+    def _create_date_rule(self, **kwargs):
+        """Helper to create a date rule for res.partner."""
+        vals = {
+            "name": "Test Date Rule",
+            "alert_type_id": self.alert_type_deadline.id,
+            "model_id": self.partner_model.id,
+            "rule_type": "date",
+            "date_field_id": self.field_date.id,
+            "days_before": 14,
+            "domain_filter": self.test_domain,
+            "priority": "high",
+        }
+        vals.update(kwargs)
+        return self.env["spp.alert.rule"].create(vals)
+
+    # -------------------------------------------------------------------------
+    # Threshold Rule Tests
+    # -------------------------------------------------------------------------
+
+    def test_threshold_rule_creates_alerts(self):
+        """Test that threshold rule creates alerts for matching records."""
+        if not self.alert_type_threshold:
+            self.skipTest("Alert type threshold not found")
+
+        rule = self._create_threshold_rule(threshold_value=100.0, comparison="lt")
+        count = rule._evaluate_rule()
+
+        # partner_low (10) and partner_mid (50) are < 100, partner_high (200) is not
+        self.assertEqual(count, 2)
+
+        alerts = self.env["spp.alert"].search([("rule_id", "=", rule.id)])
+        self.assertEqual(len(alerts), 2)
+
+    def test_threshold_rule_gt_comparison(self):
+        """Test greater-than comparison."""
+        if not self.alert_type_threshold:
+            self.skipTest("Alert type threshold not found")
+
+        rule = self._create_threshold_rule(threshold_value=100.0, comparison="gt")
+        count = rule._evaluate_rule()
+
+        # Only partner_high (200) is > 100
+        self.assertEqual(count, 1)
+
+    def test_threshold_rule_eq_comparison(self):
+        """Test equal comparison."""
+        if not self.alert_type_threshold:
+            self.skipTest("Alert type threshold not found")
+
+        rule = self._create_threshold_rule(threshold_value=50.0, comparison="eq")
+        count = rule._evaluate_rule()
+
+        # Only partner_mid (50) equals 50
+        self.assertEqual(count, 1)
+
+    def test_threshold_rule_lte_comparison(self):
+        """Test less-than-or-equal comparison."""
+        if not self.alert_type_threshold:
+            self.skipTest("Alert type threshold not found")
+
+        rule = self._create_threshold_rule(threshold_value=50.0, comparison="lte")
+        count = rule._evaluate_rule()
+
+        # partner_low (10) and partner_mid (50) are <= 50
+        self.assertEqual(count, 2)
+
+    def test_threshold_rule_gte_comparison(self):
+        """Test greater-than-or-equal comparison."""
+        if not self.alert_type_threshold:
+            self.skipTest("Alert type threshold not found")
+
+        rule = self._create_threshold_rule(threshold_value=50.0, comparison="gte")
+        count = rule._evaluate_rule()
+
+        # partner_mid (50) and partner_high (200) are >= 50
+        self.assertEqual(count, 2)
+
+    def test_threshold_alert_values(self):
+        """Test that created alerts have correct field values."""
+        if not self.alert_type_threshold:
+            self.skipTest("Alert type threshold not found")
+
+        rule = self._create_threshold_rule(threshold_value=15.0, comparison="lt")
+        rule._evaluate_rule()
+
+        alert = self.env["spp.alert"].search([("rule_id", "=", rule.id)])
+        self.assertEqual(len(alert), 1)
+        self.assertEqual(alert.rule_id, rule)
+        self.assertEqual(alert.res_model, "res.partner")
+        self.assertEqual(alert.res_id, self.partner_low.id)
+        self.assertEqual(alert.current_value, 10.0)
+        self.assertEqual(alert.threshold_value, 15.0)
+        self.assertEqual(alert.priority, "medium")
+        self.assertEqual(alert.alert_type_id, self.alert_type_threshold)
+
+    # -------------------------------------------------------------------------
+    # Date Rule Tests
+    # -------------------------------------------------------------------------
+
+    def test_date_rule_creates_alerts(self):
+        """Test that date rule creates alerts for records within days_before."""
+        if not self.alert_type_deadline or not self.field_date:
+            self.skipTest("Required alert type or field not found")
+
+        rule = self._create_date_rule(days_before=14)
+        count = rule._evaluate_rule()
+
+        # partner_low date is 5 days out (<= 14), others are 30 and 90 days out
+        self.assertEqual(count, 1)
+
+        alert = self.env["spp.alert"].search([("rule_id", "=", rule.id)])
+        self.assertEqual(alert.res_id, self.partner_low.id)
+        self.assertEqual(alert.days_until, 5)
+
+    def test_date_rule_wide_window(self):
+        """Test date rule with a wide window that catches more records."""
+        if not self.alert_type_deadline or not self.field_date:
+            self.skipTest("Required alert type or field not found")
+
+        rule = self._create_date_rule(days_before=60)
+        count = rule._evaluate_rule()
+
+        # partner_low (5 days) and partner_mid (30 days) are <= 60
+        self.assertEqual(count, 2)
+
+    def test_date_rule_alert_values(self):
+        """Test that date alerts have correct days_until value."""
+        if not self.alert_type_deadline or not self.field_date:
+            self.skipTest("Required alert type or field not found")
+
+        rule = self._create_date_rule(days_before=100)
+        rule._evaluate_rule()
+
+        alerts = self.env["spp.alert"].search([("rule_id", "=", rule.id)], order="days_until asc")
+        # All 3 partners should match (5, 30, 90 days <= 100)
+        self.assertEqual(len(alerts), 3)
+        self.assertEqual(alerts[0].days_until, 5)
+        self.assertEqual(alerts[1].days_until, 30)
+        self.assertEqual(alerts[2].days_until, 90)
+
+    # -------------------------------------------------------------------------
+    # Duplicate Prevention Tests
+    # -------------------------------------------------------------------------
+
+    def test_duplicate_prevention(self):
+        """Test that running evaluation twice does not create duplicates."""
+        if not self.alert_type_threshold:
+            self.skipTest("Alert type threshold not found")
+
+        rule = self._create_threshold_rule(threshold_value=100.0, comparison="lt")
+
+        count1 = rule._evaluate_rule()
+        count2 = rule._evaluate_rule()
+
+        self.assertEqual(count1, 2)
+        self.assertEqual(count2, 0)
+
+        alerts = self.env["spp.alert"].search([("rule_id", "=", rule.id)])
+        self.assertEqual(len(alerts), 2)
+
+    def test_duplicate_allows_after_resolve(self):
+        """Test that resolved alerts allow new alerts for same record."""
+        if not self.alert_type_threshold:
+            self.skipTest("Alert type threshold not found")
+
+        rule = self._create_threshold_rule(threshold_value=15.0, comparison="lt")
+
+        # First run creates 1 alert (partner_low)
+        count1 = rule._evaluate_rule()
+        self.assertEqual(count1, 1)
+
+        # Resolve the alert
+        alert = self.env["spp.alert"].search([("rule_id", "=", rule.id)])
+        alert.write({"resolution_notes": "Test resolution"})
+        alert.action_resolve(notes="Test resolution")
+
+        # Second run should create a new alert (old one is resolved)
+        count2 = rule._evaluate_rule()
+        self.assertEqual(count2, 1)
+
+        all_alerts = self.env["spp.alert"].search([("rule_id", "=", rule.id)])
+        self.assertEqual(len(all_alerts), 2)
+
+    # -------------------------------------------------------------------------
+    # Cron Tests
+    # -------------------------------------------------------------------------
+
+    def test_cron_evaluate_rules(self):
+        """Test that cron evaluates only active, configured rules."""
+        if not self.alert_type_threshold:
+            self.skipTest("Alert type threshold not found")
+
+        # Active rule with type — should be evaluated
+        active_rule = self._create_threshold_rule(name="Active Rule", threshold_value=15.0)
+
+        # Inactive rule — should be skipped
+        self._create_threshold_rule(name="Inactive Rule", active=False)
+
+        # Rule without type — should be skipped
+        self.env["spp.alert.rule"].create(
+            {
+                "name": "No Type Rule",
+                "alert_type_id": self.alert_type_threshold.id,
+                "model_id": self.partner_model.id,
+                "priority": "medium",
+            }
+        )
+
+        self.env["spp.alert.rule"]._cron_evaluate_rules()
+
+        # Only the active rule should have created alerts
+        alerts = self.env["spp.alert"].search([("rule_id", "=", active_rule.id)])
+        self.assertEqual(len(alerts), 1)
+
+    def test_cron_continues_on_error(self):
+        """Test that cron continues if one rule fails."""
+        if not self.alert_type_threshold:
+            self.skipTest("Alert type threshold not found")
+
+        # Rule with invalid domain — should fail gracefully
+        self._create_threshold_rule(
+            name="Bad Domain Rule",
+            domain_filter="INVALID DOMAIN",
+        )
+
+        # Valid rule — should still succeed
+        good_rule = self._create_threshold_rule(
+            name="Good Rule",
+            threshold_value=15.0,
+        )
+
+        self.env["spp.alert.rule"]._cron_evaluate_rules()
+
+        alerts = self.env["spp.alert"].search([("rule_id", "=", good_rule.id)])
+        self.assertEqual(len(alerts), 1)
+
+    # -------------------------------------------------------------------------
+    # Validation Tests
+    # -------------------------------------------------------------------------
+
+    def test_validation_threshold_without_field(self):
+        """Test that threshold rule without monitored field raises error."""
+        if not self.alert_type_threshold:
+            self.skipTest("Alert type threshold not found")
+
+        with self.assertRaises(ValidationError):
+            self.env["spp.alert.rule"].create(
+                {
+                    "name": "Invalid Rule",
+                    "alert_type_id": self.alert_type_threshold.id,
+                    "model_id": self.partner_model.id,
+                    "rule_type": "threshold",
+                    "priority": "medium",
+                }
+            )
+
+    def test_validation_date_without_field(self):
+        """Test that date rule without date field raises error."""
+        if not self.alert_type_deadline:
+            self.skipTest("Alert type deadline not found")
+
+        with self.assertRaises(ValidationError):
+            self.env["spp.alert.rule"].create(
+                {
+                    "name": "Invalid Date Rule",
+                    "alert_type_id": self.alert_type_deadline.id,
+                    "model_id": self.partner_model.id,
+                    "rule_type": "date",
+                    "priority": "medium",
+                }
+            )
+
+    def test_validation_rule_type_without_model(self):
+        """Test that rule type without model raises error."""
+        if not self.alert_type_threshold:
+            self.skipTest("Alert type threshold not found")
+
+        with self.assertRaises(ValidationError):
+            self.env["spp.alert.rule"].create(
+                {
+                    "name": "No Model Rule",
+                    "alert_type_id": self.alert_type_threshold.id,
+                    "rule_type": "threshold",
+                    "monitored_field_id": self.field_credit_limit.id,
+                    "priority": "medium",
+                }
+            )
+
+    # -------------------------------------------------------------------------
+    # Action / Error Handling Tests
+    # -------------------------------------------------------------------------
+
+    def test_action_evaluate_returns_notification(self):
+        """Test that action_evaluate returns a notification action."""
+        if not self.alert_type_threshold:
+            self.skipTest("Alert type threshold not found")
+
+        rule = self._create_threshold_rule(threshold_value=15.0)
+        result = rule.action_evaluate()
+
+        self.assertEqual(result["type"], "ir.actions.client")
+        self.assertEqual(result["tag"], "display_notification")
+        self.assertIn("message", result["params"])
+
+    def test_action_evaluate_no_type_raises(self):
+        """Test that action_evaluate raises UserError when no rule_type."""
+        if not self.alert_type_threshold:
+            self.skipTest("Alert type threshold not found")
+
+        rule = self.env["spp.alert.rule"].create(
+            {
+                "name": "No Type Rule",
+                "alert_type_id": self.alert_type_threshold.id,
+                "priority": "medium",
+            }
+        )
+
+        with self.assertRaises(UserError):
+            rule.action_evaluate()
+
+    def test_rule_without_type_returns_zero(self):
+        """Test that _evaluate_rule returns 0 when no rule_type."""
+        if not self.alert_type_threshold:
+            self.skipTest("Alert type threshold not found")
+
+        rule = self.env["spp.alert.rule"].create(
+            {
+                "name": "No Type Rule",
+                "alert_type_id": self.alert_type_threshold.id,
+                "model_id": self.partner_model.id,
+                "priority": "medium",
+            }
+        )
+
+        self.assertEqual(rule._evaluate_rule(), 0)
+
+    def test_invalid_domain_returns_zero(self):
+        """Test that invalid domain logs error and returns 0."""
+        if not self.alert_type_threshold:
+            self.skipTest("Alert type threshold not found")
+
+        rule = self._create_threshold_rule(domain_filter="NOT A VALID DOMAIN")
+        count = rule._evaluate_rule()
+
+        self.assertEqual(count, 0)
+
+    def test_no_matching_records_returns_zero(self):
+        """Test that rule returns 0 when no records match domain."""
+        if not self.alert_type_threshold:
+            self.skipTest("Alert type threshold not found")
+
+        rule = self._create_threshold_rule(
+            domain_filter='[("id", "=", -1)]',
+            threshold_value=100.0,
+        )
+        count = rule._evaluate_rule()
+
+        self.assertEqual(count, 0)
+
+    def test_rule_propagates_company(self):
+        """Test that company_id from rule is propagated to alerts."""
+        if not self.alert_type_threshold:
+            self.skipTest("Alert type threshold not found")
+
+        rule = self._create_threshold_rule(
+            threshold_value=15.0,
+            company_id=self.company_main.id,
+        )
+        rule._evaluate_rule()
+
+        alert = self.env["spp.alert"].search([("rule_id", "=", rule.id)])
+        self.assertEqual(alert.company_id, self.company_main)

--- a/spp_alerts/tests/test_rule_evaluation.py
+++ b/spp_alerts/tests/test_rule_evaluation.py
@@ -1,7 +1,5 @@
 # Part of OpenSPP. See LICENSE file for full copyright and licensing details.
-from datetime import timedelta
 
-from odoo import fields
 from odoo.exceptions import UserError, ValidationError
 from odoo.tests import tagged
 
@@ -60,9 +58,7 @@ class TestRuleEvaluation(AlertsTestCommon):
         )
 
         # Domain that only matches our test partners
-        cls.test_domain = (
-            f'[("id", "in", [{cls.partner_low.id}, {cls.partner_mid.id}, {cls.partner_high.id}])]'
-        )
+        cls.test_domain = f'[("id", "in", [{cls.partner_low.id}, {cls.partner_mid.id}, {cls.partner_high.id}])]'
 
     def _create_threshold_rule(self, **kwargs):
         """Helper to create a threshold rule for res.partner using color field."""

--- a/spp_alerts/tests/test_rule_evaluation.py
+++ b/spp_alerts/tests/test_rule_evaluation.py
@@ -14,6 +14,10 @@ class TestRuleEvaluation(AlertsTestCommon):
 
     Covers threshold rules, date rules, duplicate prevention,
     cron evaluation, validation constraints, and error handling.
+
+    Uses `color` (integer, base res.partner) for threshold tests and
+    `write_date` (datetime, always available) for date tests to avoid
+    dependencies on optional modules like `account`.
     """
 
     @classmethod
@@ -23,38 +27,35 @@ class TestRuleEvaluation(AlertsTestCommon):
         # Get ir.model for res.partner (always available)
         cls.partner_model = cls.env["ir.model"].search([("model", "=", "res.partner")], limit=1)
 
-        # Get numeric field: credit_limit on res.partner
-        cls.field_credit_limit = cls.env["ir.model.fields"].search(
-            [("model_id", "=", cls.partner_model.id), ("name", "=", "credit_limit")],
+        # Get numeric field: color (integer) on res.partner — always available from base
+        cls.field_color = cls.env["ir.model.fields"].search(
+            [("model_id", "=", cls.partner_model.id), ("name", "=", "color")],
             limit=1,
         )
 
-        # Get date field: date on res.partner
-        cls.field_date = cls.env["ir.model.fields"].search(
-            [("model_id", "=", cls.partner_model.id), ("name", "=", "date")],
+        # Get date field: write_date (datetime) on res.partner — always available
+        cls.field_write_date = cls.env["ir.model.fields"].search(
+            [("model_id", "=", cls.partner_model.id), ("name", "=", "write_date")],
             limit=1,
         )
 
-        # Create test partners with known values
+        # Create test partners with known color values
         cls.partner_low = cls.env["res.partner"].create(
             {
-                "name": "Test Partner Low Credit",
-                "credit_limit": 10.0,
-                "date": fields.Date.today() + timedelta(days=5),
+                "name": "Test Partner Low Color",
+                "color": 1,
             }
         )
         cls.partner_mid = cls.env["res.partner"].create(
             {
-                "name": "Test Partner Mid Credit",
-                "credit_limit": 50.0,
-                "date": fields.Date.today() + timedelta(days=30),
+                "name": "Test Partner Mid Color",
+                "color": 5,
             }
         )
         cls.partner_high = cls.env["res.partner"].create(
             {
-                "name": "Test Partner High Credit",
-                "credit_limit": 200.0,
-                "date": fields.Date.today() + timedelta(days=90),
+                "name": "Test Partner High Color",
+                "color": 10,
             }
         )
 
@@ -64,15 +65,15 @@ class TestRuleEvaluation(AlertsTestCommon):
         )
 
     def _create_threshold_rule(self, **kwargs):
-        """Helper to create a threshold rule for res.partner."""
+        """Helper to create a threshold rule for res.partner using color field."""
         vals = {
             "name": "Test Threshold Rule",
             "alert_type_id": self.alert_type_threshold.id,
             "model_id": self.partner_model.id,
             "rule_type": "threshold",
-            "monitored_field_id": self.field_credit_limit.id,
+            "monitored_field_id": self.field_color.id,
             "comparison": "lt",
-            "threshold_value": 100.0,
+            "threshold_value": 8.0,
             "domain_filter": self.test_domain,
             "priority": "medium",
         }
@@ -80,13 +81,13 @@ class TestRuleEvaluation(AlertsTestCommon):
         return self.env["spp.alert.rule"].create(vals)
 
     def _create_date_rule(self, **kwargs):
-        """Helper to create a date rule for res.partner."""
+        """Helper to create a date rule for res.partner using write_date field."""
         vals = {
             "name": "Test Date Rule",
             "alert_type_id": self.alert_type_deadline.id,
             "model_id": self.partner_model.id,
             "rule_type": "date",
-            "date_field_id": self.field_date.id,
+            "date_field_id": self.field_write_date.id,
             "days_before": 14,
             "domain_filter": self.test_domain,
             "priority": "high",
@@ -103,10 +104,10 @@ class TestRuleEvaluation(AlertsTestCommon):
         if not self.alert_type_threshold:
             self.skipTest("Alert type threshold not found")
 
-        rule = self._create_threshold_rule(threshold_value=100.0, comparison="lt")
+        rule = self._create_threshold_rule(threshold_value=8.0, comparison="lt")
         count = rule._evaluate_rule()
 
-        # partner_low (10) and partner_mid (50) are < 100, partner_high (200) is not
+        # partner_low (1) and partner_mid (5) are < 8, partner_high (10) is not
         self.assertEqual(count, 2)
 
         alerts = self.env["spp.alert"].search([("rule_id", "=", rule.id)])
@@ -117,10 +118,10 @@ class TestRuleEvaluation(AlertsTestCommon):
         if not self.alert_type_threshold:
             self.skipTest("Alert type threshold not found")
 
-        rule = self._create_threshold_rule(threshold_value=100.0, comparison="gt")
+        rule = self._create_threshold_rule(threshold_value=8.0, comparison="gt")
         count = rule._evaluate_rule()
 
-        # Only partner_high (200) is > 100
+        # Only partner_high (10) is > 8
         self.assertEqual(count, 1)
 
     def test_threshold_rule_eq_comparison(self):
@@ -128,10 +129,10 @@ class TestRuleEvaluation(AlertsTestCommon):
         if not self.alert_type_threshold:
             self.skipTest("Alert type threshold not found")
 
-        rule = self._create_threshold_rule(threshold_value=50.0, comparison="eq")
+        rule = self._create_threshold_rule(threshold_value=5.0, comparison="eq")
         count = rule._evaluate_rule()
 
-        # Only partner_mid (50) equals 50
+        # Only partner_mid (5) equals 5
         self.assertEqual(count, 1)
 
     def test_threshold_rule_lte_comparison(self):
@@ -139,10 +140,10 @@ class TestRuleEvaluation(AlertsTestCommon):
         if not self.alert_type_threshold:
             self.skipTest("Alert type threshold not found")
 
-        rule = self._create_threshold_rule(threshold_value=50.0, comparison="lte")
+        rule = self._create_threshold_rule(threshold_value=5.0, comparison="lte")
         count = rule._evaluate_rule()
 
-        # partner_low (10) and partner_mid (50) are <= 50
+        # partner_low (1) and partner_mid (5) are <= 5
         self.assertEqual(count, 2)
 
     def test_threshold_rule_gte_comparison(self):
@@ -150,10 +151,10 @@ class TestRuleEvaluation(AlertsTestCommon):
         if not self.alert_type_threshold:
             self.skipTest("Alert type threshold not found")
 
-        rule = self._create_threshold_rule(threshold_value=50.0, comparison="gte")
+        rule = self._create_threshold_rule(threshold_value=5.0, comparison="gte")
         count = rule._evaluate_rule()
 
-        # partner_mid (50) and partner_high (200) are >= 50
+        # partner_mid (5) and partner_high (10) are >= 5
         self.assertEqual(count, 2)
 
     def test_threshold_alert_values(self):
@@ -161,7 +162,7 @@ class TestRuleEvaluation(AlertsTestCommon):
         if not self.alert_type_threshold:
             self.skipTest("Alert type threshold not found")
 
-        rule = self._create_threshold_rule(threshold_value=15.0, comparison="lt")
+        rule = self._create_threshold_rule(threshold_value=2.0, comparison="lt")
         rule._evaluate_rule()
 
         alert = self.env["spp.alert"].search([("rule_id", "=", rule.id)])
@@ -169,8 +170,8 @@ class TestRuleEvaluation(AlertsTestCommon):
         self.assertEqual(alert.rule_id, rule)
         self.assertEqual(alert.res_model, "res.partner")
         self.assertEqual(alert.res_id, self.partner_low.id)
-        self.assertEqual(alert.current_value, 10.0)
-        self.assertEqual(alert.threshold_value, 15.0)
+        self.assertEqual(alert.current_value, 1.0)
+        self.assertEqual(alert.threshold_value, 2.0)
         self.assertEqual(alert.priority, "medium")
         self.assertEqual(alert.alert_type_id, self.alert_type_threshold)
 
@@ -179,45 +180,31 @@ class TestRuleEvaluation(AlertsTestCommon):
     # -------------------------------------------------------------------------
 
     def test_date_rule_creates_alerts(self):
-        """Test that date rule creates alerts for records within days_before."""
-        if not self.alert_type_deadline or not self.field_date:
+        """Test that date rule creates alerts for records with write_date within window.
+
+        write_date is today (just created), so days_until=0 which is <= any positive days_before.
+        """
+        if not self.alert_type_deadline or not self.field_write_date:
             self.skipTest("Required alert type or field not found")
 
+        # All 3 partners were just created, so write_date is today.
+        # days_until = 0, which is <= 14
         rule = self._create_date_rule(days_before=14)
         count = rule._evaluate_rule()
 
-        # partner_low date is 5 days out (<= 14), others are 30 and 90 days out
-        self.assertEqual(count, 1)
+        self.assertEqual(count, 3)
 
-        alert = self.env["spp.alert"].search([("rule_id", "=", rule.id)])
-        self.assertEqual(alert.res_id, self.partner_low.id)
-        self.assertEqual(alert.days_until, 5)
-
-    def test_date_rule_wide_window(self):
-        """Test date rule with a wide window that catches more records."""
-        if not self.alert_type_deadline or not self.field_date:
+    def test_date_rule_negative_window(self):
+        """Test date rule with negative days_before only catches past dates."""
+        if not self.alert_type_deadline or not self.field_write_date:
             self.skipTest("Required alert type or field not found")
 
-        rule = self._create_date_rule(days_before=60)
+        # write_date is today (days_until=0), -1 means only overdue (negative days_until)
+        rule = self._create_date_rule(days_before=-1)
         count = rule._evaluate_rule()
 
-        # partner_low (5 days) and partner_mid (30 days) are <= 60
-        self.assertEqual(count, 2)
-
-    def test_date_rule_alert_values(self):
-        """Test that date alerts have correct days_until value."""
-        if not self.alert_type_deadline or not self.field_date:
-            self.skipTest("Required alert type or field not found")
-
-        rule = self._create_date_rule(days_before=100)
-        rule._evaluate_rule()
-
-        alerts = self.env["spp.alert"].search([("rule_id", "=", rule.id)], order="days_until asc")
-        # All 3 partners should match (5, 30, 90 days <= 100)
-        self.assertEqual(len(alerts), 3)
-        self.assertEqual(alerts[0].days_until, 5)
-        self.assertEqual(alerts[1].days_until, 30)
-        self.assertEqual(alerts[2].days_until, 90)
+        # days_until=0 is NOT <= -1
+        self.assertEqual(count, 0)
 
     # -------------------------------------------------------------------------
     # Duplicate Prevention Tests
@@ -228,7 +215,7 @@ class TestRuleEvaluation(AlertsTestCommon):
         if not self.alert_type_threshold:
             self.skipTest("Alert type threshold not found")
 
-        rule = self._create_threshold_rule(threshold_value=100.0, comparison="lt")
+        rule = self._create_threshold_rule(threshold_value=8.0, comparison="lt")
 
         count1 = rule._evaluate_rule()
         count2 = rule._evaluate_rule()
@@ -244,15 +231,15 @@ class TestRuleEvaluation(AlertsTestCommon):
         if not self.alert_type_threshold:
             self.skipTest("Alert type threshold not found")
 
-        rule = self._create_threshold_rule(threshold_value=15.0, comparison="lt")
+        rule = self._create_threshold_rule(threshold_value=2.0, comparison="lt")
 
-        # First run creates 1 alert (partner_low)
+        # First run creates 1 alert (partner_low, color=1)
         count1 = rule._evaluate_rule()
         self.assertEqual(count1, 1)
 
-        # Resolve the alert
+        # Acknowledge then resolve the alert
         alert = self.env["spp.alert"].search([("rule_id", "=", rule.id)])
-        alert.write({"resolution_notes": "Test resolution"})
+        alert.action_acknowledge()
         alert.action_resolve(notes="Test resolution")
 
         # Second run should create a new alert (old one is resolved)
@@ -272,7 +259,7 @@ class TestRuleEvaluation(AlertsTestCommon):
             self.skipTest("Alert type threshold not found")
 
         # Active rule with type — should be evaluated
-        active_rule = self._create_threshold_rule(name="Active Rule", threshold_value=15.0)
+        active_rule = self._create_threshold_rule(name="Active Rule", threshold_value=2.0)
 
         # Inactive rule — should be skipped
         self._create_threshold_rule(name="Inactive Rule", active=False)
@@ -307,7 +294,7 @@ class TestRuleEvaluation(AlertsTestCommon):
         # Valid rule — should still succeed
         good_rule = self._create_threshold_rule(
             name="Good Rule",
-            threshold_value=15.0,
+            threshold_value=2.0,
         )
 
         self.env["spp.alert.rule"]._cron_evaluate_rules()
@@ -362,7 +349,7 @@ class TestRuleEvaluation(AlertsTestCommon):
                     "name": "No Model Rule",
                     "alert_type_id": self.alert_type_threshold.id,
                     "rule_type": "threshold",
-                    "monitored_field_id": self.field_credit_limit.id,
+                    "monitored_field_id": self.field_color.id,
                     "priority": "medium",
                 }
             )
@@ -376,7 +363,7 @@ class TestRuleEvaluation(AlertsTestCommon):
         if not self.alert_type_threshold:
             self.skipTest("Alert type threshold not found")
 
-        rule = self._create_threshold_rule(threshold_value=15.0)
+        rule = self._create_threshold_rule(threshold_value=2.0)
         result = rule.action_evaluate()
 
         self.assertEqual(result["type"], "ir.actions.client")
@@ -444,7 +431,7 @@ class TestRuleEvaluation(AlertsTestCommon):
             self.skipTest("Alert type threshold not found")
 
         rule = self._create_threshold_rule(
-            threshold_value=15.0,
+            threshold_value=2.0,
             company_id=self.company_main.id,
         )
         rule._evaluate_rule()

--- a/spp_alerts/views/alert_rule_views.xml
+++ b/spp_alerts/views/alert_rule_views.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8" ?>
 <odoo>
     <!-- Alert Rule List View -->
     <record id="spp_alert_rule_view_list" model="ir.ui.view">
@@ -6,16 +6,20 @@
         <field name="model">spp.alert.rule</field>
         <field name="arch" type="xml">
             <list string="Alert Rules">
-                <field name="sequence" widget="handle"/>
-                <field name="name"/>
-                <field name="alert_type_id"/>
-                <field name="model_id"/>
-                <field name="rule_type" optional="show"/>
-                <field name="priority"/>
-                <field name="threshold_value" optional="show"/>
-                <field name="days_before" optional="show"/>
-                <field name="active"/>
-                <field name="company_id" optional="hide" groups="base.group_multi_company"/>
+                <field name="sequence" widget="handle" />
+                <field name="name" />
+                <field name="alert_type_id" />
+                <field name="model_id" />
+                <field name="rule_type" optional="show" />
+                <field name="priority" />
+                <field name="threshold_value" optional="show" />
+                <field name="days_before" optional="show" />
+                <field name="active" />
+                <field
+                    name="company_id"
+                    optional="hide"
+                    groups="base.group_multi_company"
+                />
             </list>
         </field>
     </record>
@@ -27,50 +31,82 @@
         <field name="arch" type="xml">
             <form string="Alert Rule">
                 <header>
-                    <button name="action_evaluate" type="object" string="Run Now"
-                            class="btn-primary"
-                            invisible="not rule_type or not model_id"
-                            groups="group_alerts_manager,base.group_system"/>
+                    <button
+                        name="action_evaluate"
+                        type="object"
+                        string="Run Now"
+                        class="btn-primary"
+                        invisible="not rule_type or not model_id"
+                        groups="group_alerts_manager,base.group_system"
+                    />
                 </header>
                 <sheet>
                     <div class="oe_button_box" name="button_box">
-                        <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
+                        <widget
+                            name="web_ribbon"
+                            title="Archived"
+                            bg_color="text-bg-danger"
+                            invisible="active"
+                        />
                     </div>
                     <group>
                         <group>
-                            <field name="name" placeholder="e.g., Low Stock Warning"/>
-                            <field name="alert_type_id"/>
-                            <field name="model_id"/>
-                            <field name="rule_type"/>
-                            <field name="active"/>
+                            <field name="name" placeholder="e.g., Low Stock Warning" />
+                            <field name="alert_type_id" />
+                            <field name="model_id" />
+                            <field name="rule_type" />
+                            <field name="active" />
                         </group>
                         <group>
-                            <field name="priority"/>
-                            <field name="sequence"/>
-                            <field name="company_id" groups="base.group_multi_company"/>
+                            <field name="priority" />
+                            <field name="sequence" />
+                            <field
+                                name="company_id"
+                                groups="base.group_multi_company"
+                            />
                         </group>
                     </group>
                     <notebook>
-                        <page string="Evaluation" name="evaluation" invisible="not rule_type">
+                        <page
+                            string="Evaluation"
+                            name="evaluation"
+                            invisible="not rule_type"
+                        >
                             <group>
-                                <group string="Threshold Settings" invisible="rule_type != 'threshold'">
-                                    <field name="monitored_field_id"
-                                           required="rule_type == 'threshold'"/>
-                                    <field name="comparison"/>
-                                    <field name="threshold_value"/>
+                                <group
+                                    string="Threshold Settings"
+                                    invisible="rule_type != 'threshold'"
+                                >
+                                    <field
+                                        name="monitored_field_id"
+                                        required="rule_type == 'threshold'"
+                                    />
+                                    <field name="comparison" />
+                                    <field name="threshold_value" />
                                 </group>
-                                <group string="Date Settings" invisible="rule_type != 'date'">
-                                    <field name="date_field_id"
-                                           required="rule_type == 'date'"/>
-                                    <field name="days_before"/>
+                                <group
+                                    string="Date Settings"
+                                    invisible="rule_type != 'date'"
+                                >
+                                    <field
+                                        name="date_field_id"
+                                        required="rule_type == 'date'"
+                                    />
+                                    <field name="days_before" />
                                 </group>
                             </group>
-                            <separator string="Record Filter"/>
-                            <field name="domain_filter"
-                                   placeholder='[("active", "=", True)]'/>
+                            <separator string="Record Filter" />
+                            <field
+                                name="domain_filter"
+                                placeholder='[("active", "=", True)]'
+                            />
                         </page>
                         <page string="Description" name="description">
-                            <field name="description" placeholder="Describe when this rule triggers and what it monitors..."/>
+                            <field
+                                name="description"
+                                placeholder="Describe when this rule triggers and what it monitors..."
+                            />
+                            <group name="additional_description" invisible="1" />
                         </page>
                     </notebook>
                 </sheet>
@@ -84,20 +120,52 @@
         <field name="model">spp.alert.rule</field>
         <field name="arch" type="xml">
             <search string="Search Alert Rules">
-                <field name="name"/>
-                <field name="alert_type_id"/>
-                <field name="model_id"/>
-                <separator/>
-                <filter name="filter_active" string="Active" domain="[('active', '=', True)]"/>
-                <filter name="filter_inactive" string="Inactive" domain="[('active', '=', False)]"/>
-                <separator/>
-                <filter name="filter_critical" string="Critical Priority" domain="[('priority', '=', 'critical')]"/>
-                <filter name="filter_high" string="High Priority" domain="[('priority', '=', 'high')]"/>
-                <separator/>
-                <filter name="groupby_type" string="Alert Type" context="{'group_by': 'alert_type_id'}"/>
-                <filter name="groupby_model" string="Model" context="{'group_by': 'model_id'}"/>
-                <filter name="groupby_priority" string="Priority" context="{'group_by': 'priority'}"/>
-                <filter name="groupby_rule_type" string="Rule Type" context="{'group_by': 'rule_type'}"/>
+                <field name="name" />
+                <field name="alert_type_id" />
+                <field name="model_id" />
+                <separator />
+                <filter
+                    name="filter_active"
+                    string="Active"
+                    domain="[('active', '=', True)]"
+                />
+                <filter
+                    name="filter_inactive"
+                    string="Inactive"
+                    domain="[('active', '=', False)]"
+                />
+                <separator />
+                <filter
+                    name="filter_critical"
+                    string="Critical Priority"
+                    domain="[('priority', '=', 'critical')]"
+                />
+                <filter
+                    name="filter_high"
+                    string="High Priority"
+                    domain="[('priority', '=', 'high')]"
+                />
+                <separator />
+                <filter
+                    name="groupby_type"
+                    string="Alert Type"
+                    context="{'group_by': 'alert_type_id'}"
+                />
+                <filter
+                    name="groupby_model"
+                    string="Model"
+                    context="{'group_by': 'model_id'}"
+                />
+                <filter
+                    name="groupby_priority"
+                    string="Priority"
+                    context="{'group_by': 'priority'}"
+                />
+                <filter
+                    name="groupby_rule_type"
+                    string="Rule Type"
+                    context="{'group_by': 'rule_type'}"
+                />
             </search>
         </field>
     </record>

--- a/spp_alerts/views/alert_rule_views.xml
+++ b/spp_alerts/views/alert_rule_views.xml
@@ -10,6 +10,7 @@
                 <field name="name"/>
                 <field name="alert_type_id"/>
                 <field name="model_id"/>
+                <field name="rule_type" optional="show"/>
                 <field name="priority"/>
                 <field name="threshold_value" optional="show"/>
                 <field name="days_before" optional="show"/>
@@ -25,6 +26,12 @@
         <field name="model">spp.alert.rule</field>
         <field name="arch" type="xml">
             <form string="Alert Rule">
+                <header>
+                    <button name="action_evaluate" type="object" string="Run Now"
+                            class="btn-primary"
+                            invisible="not rule_type or not model_id"
+                            groups="group_alerts_manager,base.group_system"/>
+                </header>
                 <sheet>
                     <div class="oe_button_box" name="button_box">
                         <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
@@ -34,6 +41,7 @@
                             <field name="name" placeholder="e.g., Low Stock Warning"/>
                             <field name="alert_type_id"/>
                             <field name="model_id"/>
+                            <field name="rule_type"/>
                             <field name="active"/>
                         </group>
                         <group>
@@ -43,16 +51,25 @@
                         </group>
                     </group>
                     <notebook>
-                        <page string="Thresholds" name="thresholds">
+                        <page string="Evaluation" name="evaluation" invisible="not rule_type">
                             <group>
-                                <group>
+                                <group string="Threshold Settings" invisible="rule_type != 'threshold'">
+                                    <field name="monitored_field_id"
+                                           required="rule_type == 'threshold'"/>
+                                    <field name="comparison"/>
                                     <field name="threshold_value"/>
                                 </group>
-                                <group>
+                                <group string="Date Settings" invisible="rule_type != 'date'">
+                                    <field name="date_field_id"
+                                           required="rule_type == 'date'"/>
                                     <field name="days_before"/>
                                 </group>
                             </group>
-                            <separator string="Description"/>
+                            <separator string="Record Filter"/>
+                            <field name="domain_filter"
+                                   placeholder='[("active", "=", True)]'/>
+                        </page>
+                        <page string="Description" name="description">
                             <field name="description" placeholder="Describe when this rule triggers and what it monitors..."/>
                         </page>
                     </notebook>
@@ -80,6 +97,7 @@
                 <filter name="groupby_type" string="Alert Type" context="{'group_by': 'alert_type_id'}"/>
                 <filter name="groupby_model" string="Model" context="{'group_by': 'model_id'}"/>
                 <filter name="groupby_priority" string="Priority" context="{'group_by': 'priority'}"/>
+                <filter name="groupby_rule_type" string="Rule Type" context="{'group_by': 'rule_type'}"/>
             </search>
         </field>
     </record>

--- a/spp_alerts/views/alert_views.xml
+++ b/spp_alerts/views/alert_views.xml
@@ -17,6 +17,7 @@
                        decoration-danger="state == 'active'"
                        decoration-warning="state == 'acknowledged'"
                        decoration-success="state == 'resolved'"/>
+                <field name="rule_id" optional="hide"/>
                 <field name="create_date" optional="hide"/>
                 <field name="company_id" optional="hide" groups="base.group_multi_company"/>
             </list>
@@ -33,7 +34,7 @@
                     <button name="action_acknowledge" type="object" string="Acknowledge"
                             class="btn-primary" invisible="state != 'active'"/>
                     <button name="action_resolve" type="object" string="Resolve"
-                            class="btn-success" invisible="state == 'resolved'"/>
+                            class="btn-success" invisible="state != 'acknowledged'"/>
                     <field name="state" widget="statusbar" statusbar_visible="active,acknowledged,resolved"/>
                 </header>
                 <sheet>
@@ -42,24 +43,32 @@
                         <h1>
                             <field name="reference" readonly="1"/>
                         </h1>
-                        <field name="title" placeholder="Alert Title" class="oe_inline"/>
+                        <h2>
+                            <field name="title" placeholder="Alert Title"
+                                   readonly="state == 'resolved'"/>
+                        </h2>
                     </div>
                     <group>
                         <group>
-                            <field name="alert_type_id"/>
-                            <field name="priority"/>
-                            <field name="company_id" groups="base.group_multi_company"/>
+                            <field name="alert_type_id" readonly="state == 'resolved'"/>
+                            <field name="priority" readonly="state == 'resolved'"/>
+                            <field name="create_date" string="Created On" readonly="1"/>
+                            <field name="company_id" groups="base.group_multi_company"
+                                   readonly="state == 'resolved'"/>
                         </group>
                         <group>
                             <field name="current_value" readonly="1"/>
                             <field name="threshold_value" readonly="1"/>
                             <field name="days_until" readonly="1"/>
+                            <field name="rule_id" readonly="1" invisible="not rule_id"/>
+                            <field name="res_model" readonly="1" invisible="not res_model"/>
+                            <field name="res_id" readonly="1" invisible="not res_model"/>
                         </group>
                     </group>
                     <notebook>
                         <page string="Details" name="details">
                             <separator string="Description"/>
-                            <field name="description"/>
+                            <field name="description" readonly="state == 'resolved'"/>
                         </page>
                         <page string="Resolution" name="resolution" invisible="state == 'active'">
                             <group>
@@ -67,7 +76,9 @@
                                 <field name="resolved_at" readonly="1"/>
                             </group>
                             <separator string="Resolution Notes"/>
-                            <field name="resolution_notes"/>
+                            <field name="resolution_notes"
+                                   required="state == 'resolved'"
+                                   readonly="state == 'resolved'"/>
                         </page>
                     </notebook>
                 </sheet>
@@ -86,7 +97,7 @@
                 <searchpanel>
                     <field name="state" select="multi" icon="fa-tasks" enable_counters="1"/>
                     <field name="priority" select="multi" icon="fa-flag" enable_counters="1"/>
-                    <field name="alert_type" select="multi" icon="fa-bell" enable_counters="1"/>
+                    <field name="alert_type_id" select="multi" icon="fa-bell" enable_counters="1"/>
                 </searchpanel>
 
                 <field name="reference"/>

--- a/spp_alerts/views/alert_views.xml
+++ b/spp_alerts/views/alert_views.xml
@@ -1,25 +1,39 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8" ?>
 <odoo>
     <!-- Alert List View -->
     <record id="spp_alert_view_list" model="ir.ui.view">
         <field name="name">spp.alert.list</field>
         <field name="model">spp.alert</field>
         <field name="arch" type="xml">
-            <list string="Alerts" decoration-danger="priority=='critical'" decoration-warning="priority=='high'">
-                <field name="reference"/>
-                <field name="title"/>
-                <field name="alert_type_id"/>
-                <field name="priority" widget="badge"
-                       decoration-danger="priority == 'critical'"
-                       decoration-warning="priority == 'high'"
-                       decoration-info="priority == 'medium'"/>
-                <field name="state" widget="badge"
-                       decoration-danger="state == 'active'"
-                       decoration-warning="state == 'acknowledged'"
-                       decoration-success="state == 'resolved'"/>
-                <field name="rule_id" optional="hide"/>
-                <field name="create_date" optional="hide"/>
-                <field name="company_id" optional="hide" groups="base.group_multi_company"/>
+            <list
+                string="Alerts"
+                decoration-danger="priority=='critical'"
+                decoration-warning="priority=='high'"
+            >
+                <field name="reference" />
+                <field name="title" />
+                <field name="alert_type_id" />
+                <field
+                    name="priority"
+                    widget="badge"
+                    decoration-danger="priority == 'critical'"
+                    decoration-warning="priority == 'high'"
+                    decoration-info="priority == 'medium'"
+                />
+                <field
+                    name="state"
+                    widget="badge"
+                    decoration-danger="state == 'active'"
+                    decoration-warning="state == 'acknowledged'"
+                    decoration-success="state == 'resolved'"
+                />
+                <field name="rule_id" optional="hide" />
+                <field name="create_date" optional="hide" />
+                <field
+                    name="company_id"
+                    optional="hide"
+                    groups="base.group_multi_company"
+                />
             </list>
         </field>
     </record>
@@ -31,58 +45,104 @@
         <field name="arch" type="xml">
             <form string="Alert">
                 <header>
-                    <button name="action_acknowledge" type="object" string="Acknowledge"
-                            class="btn-primary" invisible="state != 'active'"/>
-                    <button name="action_resolve" type="object" string="Resolve"
-                            class="btn-success" invisible="state != 'acknowledged'"/>
-                    <field name="state" widget="statusbar" statusbar_visible="active,acknowledged,resolved"/>
+                    <button
+                        name="action_acknowledge"
+                        type="object"
+                        string="Acknowledge"
+                        class="btn-primary"
+                        invisible="state != 'active'"
+                    />
+                    <button
+                        name="action_resolve"
+                        type="object"
+                        string="Resolve"
+                        class="btn-success"
+                        invisible="state != 'acknowledged'"
+                    />
+                    <field
+                        name="state"
+                        widget="statusbar"
+                        statusbar_visible="active,acknowledged,resolved"
+                    />
                 </header>
                 <sheet>
-                    <div class="oe_button_box" name="button_box"/>
+                    <div class="oe_button_box" name="button_box" />
                     <div class="oe_title">
                         <h1>
-                            <field name="reference" readonly="1"/>
+                            <field name="reference" readonly="1" />
                         </h1>
                         <h2>
-                            <field name="title" placeholder="Alert Title"
-                                   readonly="state == 'resolved'"/>
+                            <field
+                                name="title"
+                                placeholder="Alert Title"
+                                readonly="state == 'resolved'"
+                            />
                         </h2>
                     </div>
                     <group>
                         <group>
-                            <field name="alert_type_id" readonly="state == 'resolved'"/>
-                            <field name="priority" readonly="state == 'resolved'"/>
-                            <field name="create_date" string="Created On" readonly="1"/>
-                            <field name="company_id" groups="base.group_multi_company"
-                                   readonly="state == 'resolved'"/>
+                            <field
+                                name="alert_type_id"
+                                readonly="state == 'resolved'"
+                            />
+                            <field name="priority" readonly="state == 'resolved'" />
+                            <field
+                                name="create_date"
+                                string="Created On"
+                                readonly="1"
+                            />
+                            <field
+                                name="company_id"
+                                groups="base.group_multi_company"
+                                readonly="state == 'resolved'"
+                            />
                         </group>
                         <group>
-                            <field name="current_value" readonly="1"/>
-                            <field name="threshold_value" readonly="1"/>
-                            <field name="days_until" readonly="1"/>
-                            <field name="rule_id" readonly="1" invisible="not rule_id"/>
-                            <field name="res_model" readonly="1" invisible="not res_model"/>
-                            <field name="res_id" readonly="1" invisible="not res_model"/>
+                            <field name="current_value" readonly="1" />
+                            <field name="threshold_value" readonly="1" />
+                            <field name="days_until" readonly="1" />
+                            <field
+                                name="rule_id"
+                                readonly="1"
+                                invisible="not rule_id"
+                            />
+                            <field
+                                name="res_model"
+                                readonly="1"
+                                invisible="not res_model"
+                            />
+                            <field
+                                name="res_id"
+                                readonly="1"
+                                invisible="not res_model"
+                            />
                         </group>
                     </group>
                     <notebook>
                         <page string="Details" name="details">
-                            <separator string="Description"/>
-                            <field name="description" readonly="state == 'resolved'"/>
+                            <separator string="Description" />
+                            <field name="description" readonly="state == 'resolved'" />
+                            <group name="additional_details" invisible="1" />
                         </page>
-                        <page string="Resolution" name="resolution" invisible="state == 'active'">
+                        <page
+                            string="Resolution"
+                            name="resolution"
+                            invisible="state == 'active'"
+                        >
                             <group>
-                                <field name="resolved_by_id" readonly="1"/>
-                                <field name="resolved_at" readonly="1"/>
+                                <field name="resolved_by_id" readonly="1" />
+                                <field name="resolved_at" readonly="1" />
                             </group>
-                            <separator string="Resolution Notes"/>
-                            <field name="resolution_notes"
-                                   required="state == 'resolved'"
-                                   readonly="state == 'resolved'"/>
+                            <separator string="Resolution Notes" />
+                            <field
+                                name="resolution_notes"
+                                required="state == 'resolved'"
+                                readonly="state == 'resolved'"
+                            />
                         </page>
                     </notebook>
                 </sheet>
-                <chatter/>
+                <chatter />
             </form>
         </field>
     </record>
@@ -95,25 +155,72 @@
             <search string="Search Alerts">
                 <!-- Searchpanel for quick filtering -->
                 <searchpanel>
-                    <field name="state" select="multi" icon="fa-tasks" enable_counters="1"/>
-                    <field name="priority" select="multi" icon="fa-flag" enable_counters="1"/>
-                    <field name="alert_type_id" select="multi" icon="fa-bell" enable_counters="1"/>
+                    <field
+                        name="state"
+                        select="multi"
+                        icon="fa-tasks"
+                        enable_counters="1"
+                    />
+                    <field
+                        name="priority"
+                        select="multi"
+                        icon="fa-flag"
+                        enable_counters="1"
+                    />
+                    <field
+                        name="alert_type_id"
+                        select="multi"
+                        icon="fa-bell"
+                        enable_counters="1"
+                    />
                 </searchpanel>
 
-                <field name="reference"/>
-                <field name="title"/>
-                <field name="alert_type_id"/>
-                <separator/>
-                <filter name="filter_active" string="Active" domain="[('state', '=', 'active')]"/>
-                <filter name="filter_acknowledged" string="Acknowledged" domain="[('state', '=', 'acknowledged')]"/>
-                <filter name="filter_resolved" string="Resolved" domain="[('state', '=', 'resolved')]"/>
-                <separator/>
-                <filter name="filter_critical" string="Critical" domain="[('priority', '=', 'critical')]"/>
-                <filter name="filter_high" string="High Priority" domain="[('priority', '=', 'high')]"/>
-                <separator/>
-                <filter name="groupby_state" string="State" context="{'group_by': 'state'}"/>
-                <filter name="groupby_priority" string="Priority" context="{'group_by': 'priority'}"/>
-                <filter name="groupby_type" string="Type" context="{'group_by': 'alert_type_id'}"/>
+                <field name="reference" />
+                <field name="title" />
+                <field name="alert_type_id" />
+                <separator />
+                <filter
+                    name="filter_active"
+                    string="Active"
+                    domain="[('state', '=', 'active')]"
+                />
+                <filter
+                    name="filter_acknowledged"
+                    string="Acknowledged"
+                    domain="[('state', '=', 'acknowledged')]"
+                />
+                <filter
+                    name="filter_resolved"
+                    string="Resolved"
+                    domain="[('state', '=', 'resolved')]"
+                />
+                <separator />
+                <filter
+                    name="filter_critical"
+                    string="Critical"
+                    domain="[('priority', '=', 'critical')]"
+                />
+                <filter
+                    name="filter_high"
+                    string="High Priority"
+                    domain="[('priority', '=', 'high')]"
+                />
+                <separator />
+                <filter
+                    name="groupby_state"
+                    string="State"
+                    context="{'group_by': 'state'}"
+                />
+                <filter
+                    name="groupby_priority"
+                    string="Priority"
+                    context="{'group_by': 'priority'}"
+                />
+                <filter
+                    name="groupby_type"
+                    string="Type"
+                    context="{'group_by': 'alert_type_id'}"
+                />
             </search>
         </field>
     </record>


### PR DESCRIPTION
## Why is this change needed?
The `spp_alerts` module had alert rules (`spp.alert.rule`) as configuration-only — nothing evaluated them to create alerts automatically. This made the module unusable standalone. Adding a generic rule evaluation engine allows alert rules to automatically monitor models and create alerts based on threshold and date conditions, making the module ready for Beta.

## How was the change implemented?
- Added evaluation fields to `spp.alert.rule`: `rule_type` (threshold/date), `domain_filter`, `monitored_field_id`, `date_field_id`, `comparison`
- Added source tracking fields to `spp.alert`: `rule_id`, `res_model`, `res_id` (all optional, no impact on existing alerts)
- Implemented evaluation engine with batch duplicate prevention (same pattern as spp_drims)
- Added daily cron job (`_cron_evaluate_rules`) and manual "Run Now" button on rule form
- UI improvements: readonly fields when resolved, required resolution notes, searchpanel char field fix, resolve only after acknowledge
- Promoted `development_status` from Alpha to Beta

DRIMS compatibility verified: DRIMS uses prototype inheritance (`_name = "spp.drims.alert"`) with separate DB table and its own crons — completely unaffected.

## New unit tests
- 20 test cases in `test_rule_evaluation.py` covering:
  - All 5 comparison operators (lt, lte, gt, gte, eq)
  - Date rule evaluation with various day windows
  - Duplicate prevention and re-alerting after resolve
  - Cron evaluation (active/inactive/unconfigured rules)
  - Error handling (invalid domains, missing config)
  - Validation constraints
  - Alert value propagation (rule_id, res_model, res_id, company)

## Unit tests executed by the author

## How to test manually
1. Install/upgrade `spp_alerts` module
2. Go to Settings > Technical > Alerts > Alert Rules
3. Open a rule with Rule Type set (e.g., "Low Credit Limit Partners")
4. Click "Run Now" — notification shows number of alerts created
5. Go to Alerts list — verify alerts created with correct source rule and record links
6. Click "Run Now" again — verify 0 duplicates created
7. Acknowledge then resolve an alert — verify readonly fields and required resolution notes
8. Run rule again — verify new alert created for the resolved record

## Related links