### PR TITLE
fix(spp_registry): disable gender creation in individual form

### DIFF
--- a/spp_registry/views/individual_views.xml
+++ b/spp_registry/views/individual_views.xml
@@ -222,7 +222,7 @@
                                     <field name="birthdate" readonly="disabled" help="Date of Birth - mm/dd/yyyy" />
                                 </group>
                                 <group>
-                                    <field name="gender_id" readonly="disabled" />
+                                    <field name="gender_id" readonly="disabled" options="{'no_create': True, 'no_open': True}" />
                                 </group>
                                 <group>
                                     <field name="age" />


### PR DESCRIPTION
## Why is this change needed?
Users should not be able to create or edit gender records inline from the individual registrant form.

## How was the change implemented?
Added `no_create` and `no_open` options to the `gender_id` field in `individual_views.xml`.

## New unit tests

## Unit tests executed by the author

## How to test manually
- Open an individual registrant form
- Click the Gender dropdown
- Verify there is no "Create and Edit" or "Create" option
- Verify clicking a gender value does not open the gender form

## Related links