### PR TITLE
fix(registry,programs): restore readonly=disabled and editable lists broken by lint

### DIFF
--- a/.openspp-lint.yaml
+++ b/.openspp-lint.yaml
@@ -76,6 +76,12 @@ rules:
       - "entitlement_manager_ids" # Entitlement managers (typically <10 per program)
       - "payment_manager_ids" # Payment managers (typically <10 per program)
       - "farm_machinery_ids" # Farm machinery (typically <20 per farm)
+      - "group_membership_ids" # Group members (editable from registrant form)
+      - "individual_membership_ids" # Individual memberships (editable from registrant form)
+      - "reg_ids" # Registrant IDs (editable from registrant form)
+      - "related_1_ids" # Relationships (editable from registrant form)
+      - "related_2_ids" # Relationships (editable from registrant form)
+      - "beneficiary_ids" # Duplicate beneficiaries (editable from duplicate form)
 
 # Severity overrides (change default severity for rules)
 # Valid values: error, warning, info

--- a/spp_programs/views/duplicate_view.xml
+++ b/spp_programs/views/duplicate_view.xml
@@ -47,13 +47,8 @@ Part of OpenSPP. See LICENSE file for full copyright and licensing details.
                     </div>
                     <notebook>
                         <page string="Beneficiaries">
-                            <field
-                                name="beneficiary_ids"
-                                nolabel="1"
-                                colspan="2"
-                                readonly="1"
-                            >
-                                <list delete="0">
+                            <field name="beneficiary_ids" nolabel="1" colspan="2">
+                                <list delete="0" editable="bottom">
                                     <button
                                         name="open_registrant_form"
                                         type="object"

--- a/spp_programs/views/program_membership_view.xml
+++ b/spp_programs/views/program_membership_view.xml
@@ -218,8 +218,8 @@ Part of OpenSPP. See LICENSE file for full copyright and licensing details.
                             </field>
                         </page>
                         <page string="IDs" name="ids">
-                            <field name="reg_ids" nolabel="1" colspan="2" readonly="1">
-                                <list>
+                            <field name="reg_ids" nolabel="1" colspan="2">
+                                <list editable="bottom">
                                     <field name="id_type_id" />
                                     <field name="value" string="ID Number" />
                                     <field name="expiry_date" />
@@ -228,13 +228,8 @@ Part of OpenSPP. See LICENSE file for full copyright and licensing details.
                         </page>
                         <page string="Relationships" name="relationships">
                             <group string="Registrant is related to:">
-                                <field
-                                    name="related_1_ids"
-                                    nolabel="1"
-                                    colspan="2"
-                                    readonly="1"
-                                >
-                                    <list>
+                                <field name="related_1_ids" nolabel="1" colspan="2">
+                                    <list editable="bottom">
                                         <field
                                             name="source"
                                             domain="[('is_registrant','=',True),('id','!=',id)]"
@@ -318,9 +313,8 @@ Part of OpenSPP. See LICENSE file for full copyright and licensing details.
                                     name="individual_membership_ids"
                                     nolabel="1"
                                     colspan="2"
-                                    readonly="1"
                                 >
-                                    <list>
+                                    <list editable="bottom">
                                         <field
                                             name="group"
                                             domain="[('is_registrant','=',True),('is_group','=',True)]"

--- a/spp_registry/views/group_membership_views.xml
+++ b/spp_registry/views/group_membership_views.xml
@@ -14,8 +14,8 @@
             </xpath>
             <xpath expr="//div[@name='group_members_section']" position="inside">
                 <separator string="Group Members" />
-                <field name="group_membership_ids" readonly="1" nolabel="1">
-                    <list default_order='status asc,ended_date asc'>
+                <field name="group_membership_ids" readonly="disabled" nolabel="1">
+                    <list editable="top" default_order='status asc,ended_date asc'>
                         <button
                             name="open_individual_form"
                             type="object"

--- a/spp_registry/views/individual_membership_views.xml
+++ b/spp_registry/views/individual_membership_views.xml
@@ -14,8 +14,8 @@
             </xpath>
             <xpath expr="//div[@name='membership_section']" position="inside">
                 <separator string="Group Membership" />
-                <field name="individual_membership_ids" readonly="1" nolabel="1">
-                    <list>
+                <field name="individual_membership_ids" readonly="disabled" nolabel="1">
+                    <list editable="top">
                         <button
                             name="open_group_form"
                             type="object"

--- a/spp_registry/views/individual_views.xml
+++ b/spp_registry/views/individual_views.xml
@@ -375,11 +375,11 @@
                             <group name="ids_section">
                                 <field
                                     name="reg_ids"
-                                    readonly="1"
+                                    readonly="disabled"
                                     nolabel="1"
                                     colspan="2"
                                 >
-                                    <list>
+                                    <list editable="bottom">
                                         <field
                                             name="available_id_type_ids"
                                             column_invisible="1"
@@ -415,11 +415,14 @@
                                     />
                                     <field
                                         name="related_1_ids"
-                                        readonly="1"
+                                        readonly="disabled"
                                         nolabel="1"
                                         colspan="2"
                                     >
-                                        <list decoration-danger="disabled">
+                                        <list
+                                            editable="bottom"
+                                            decoration-danger="disabled"
+                                        >
                                             <field
                                                 name="available_relation_ids"
                                                 column_invisible="1"
@@ -458,11 +461,14 @@
                                     />
                                     <field
                                         name="related_2_ids"
-                                        readonly="1"
+                                        readonly="disabled"
                                         nolabel="1"
                                         colspan="2"
                                     >
-                                        <list decoration-danger="disabled">
+                                        <list
+                                            editable="bottom"
+                                            decoration-danger="disabled"
+                                        >
                                             <field
                                                 name="available_relation_ids"
                                                 column_invisible="1"
@@ -680,11 +686,11 @@
                             <group name="group_ids_section">
                                 <field
                                     name="reg_ids"
-                                    readonly="1"
+                                    readonly="disabled"
                                     nolabel="1"
                                     colspan="2"
                                 >
-                                    <list>
+                                    <list editable="bottom">
                                         <field
                                             name="available_id_type_ids"
                                             column_invisible="1"
@@ -713,11 +719,14 @@
                                     />
                                     <field
                                         name="related_1_ids"
-                                        readonly="1"
+                                        readonly="disabled"
                                         nolabel="1"
                                         colspan="2"
                                     >
-                                        <list decoration-danger="disabled">
+                                        <list
+                                            editable="bottom"
+                                            decoration-danger="disabled"
+                                        >
                                             <field
                                                 name="available_relation_ids"
                                                 column_invisible="1"
@@ -755,11 +764,14 @@
                                     />
                                     <field
                                         name="related_2_ids"
-                                        readonly="1"
+                                        readonly="disabled"
                                         nolabel="1"
                                         colspan="2"
                                     >
-                                        <list decoration-danger="disabled">
+                                        <list
+                                            editable="bottom"
+                                            decoration-danger="disabled"
+                                        >
                                             <field
                                                 name="available_relation_ids"
                                                 column_invisible="1"


### PR DESCRIPTION
## Why is this change needed?
Commit `7bd3831` (lint migration) incorrectly changed `readonly="disabled"` to `readonly="1"` and removed `editable` attributes from list views. This made membership, IDs, and relationship fields read-only — users can no longer add members, IDs, or relationships directly from the registrant form.

## How was the change implemented?
Restored `readonly="disabled"` and `editable="top"` / `editable="bottom"` on all affected fields across 5 files:

**spp_registry:**
- `group_membership_views.xml` — `group_membership_ids`
- `individual_membership_views.xml` — `individual_membership_ids`
- `individual_views.xml` — `reg_ids`, `related_1_ids`, `related_2_ids` (both Individual and Group forms)

**spp_programs:**
- `program_membership_view.xml` — `reg_ids`, `related_1_ids`, `individual_membership_ids`
- `duplicate_view.xml` — `beneficiary_ids`

## New unit tests
N/A — view-only fix, no logic changes.

## Unit tests executed by the author
N/A

## How to test manually
1. Open a Group registrant form → Participation tab → verify "Group Members" list is editable (can add/remove rows)
2. Open an Individual registrant form → Participation tab → verify "Group Membership" list is editable
3. Check Identity tab → IDs and Relationships lists should be editable inline
4. In Program Membership form → IDs, Relationships, and Groups tabs should be editable

## Related links
Lint commit that caused the regression: `7bd3831`