### PR TITLE
fix(spp_change_request_v2): add no_create/no_open to lookup fields in CR detail views

### DIFF
--- a/spp_change_request_v2/views/detail_add_member_views.xml
+++ b/spp_change_request_v2/views/detail_add_member_views.xml
@@ -47,8 +47,14 @@
                         </group>
                         <group>
                             <field name="birthdate" />
-                            <field name="gender_id" />
-                            <field name="relationship_id" />
+                            <field
+                                name="gender_id"
+                                options="{'no_create': True, 'no_open': True}"
+                            />
+                            <field
+                                name="relationship_id"
+                                options="{'no_create': True, 'no_open': True}"
+                            />
                         </group>
                     </group>
 

--- a/spp_change_request_v2/views/detail_change_hoh_views.xml
+++ b/spp_change_request_v2/views/detail_change_hoh_views.xml
@@ -55,7 +55,7 @@
                         <group string="Previous Head Reassignment">
                             <field
                                 name="previous_head_new_role_id"
-                                options="{'no_create': True}"
+                                options="{'no_create': True, 'no_open': True}"
                             />
                         </group>
                     </group>

--- a/spp_change_request_v2/views/detail_create_group_views.xml
+++ b/spp_change_request_v2/views/detail_create_group_views.xml
@@ -31,7 +31,7 @@
                     <group>
                         <group string="Group Information">
                             <field name="group_name" required="1" />
-                            <field name="group_type_id" options="{'no_create': True}" />
+                            <field name="group_type_id" options="{'no_create': True, 'no_open': True}" />
                         </group>
                         <group string="Contact">
                             <field name="phone" />
@@ -61,7 +61,7 @@
                             <field name="head_birthdate" />
                             <field
                                 name="head_gender_id"
-                                options="{'no_create': True}"
+                                options="{'no_create': True, 'no_open': True}"
                             />
                             <field name="head_phone" />
                         </group>
@@ -75,9 +75,9 @@
                             <field name="city" />
                         </group>
                         <group>
-                            <field name="state_id" options="{'no_create': True}" />
+                            <field name="state_id" options="{'no_create': True, 'no_open': True}" />
                             <field name="postal_code" />
-                            <field name="country_id" options="{'no_create': True}" />
+                            <field name="country_id" options="{'no_create': True, 'no_open': True}" />
                         </group>
                     </group>
 

--- a/spp_change_request_v2/views/detail_edit_individual_views.xml
+++ b/spp_change_request_v2/views/detail_edit_individual_views.xml
@@ -44,7 +44,10 @@
                                     <field name="given_name" required="1" />
                                     <field name="family_name" required="1" />
                                     <field name="birthdate" />
-                                    <field name="gender_id" />
+                                    <field
+                                        name="gender_id"
+                                        options="{'no_create': True, 'no_open': True}"
+                                    />
                                 </group>
                                 <group>
                                     <field name="phone" />

--- a/spp_change_request_v2/views/detail_exit_registrant_views.xml
+++ b/spp_change_request_v2/views/detail_exit_registrant_views.xml
@@ -55,6 +55,7 @@
                             <field
                                 name="destination_country_id"
                                 invisible="exit_reason != 'emigrated'"
+                                options="{'no_create': True, 'no_open': True}"
                             />
                         </group>
                         <group string="Options">

--- a/spp_change_request_v2/views/detail_merge_registrants_views.xml
+++ b/spp_change_request_v2/views/detail_merge_registrants_views.xml
@@ -40,7 +40,11 @@
 
                     <group>
                         <group string="Primary Registrant (Keep)">
-                            <field name="primary_registrant_id" required="1" />
+                            <field
+                                name="primary_registrant_id"
+                                required="1"
+                                options="{'no_create': True, 'no_open': True}"
+                            />
                             <field name="primary_name" invisible="1" />
                             <field name="is_group_merge" invisible="1" />
                             <field name="available_duplicate_ids" invisible="1" />

--- a/spp_change_request_v2/views/detail_split_household_views.xml
+++ b/spp_change_request_v2/views/detail_split_household_views.xml
@@ -47,7 +47,11 @@
 
                     <group>
                         <group string="Source Household">
-                            <field name="source_group_id" required="1" />
+                            <field
+                                name="source_group_id"
+                                required="1"
+                                options="{'no_create': True, 'no_open': True}"
+                            />
                             <field name="source_group_name" invisible="1" />
                             <field name="available_member_ids" invisible="1" />
                             <field name="members_to_split_ids" invisible="1" />
@@ -89,7 +93,7 @@
                             <field name="new_group_name" required="1" />
                             <field
                                 name="new_group_type_id"
-                                options="{'no_create': True}"
+                                options="{'no_create': True, 'no_open': True}"
                             />
                         </group>
                         <group>
@@ -104,9 +108,9 @@
                             <field name="city" />
                         </group>
                         <group string="Location">
-                            <field name="state_id" options="{'no_create': True}" />
+                            <field name="state_id" options="{'no_create': True, 'no_open': True}" />
                             <field name="postal_code" />
-                            <field name="country_id" options="{'no_create': True}" />
+                            <field name="country_id" options="{'no_create': True, 'no_open': True}" />
                         </group>
                         <group string="Contact">
                             <field name="phone" />

--- a/spp_change_request_v2/views/detail_transfer_member_views.xml
+++ b/spp_change_request_v2/views/detail_transfer_member_views.xml
@@ -30,7 +30,10 @@
                 <sheet>
                     <group>
                         <group string="Source">
-                            <field name="source_group_id" />
+                            <field
+                                name="source_group_id"
+                                options="{'no_create': True, 'no_open': True}"
+                            />
                             <field name="available_individual_ids" invisible="1" />
                             <field
                                 name="individual_id"
@@ -47,7 +50,7 @@
                                 options="{'no_create': True}"
                                 required="1"
                             />
-                            <field name="new_role_id" options="{'no_create': True}" />
+                            <field name="new_role_id" options="{'no_create': True, 'no_open': True}" />
                         </group>
                     </group>
                     <group>

--- a/spp_change_request_v2/views/detail_update_id_views.xml
+++ b/spp_change_request_v2/views/detail_update_id_views.xml
@@ -51,7 +51,7 @@
                     </group>
                     <group invisible="operation == 'remove'">
                         <group string="ID Information">
-                            <field name="id_type_id" options="{'no_create': True}" />
+                            <field name="id_type_id" options="{'no_create': True, 'no_open': True}" />
                             <field name="id_value" required="operation == 'add'" />
                             <field name="expiry_date" />
                         </group>


### PR DESCRIPTION
## Why is this change needed?
Users could create or edit configuration/lookup records (gender, relationship, country, state, group type, role, ID type) and registrant records directly from change request forms. These fields should be select-only.

## How was the change implemented?
Added `options="{'no_create': True, 'no_open': True}"` to all lookup and registrant Many2one fields across 9 CR detail views:
- **add_member**: `gender_id`, `relationship_id`
- **edit_individual**: `gender_id`
- **exit_registrant**: `destination_country_id`
- **change_hoh**: `previous_head_new_role_id` (added `no_open`)
- **create_group**: `group_type_id`, `head_gender_id`, `state_id`, `country_id` (added `no_open`)
- **split_household**: `source_group_id`, `new_group_type_id`, `state_id`, `country_id` (added `no_open`)
- **transfer_member**: `source_group_id`, `new_role_id` (added `no_open`)
- **merge_registrants**: `primary_registrant_id`
- **update_id**: `id_type_id` (added `no_open`)

## New unit tests
N/A — view-only change

## Unit tests executed by the author
N/A

## How to test manually
- Open any change request detail form (e.g., Add Member)
- Verify that lookup fields (gender, relationship, country, etc.) only allow selection from existing values
- Verify no "Create and Edit" or external link icon appears on these fields