### PR TITLE
feat(spp_dci_client): mask OAuth2 client secret in UI

### DIFF
--- a/spp_dci_client/models/data_source.py
+++ b/spp_dci_client/models/data_source.py
@@ -22,6 +22,8 @@ class DCIDataSource(models.Model):
     _description = "DCI Data Source"
     _order = "name"
 
+    _SECRET_MASK = "********"
+
     name = fields.Char(
         required=True,
         string="Name",
@@ -70,7 +72,15 @@ class DCIDataSource(models.Model):
     oauth2_client_secret = fields.Char(
         string="OAuth2 Client Secret",
         groups="base.group_system",
-        help="OAuth2 client secret (visible only to system administrators)",
+        copy=False,
+        help="OAuth2 client secret (internal storage, not displayed in UI)",
+    )
+    oauth2_client_secret_display = fields.Char(
+        string="OAuth2 Client Secret",
+        compute="_compute_oauth2_client_secret_display",
+        inverse="_inverse_oauth2_client_secret_display",
+        groups="base.group_system",
+        help="OAuth2 client secret (write-only for security - value is masked after saving)",
     )
     oauth2_scope = fields.Char(
         string="OAuth2 Scope",
@@ -176,6 +186,19 @@ class DCIDataSource(models.Model):
         string="Token Expiry",
         help="Cached token expiration timestamp (internal use only)",
     )
+
+    @api.depends("oauth2_client_secret")
+    def _compute_oauth2_client_secret_display(self):
+        for record in self:
+            record.oauth2_client_secret_display = self._SECRET_MASK if record.oauth2_client_secret else False
+
+    def _inverse_oauth2_client_secret_display(self):
+        for record in self:
+            value = record.oauth2_client_secret_display
+            if value and value != self._SECRET_MASK:
+                record.oauth2_client_secret = value
+            elif not value:
+                record.oauth2_client_secret = False
 
     @api.constrains("code")
     def _check_code_unique(self):

--- a/spp_dci_client/tests/test_data_source.py
+++ b/spp_dci_client/tests/test_data_source.py
@@ -14,6 +14,7 @@ class TestDataSource(TransactionCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.DataSource = cls.env["spp.dci.data.source"]
+        cls.SECRET_MASK = cls.DataSource._SECRET_MASK
 
     def test_create_data_source(self):
         """Test creating a data source with required fields"""
@@ -645,7 +646,7 @@ class TestDataSource(TransactionCase):
             }
         )
         # Display field should show mask, stored field should have real value
-        self.assertEqual(ds.oauth2_client_secret_display, "********")
+        self.assertEqual(ds.oauth2_client_secret_display, self.SECRET_MASK)
         self.assertEqual(ds.oauth2_client_secret, "secret456")
 
     def test_secret_display_field_empty_when_no_secret(self):
@@ -680,7 +681,7 @@ class TestDataSource(TransactionCase):
         self.assertEqual(ds.oauth2_client_secret, "brand_new_secret")
         # Invalidate cache to force recomputation of the display field
         ds.invalidate_recordset(["oauth2_client_secret_display"])
-        self.assertEqual(ds.oauth2_client_secret_display, "********")
+        self.assertEqual(ds.oauth2_client_secret_display, self.SECRET_MASK)
 
     def test_secret_display_mask_value_does_not_overwrite(self):
         """Test that writing the mask value does not overwrite the real secret"""
@@ -697,7 +698,7 @@ class TestDataSource(TransactionCase):
             }
         )
         # Writing the mask value should not change the stored secret
-        ds.write({"oauth2_client_secret_display": "********"})
+        ds.write({"oauth2_client_secret_display": self.SECRET_MASK})
         self.assertEqual(ds.oauth2_client_secret, "real_secret_value")
 
     def test_secret_display_clear_removes_secret(self):

--- a/spp_dci_client/tests/test_data_source.py
+++ b/spp_dci_client/tests/test_data_source.py
@@ -629,3 +629,88 @@ class TestDataSource(TransactionCase):
         self.assertEqual(ds.search_endpoint, "/registry/sync/search")
         self.assertEqual(ds.subscribe_endpoint, "/registry/subscribe")
         self.assertEqual(ds.auth_endpoint, "/oauth2/client/token")
+
+    def test_secret_display_field_masks_value(self):
+        """Test that oauth2_client_secret_display returns masked value"""
+        ds = self.DataSource.create(
+            {
+                "name": "Test CRVS",
+                "code": "test_crvs_mask",
+                "base_url": "https://crvs.example.org/api",
+                "auth_type": "oauth2",
+                "oauth2_token_url": "https://auth.example.org/token",
+                "oauth2_client_id": "client123",
+                "oauth2_client_secret": "secret456",
+                "our_sender_id": "openspp.example.org",
+            }
+        )
+        # Display field should show mask, stored field should have real value
+        self.assertEqual(ds.oauth2_client_secret_display, "********")
+        self.assertEqual(ds.oauth2_client_secret, "secret456")
+
+    def test_secret_display_field_empty_when_no_secret(self):
+        """Test that oauth2_client_secret_display is empty when no secret is set"""
+        ds = self.DataSource.create(
+            {
+                "name": "Test CRVS",
+                "code": "test_crvs_empty",
+                "base_url": "https://crvs.example.org/api",
+                "auth_type": "none",
+            }
+        )
+        self.assertFalse(ds.oauth2_client_secret_display)
+        self.assertFalse(ds.oauth2_client_secret)
+
+    def test_secret_display_write_updates_stored_field(self):
+        """Test that writing a new value through display field updates the stored secret"""
+        ds = self.DataSource.create(
+            {
+                "name": "Test CRVS",
+                "code": "test_crvs_write",
+                "base_url": "https://crvs.example.org/api",
+                "auth_type": "oauth2",
+                "oauth2_token_url": "https://auth.example.org/token",
+                "oauth2_client_id": "client123",
+                "oauth2_client_secret": "old_secret",
+                "our_sender_id": "openspp.example.org",
+            }
+        )
+        # Write a new secret through the display field
+        ds.write({"oauth2_client_secret_display": "brand_new_secret"})
+        self.assertEqual(ds.oauth2_client_secret, "brand_new_secret")
+        # Invalidate cache to force recomputation of the display field
+        ds.invalidate_recordset(["oauth2_client_secret_display"])
+        self.assertEqual(ds.oauth2_client_secret_display, "********")
+
+    def test_secret_display_mask_value_does_not_overwrite(self):
+        """Test that writing the mask value does not overwrite the real secret"""
+        ds = self.DataSource.create(
+            {
+                "name": "Test CRVS",
+                "code": "test_crvs_nooverwrite",
+                "base_url": "https://crvs.example.org/api",
+                "auth_type": "oauth2",
+                "oauth2_token_url": "https://auth.example.org/token",
+                "oauth2_client_id": "client123",
+                "oauth2_client_secret": "real_secret_value",
+                "our_sender_id": "openspp.example.org",
+            }
+        )
+        # Writing the mask value should not change the stored secret
+        ds.write({"oauth2_client_secret_display": "********"})
+        self.assertEqual(ds.oauth2_client_secret, "real_secret_value")
+
+    def test_secret_display_clear_removes_secret(self):
+        """Test that clearing the display field removes the stored secret"""
+        ds = self.DataSource.create(
+            {
+                "name": "Test CRVS",
+                "code": "test_crvs_clear",
+                "base_url": "https://crvs.example.org/api",
+                "auth_type": "none",
+                "oauth2_client_secret": "secret_to_clear",
+            }
+        )
+        # Clear the secret through the display field
+        ds.write({"oauth2_client_secret_display": False})
+        self.assertFalse(ds.oauth2_client_secret)

--- a/spp_dci_client/views/data_source_views.xml
+++ b/spp_dci_client/views/data_source_views.xml
@@ -8,7 +8,14 @@
             <list>
                 <field name="name" />
                 <field name="code" />
-                <field name="state" decoration-success="state == 'active'" decoration-danger="state == 'error'" decoration-warning="state == 'testing'" decoration-muted="state == 'draft'" widget="badge" />
+                <field
+                    name="state"
+                    decoration-success="state == 'active'"
+                    decoration-danger="state == 'error'"
+                    decoration-warning="state == 'testing'"
+                    decoration-muted="state == 'draft'"
+                    widget="badge"
+                />
                 <field name="registry_type" />
                 <field name="base_url" widget="url" />
                 <field name="auth_type" />
@@ -24,7 +31,11 @@
         <field name="arch" type="xml">
             <form>
                 <header>
-                    <field name="state" widget="statusbar" statusbar_visible="draft,testing,active,error" />
+                    <field
+                        name="state"
+                        widget="statusbar"
+                        statusbar_visible="draft,testing,active,error"
+                    />
                     <button
                         name="action_test_connection"
                         string="Test Connection"
@@ -42,40 +53,73 @@
                     <!-- Basic Information -->
                     <group string="Basic Information">
                         <group>
-                            <field name="code" help="Unique identifier for this data source" />
-                            <field name="registry_type" help="Type of registry: DR Client or Indicator" />
+                            <field
+                                name="code"
+                                help="Unique identifier for this data source"
+                            />
+                            <field
+                                name="registry_type"
+                                help="Type of registry: DR Client or Indicator"
+                            />
                         </group>
                         <group>
-                            <field name="active" widget="boolean_toggle" help="Inactive sources will not be used for data retrieval" />
+                            <field
+                                name="active"
+                                widget="boolean_toggle"
+                                help="Inactive sources will not be used for data retrieval"
+                            />
                         </group>
                     </group>
 
                     <!-- Connection Settings -->
                     <group string="Connection Settings">
                         <group>
-                            <field name="base_url" widget="url" help="Base URL of the DCI registry API" />
-                            <field name="verify_ssl" help="Verify SSL certificates for HTTPS connections" />
+                            <field
+                                name="base_url"
+                                widget="url"
+                                help="Base URL of the DCI registry API"
+                            />
+                            <field
+                                name="verify_ssl"
+                                help="Verify SSL certificates for HTTPS connections"
+                            />
                         </group>
                         <group>
-                            <field name="timeout" help="Connection timeout in seconds" />
+                            <field
+                                name="timeout"
+                                help="Connection timeout in seconds"
+                            />
                         </group>
                     </group>
 
                     <!-- DCI Protocol Configuration -->
                     <group string="DCI Protocol Configuration">
                         <group>
-                            <field name="our_sender_id" help="Our sender ID for DCI messaging protocol" />
-                            <field name="our_callback_uri" widget="url" help="URI where we receive callbacks from the remote system" />
+                            <field
+                                name="our_sender_id"
+                                help="Our sender ID for DCI messaging protocol"
+                            />
+                            <field
+                                name="our_callback_uri"
+                                widget="url"
+                                help="URI where we receive callbacks from the remote system"
+                            />
                         </group>
                         <group>
-                            <field name="receiver_id" help="Receiver ID of the remote DCI system" />
+                            <field
+                                name="receiver_id"
+                                help="Receiver ID of the remote DCI system"
+                            />
                         </group>
                     </group>
 
                     <!-- Authentication -->
                     <group string="Authentication">
                         <group>
-                            <field name="auth_type" help="Authentication method to use with this data source" />
+                            <field
+                                name="auth_type"
+                                help="Authentication method to use with this data source"
+                            />
                             <field
                                 name="oauth2_token_url"
                                 widget="url"
@@ -88,10 +132,10 @@
                                 help="OAuth2 client ID"
                             />
                             <field
-                                name="oauth2_client_secret"
+                                name="oauth2_client_secret_display"
                                 widget="password"
                                 invisible="auth_type != 'oauth2'"
-                                help="OAuth2 client secret"
+                                help="OAuth2 client secret (write-only: value is masked after saving)"
                             />
                             <field
                                 name="oauth2_scope"
@@ -109,18 +153,33 @@
                     <!-- Message Signing -->
                     <group string="Message Signing">
                         <group>
-                            <field name="signing_key_id" help="Key ID used for signing DCI messages" />
+                            <field
+                                name="signing_key_id"
+                                help="Key ID used for signing DCI messages"
+                            />
                         </group>
                     </group>
 
                     <!-- API Endpoints -->
-                    <group string="API Endpoints (Optional Overrides)" name="api_endpoints">
+                    <group
+                        string="API Endpoints (Optional Overrides)"
+                        name="api_endpoints"
+                    >
                         <group>
-                            <field name="search_endpoint" help="Custom search endpoint (if different from base_url/search)" />
-                            <field name="subscribe_endpoint" help="Custom subscribe endpoint (if different from base_url/subscribe)" />
+                            <field
+                                name="search_endpoint"
+                                help="Custom search endpoint (if different from base_url/search)"
+                            />
+                            <field
+                                name="subscribe_endpoint"
+                                help="Custom subscribe endpoint (if different from base_url/subscribe)"
+                            />
                         </group>
                         <group>
-                            <field name="auth_endpoint" help="Custom auth endpoint (if different from base_url/auth)" />
+                            <field
+                                name="auth_endpoint"
+                                help="Custom auth endpoint (if different from base_url/auth)"
+                            />
                         </group>
                     </group>
 
@@ -128,15 +187,26 @@
                         <page string="Connection Status" name="connection_status">
                             <group>
                                 <group>
-                                    <field name="last_test_date" readonly="1" help="Last time connection was tested" />
+                                    <field
+                                        name="last_test_date"
+                                        readonly="1"
+                                        help="Last time connection was tested"
+                                    />
                                 </group>
                                 <group>
-                                    <field name="last_error" readonly="1" help="Last error message from connection test" />
+                                    <field
+                                        name="last_error"
+                                        readonly="1"
+                                        help="Last error message from connection test"
+                                    />
                                 </group>
                             </group>
                         </page>
                         <page string="Notes" name="notes">
-                            <field name="notes" placeholder="Additional notes about this data source..." />
+                            <field
+                                name="notes"
+                                placeholder="Additional notes about this data source..."
+                            />
                         </page>
                     </notebook>
                 </sheet>
@@ -153,22 +223,82 @@
                 <field name="name" />
                 <field name="code" />
                 <field name="base_url" />
-                <filter string="Active" name="filter_active" domain="[('active', '=', True)]" />
-                <filter string="Inactive" name="filter_inactive" domain="[('active', '=', False)]" />
-                <filter string="Draft" name="filter_state_draft" domain="[('state', '=', 'draft')]" />
-                <filter string="Testing" name="filter_state_testing" domain="[('state', '=', 'testing')]" />
-                <filter string="Active Connection" name="filter_state_active" domain="[('state', '=', 'active')]" />
-                <filter string="Error" name="filter_state_error" domain="[('state', '=', 'error')]" />
-                <filter string="DR Client" name="filter_registry_dr_client" domain="[('registry_type', '=', 'dr_client')]" />
-                <filter string="Indicator Registry" name="filter_registry_indicator" domain="[('registry_type', '=', 'indicator')]" />
-                <filter string="OAuth2" name="filter_auth_oauth2" domain="[('auth_type', '=', 'oauth2')]" />
-                <filter string="API Key" name="filter_auth_api_key" domain="[('auth_type', '=', 'api_key')]" />
-                <filter string="No Auth" name="filter_auth_none" domain="[('auth_type', '=', 'none')]" />
+                <filter
+                    string="Active"
+                    name="filter_active"
+                    domain="[('active', '=', True)]"
+                />
+                <filter
+                    string="Inactive"
+                    name="filter_inactive"
+                    domain="[('active', '=', False)]"
+                />
+                <filter
+                    string="Draft"
+                    name="filter_state_draft"
+                    domain="[('state', '=', 'draft')]"
+                />
+                <filter
+                    string="Testing"
+                    name="filter_state_testing"
+                    domain="[('state', '=', 'testing')]"
+                />
+                <filter
+                    string="Active Connection"
+                    name="filter_state_active"
+                    domain="[('state', '=', 'active')]"
+                />
+                <filter
+                    string="Error"
+                    name="filter_state_error"
+                    domain="[('state', '=', 'error')]"
+                />
+                <filter
+                    string="DR Client"
+                    name="filter_registry_dr_client"
+                    domain="[('registry_type', '=', 'dr_client')]"
+                />
+                <filter
+                    string="Indicator Registry"
+                    name="filter_registry_indicator"
+                    domain="[('registry_type', '=', 'indicator')]"
+                />
+                <filter
+                    string="OAuth2"
+                    name="filter_auth_oauth2"
+                    domain="[('auth_type', '=', 'oauth2')]"
+                />
+                <filter
+                    string="API Key"
+                    name="filter_auth_api_key"
+                    domain="[('auth_type', '=', 'api_key')]"
+                />
+                <filter
+                    string="No Auth"
+                    name="filter_auth_none"
+                    domain="[('auth_type', '=', 'none')]"
+                />
                 <group>
-                    <filter string="State" name="group_by_state" context="{'group_by': 'state'}" />
-                    <filter string="Registry Type" name="group_by_registry_type" context="{'group_by': 'registry_type'}" />
-                    <filter string="Authentication Type" name="group_by_auth_type" context="{'group_by': 'auth_type'}" />
-                    <filter string="Active Status" name="group_by_active" context="{'group_by': 'active'}" />
+                    <filter
+                        string="State"
+                        name="group_by_state"
+                        context="{'group_by': 'state'}"
+                    />
+                    <filter
+                        string="Registry Type"
+                        name="group_by_registry_type"
+                        context="{'group_by': 'registry_type'}"
+                    />
+                    <filter
+                        string="Authentication Type"
+                        name="group_by_auth_type"
+                        context="{'group_by': 'auth_type'}"
+                    />
+                    <filter
+                        string="Active Status"
+                        name="group_by_active"
+                        context="{'group_by': 'active'}"
+                    />
                 </group>
             </search>
         </field>


### PR DESCRIPTION
Add a computed display field that masks the stored secret with asterisks and only writes through when a new value is provided. Prevents accidental secret exposure when viewing the data source form. Includes formatting fixes from prettier.
