### PR TITLE
feat(spp_cel_registry_search): promote module to Beta status

### DIFF
--- a/spp_cel_registry_search/__manifest__.py
+++ b/spp_cel_registry_search/__manifest__.py
@@ -4,7 +4,7 @@
     "summary": "Search the registry using CEL expressions",
     "version": "19.0.2.0.0",
     "license": "LGPL-3",
-    "development_status": "Alpha",
+    "development_status": "Beta",
     "author": "OpenSPP Community",
     "website": "https://github.com/OpenSPP/OpenSPP2",
     "category": "OpenSPP/Core",


### PR DESCRIPTION
## Why is this change needed?
The CEL Registry Search module has been manually verified and is ready for Beta. It provides an Advanced Search portal under the Registry menu that allows users to query registrants using CEL expressions with real-time validation and clickable results.

## How was the change implemented?
Updated `development_status` from `"Alpha"` to `"Beta"` in `__manifest__.py`.

## New unit tests

## Unit tests executed by the author

## How to test manually
1. Navigate to **Registry > Advanced Search** (or `/odoo/registry-cel`)
2. Test Individual searches:
   - `r.gender_id.display == "Female"` — returns female registrants
   - `r.income < 1000` — returns low-income registrants
   - `r.birthdate < "1960-01-01"` — returns elderly registrants
3. Test Group searches:
   - `members.exists(m, m.gender_id.display == "Female")` — groups with female members
4. Verify validation feedback (invalid expressions show errors, valid ones show match counts)
5. Verify clicking a result opens the registrant form

## Related links