### PR TITLE
feat(spp_hazard): promote to Beta with UX improvements

### DIFF
--- a/spp_hazard/views/registrant_views.xml
+++ b/spp_hazard/views/registrant_views.xml
@@ -45,51 +45,6 @@
         </field>
     </record>
 
-    <!-- Extend Group Form View to show hazard impacts -->
-    <record id="view_group_form_hazard" model="ir.ui.view">
-        <field name="name">view.group.form.hazard</field>
-        <field name="model">res.partner</field>
-        <field name="inherit_id" ref="spp_registry.view_groups_form_membership"/>
-        <field name="priority">50</field>
-        <field name="arch" type="xml">
-            <xpath expr="//div[@name='button_box']" position="inside">
-                <button name="action_view_hazard_impacts"
-                    type="object"
-                    class="oe_stat_button"
-                    icon="fa-bolt"
-                    invisible="hazard_impact_count == 0">
-                    <field name="hazard_impact_count" widget="statinfo" string="Impacts"/>
-                </button>
-            </xpath>
-            <!-- Add Emergency Response tab for hazard impacts -->
-            <xpath expr="//page[@name='participation']" position="after">
-                <page string="Emergency Response" name="emergency_response"
-                    invisible="not is_registrant">
-                    <field name="has_active_impact" invisible="1"/>
-                    <div class="alert alert-warning" role="alert" invisible="not has_active_impact">
-                        <span class="fw-bold">Active incident impacts recorded</span>
-                    </div>
-                    <group name="hazard_impacts_section" string="Incident Impacts"
-                        invisible="hazard_impact_count == 0">
-                        <field name="hazard_impact_ids" nolabel="1" readonly="1" colspan="2">
-                            <list>
-                                <field name="incident_id"/>
-                                <field name="impact_type_id"/>
-                                <field name="damage_level" widget="badge"/>
-                                <field name="impact_date"/>
-                                <field name="verification_status" widget="badge"
-                                    decoration-info="verification_status == 'reported'"
-                                    decoration-success="verification_status == 'verified'"
-                                    decoration-warning="verification_status == 'disputed'"
-                                    decoration-muted="verification_status == 'closed'"/>
-                            </list>
-                        </field>
-                    </group>
-                </page>
-            </xpath>
-        </field>
-    </record>
-
     <!-- Extend Individual List View -->
     <record id="view_individual_list_hazard" model="ir.ui.view">
         <field name="name">view.individual.list.hazard</field>

--- a/spp_hazard/views/registrant_views.xml
+++ b/spp_hazard/views/registrant_views.xml
@@ -24,6 +24,9 @@
                     <div class="alert alert-warning" role="alert" invisible="not has_active_impact">
                         <span class="fw-bold">Active incident impacts recorded</span>
                     </div>
+                    <p class="text-muted" invisible="hazard_impact_count != 0">
+                        No emergency response records yet. Impact records will appear here when this registrant is affected by a hazard incident.
+                    </p>
                     <group name="hazard_impacts_section" string="Incident Impacts"
                         invisible="hazard_impact_count == 0">
                         <field name="hazard_impact_ids" nolabel="1" readonly="1" colspan="2">


### PR DESCRIPTION
## Why is this change needed?
1. Duplicate "Emergency Response" tabs and stat buttons appeared on registrant forms due to view inheritance chain.
2. Empty Emergency Response tab showed blank page with no guidance.
3. Impact records and incidents remained editable after being closed.
4. Module was at Alpha status but ready for Beta.

## How was the change implemented?
- Removed `view_group_form_hazard` — `view_groups_form_membership` inherits from `view_individuals_form`, so one hazard view covers both.
- Added empty state message in Emergency Response tab.
- Added `readonly="verification_status == 'closed'"` to all editable fields in impact form.
- Added `readonly="status == 'closed'"` to all editable fields in incident form.
- Set `development_status` to Beta, added `emjay0921` as maintainer.
- Removed OCA banner from README/HTML.

## New unit tests

## Unit tests executed by the author

## How to test manually
- Open any registrant — verify only one "Emergency Response" tab
- Open registrant with no impacts — should show "No emergency response records yet..." message
- Open a closed incident — all fields should be readonly
- Open a closed impact record — all fields should be readonly
- Verify "Reset to Reported" button still works to unlock a closed impact

## Related links