### PR TITLE
chore(spp_cel_event): promote to Beta

### DIFF
--- a/spp_cel_event/README.rst
+++ b/spp_cel_event/README.rst
@@ -14,9 +14,9 @@ OpenSPP CEL Event Data Integration
    !! source digest: sha256:e2f2bc40368e1bb65ac6336eec7a46ff133360ef67c8283271317282c593c0df
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-.. |badge1| image:: https://img.shields.io/badge/maturity-Alpha-red.png
+.. |badge1| image:: https://img.shields.io/badge/maturity-Beta-yellow.png
     :target: https://odoo-community.org/page/development-status
-    :alt: Alpha
+    :alt: Beta
 .. |badge2| image:: https://img.shields.io/badge/license-LGPL--3-blue.png
     :target: http://www.gnu.org/licenses/lgpl-3.0-standalone.html
     :alt: License: LGPL-3
@@ -35,15 +35,15 @@ with Python fallback for complex cases.
 Key Capabilities
 ~~~~~~~~~~~~~~~~
 
--  Query event field values with temporal filtering (within_days,
-   within_months, named periods) and selection modes (active, latest,
-   latest_active, first, any)
--  Check event existence with date-based filtering
--  Aggregate event data using count, sum, avg, min, max functions
--  Generate period strings using helper functions (this_year,
-   this_quarter, etc.)
--  Optimize queries using SQL fast paths with automatic fallback to
-   Python evaluation
+- Query event field values with temporal filtering (within_days,
+  within_months, named periods) and selection modes (active, latest,
+  latest_active, first, any)
+- Check event existence with date-based filtering
+- Aggregate event data using count, sum, avg, min, max functions
+- Generate period strings using helper functions (this_year,
+  this_quarter, etc.)
+- Optimize queries using SQL fast paths with automatic fallback to
+  Python evaluation
 
 Key Models
 ~~~~~~~~~~
@@ -74,9 +74,9 @@ optimal query performance.
 UI Location
 ~~~~~~~~~~~
 
--  **Menu**: Studio > Rules > Variables > All Variables
--  **Form**: Event aggregation fields appear in the Source Configuration
-   section when **Aggregate Target** is set to "Events"
+- **Menu**: Studio > Rules > Variables > All Variables
+- **Form**: Event aggregation fields appear in the Source Configuration
+  section when **Aggregate Target** is set to "Events"
 
 Security
 ~~~~~~~~
@@ -87,23 +87,18 @@ No module-specific security. Access control inherits from
 Extension Points
 ~~~~~~~~~~~~~~~~
 
--  Override ``spp.cel.translator._to_plan()`` to add custom event query
-   plan nodes
--  Override ``spp.cel.executor._exec_event_value_sql()`` to customize
-   SQL execution logic
--  Extend period helper functions in ``models/cel_event_functions.py``
--  Implement custom aggregation functions following the
-   events_count/sum/avg pattern
+- Override ``spp.cel.translator._to_plan()`` to add custom event query
+  plan nodes
+- Override ``spp.cel.executor._exec_event_value_sql()`` to customize SQL
+  execution logic
+- Extend period helper functions in ``models/cel_event_functions.py``
+- Implement custom aggregation functions following the
+  events_count/sum/avg pattern
 
 Dependencies
 ~~~~~~~~~~~~
 
 ``spp_cel_domain``, ``spp_event_data``, ``spp_studio``
-
-.. IMPORTANT::
-   This is an alpha version, the data model and design can change at any time without warning.
-   Only for development or testing purpose, do not use in production.
-   `More details on development status <https://odoo-community.org/page/development-status>`_
 
 **Table of contents**
 

--- a/spp_cel_event/__manifest__.py
+++ b/spp_cel_event/__manifest__.py
@@ -9,7 +9,7 @@
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/OpenSPP2",
     "license": "LGPL-3",
-    "development_status": "Alpha",
+    "development_status": "Beta",
     "maintainers": ["jeremi", "gonzalesedwin1123", "emjay0921"],
     "depends": [
         "spp_cel_domain",

--- a/spp_cel_event/static/description/index.html
+++ b/spp_cel_event/static/description/index.html
@@ -374,7 +374,7 @@ ul.auto-toc {
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !! source digest: sha256:e2f2bc40368e1bb65ac6336eec7a46ff133360ef67c8283271317282c593c0df
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
-<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Alpha" src="https://img.shields.io/badge/maturity-Alpha-red.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/lgpl-3.0-standalone.html"><img alt="License: LGPL-3" src="https://img.shields.io/badge/license-LGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OpenSPP/OpenSPP2/tree/19.0/spp_cel_event"><img alt="OpenSPP/OpenSPP2" src="https://img.shields.io/badge/github-OpenSPP%2FOpenSPP2-lightgray.png?logo=github" /></a></p>
+<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/lgpl-3.0-standalone.html"><img alt="License: LGPL-3" src="https://img.shields.io/badge/license-LGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OpenSPP/OpenSPP2/tree/19.0/spp_cel_event"><img alt="OpenSPP/OpenSPP2" src="https://img.shields.io/badge/github-OpenSPP%2FOpenSPP2-lightgray.png?logo=github" /></a></p>
 <p>Integrates event data with CEL expressions for eligibility and
 entitlement rules. Extends the CEL domain framework to query event data
 records collected through surveys, field visits, and assessments.
@@ -451,8 +451,8 @@ section when <strong>Aggregate Target</strong> is set to “Events”</li>
 <ul class="simple">
 <li>Override <tt class="docutils literal">spp.cel.translator._to_plan()</tt> to add custom event query
 plan nodes</li>
-<li>Override <tt class="docutils literal">spp.cel.executor._exec_event_value_sql()</tt> to customize
-SQL execution logic</li>
+<li>Override <tt class="docutils literal">spp.cel.executor._exec_event_value_sql()</tt> to customize SQL
+execution logic</li>
 <li>Extend period helper functions in <tt class="docutils literal">models/cel_event_functions.py</tt></li>
 <li>Implement custom aggregation functions following the
 events_count/sum/avg pattern</li>
@@ -461,12 +461,6 @@ events_count/sum/avg pattern</li>
 <div class="section" id="dependencies">
 <h2>Dependencies</h2>
 <p><tt class="docutils literal">spp_cel_domain</tt>, <tt class="docutils literal">spp_event_data</tt>, <tt class="docutils literal">spp_studio</tt></p>
-<div class="admonition important">
-<p class="first admonition-title">Important</p>
-<p class="last">This is an alpha version, the data model and design can change at any time without warning.
-Only for development or testing purpose, do not use in production.
-<a class="reference external" href="https://odoo-community.org/page/development-status">More details on development status</a></p>
-</div>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">


### PR DESCRIPTION
## Why is this change needed?
Module has been manually tested and confirmed working. All core CEL event expressions return expected results. Promoting from Alpha to Beta.

## How was the change implemented?
Changed `development_status` from `"Alpha"` to `"Beta"` in `__manifest__.py`.

## New unit tests

## Unit tests executed by the author
All 102 spp_cel_event tests pass (0 failed, 0 errors).

## How to test manually
1. Create event types (e.g., vulnerability_assessment, training, verification)
2. Create event data records with JSON data (e.g., vulnerability_score, monthly_income, hours_completed)
3. Create CEL variables (Studio > Rules > Variables) with aggregate target "Events":
   - `vulnerability_score` — event value from vulnerability_assessment
   - `training_count` — count of training events this year
   - `total_training_hours` — sum of hours_completed across trainings
   - `has_verification` — exists check for verification events
   - `avg_training_score` — average of training scores
4. Use CEL expressions in program eligibility rules:
   - `event('vulnerability_assessment', 'vulnerability_score') > 70`
   - `has_event('verification')`
   - `events_count('training') >= 3`
   - `event('vulnerability_assessment', 'monthly_income') < 5000`
   - `has_event('training', within_days=60)`
   - `events_count('training', period=this_year()) >= 2`
5. Preview eligibility to confirm correct registrant matches

## Related links