### PR TITLE
feat(spp_mis_demo_v2): add demo API client and statistics data

### DIFF
--- a/spp_mis_demo_v2/__manifest__.py
+++ b/spp_mis_demo_v2/__manifest__.py
@@ -52,6 +52,9 @@
         "views/mis_demo_wizard_view.xml",
     ],
     "assets": {},
+    "oca_data_manual": [
+        "data/demo_api_client.xml",
+    ],
     "demo": [],
     "images": [],
     "application": False,

--- a/spp_mis_demo_v2/__manifest__.py
+++ b/spp_mis_demo_v2/__manifest__.py
@@ -20,6 +20,8 @@
         "spp_demo",
         # GIS Reports for geographic visualization
         "spp_gis_report",
+        # Registrant GPS coordinates for QGIS plugin demo
+        "spp_registrant_gis",
         # Statistics and aggregation for demo indicators
         "spp_statistic",
         "spp_aggregation",

--- a/spp_mis_demo_v2/__manifest__.py
+++ b/spp_mis_demo_v2/__manifest__.py
@@ -47,7 +47,8 @@
         "data/demo_change_requests_ux.xml",
         "data/demo_gis_reports.xml",
         "data/demo_statistics.xml",
-        "data/demo_api_client.xml",
+        # NOTE: demo_api_client.xml requires spp_api_v2_gis (adds 'gis' resource).
+        # It is loaded conditionally in the post_init_hook when the module is available.
         "views/mis_demo_wizard_view.xml",
     ],
     "assets": {},

--- a/spp_mis_demo_v2/__manifest__.py
+++ b/spp_mis_demo_v2/__manifest__.py
@@ -26,8 +26,8 @@
         "spp_statistic",
         "spp_aggregation",
         "spp_studio",
-        # GIS API for QGIS plugin (registers 'gis' scope for demo API client)
-        "spp_api_v2_gis",
+        # NOTE: spp_api_v2_gis (GIS API for QGIS plugin) is a soft dependency.
+        # Install it separately to activate the 'gis' scopes on the demo API client.
         # QR Credentials (Claim 169)
         "spp_claim_169",
         # Demo-specific extensions

--- a/spp_mis_demo_v2/__manifest__.py
+++ b/spp_mis_demo_v2/__manifest__.py
@@ -20,6 +20,10 @@
         "spp_demo",
         # GIS Reports for geographic visualization
         "spp_gis_report",
+        # Statistics and aggregation for demo indicators
+        "spp_statistic",
+        "spp_aggregation",
+        "spp_studio",
         # QR Credentials (Claim 169)
         "spp_claim_169",
         # Demo-specific extensions
@@ -38,6 +42,8 @@
         "data/change_request_types.xml",
         "data/demo_change_requests_ux.xml",
         "data/demo_gis_reports.xml",
+        "data/demo_statistics.xml",
+        "data/demo_api_client.xml",
         "views/mis_demo_wizard_view.xml",
     ],
     "assets": {},

--- a/spp_mis_demo_v2/__manifest__.py
+++ b/spp_mis_demo_v2/__manifest__.py
@@ -24,6 +24,8 @@
         "spp_statistic",
         "spp_aggregation",
         "spp_studio",
+        # GIS API for QGIS plugin (registers 'gis' scope for demo API client)
+        "spp_api_v2_gis",
         # QR Credentials (Claim 169)
         "spp_claim_169",
         # Demo-specific extensions

--- a/spp_mis_demo_v2/data/demo_api_client.xml
+++ b/spp_mis_demo_v2/data/demo_api_client.xml
@@ -14,34 +14,34 @@
     create API clients through the UI with proper access controls.
 -->
 <odoo noupdate="1">
-        <!-- Demo API Client for QGIS Plugin -->
-        <record id="demo_api_client_qgis" model="spp.api.client">
-            <field name="name">QGIS Demo Client</field>
-            <field
-                name="description"
-            >Demo API client for testing QGIS plugin integration. Grants read access to GIS layers, reports, and statistics queries.</field>
-            <field name="partner_id" ref="base.main_partner" />
-            <field name="organization_type_id" ref="spp_consent.org_type_government" />
-            <field name="active" eval="True" />
-        </record>
+    <!-- Demo API Client for QGIS Plugin -->
+    <record id="demo_api_client_qgis" model="spp.api.client">
+        <field name="name">QGIS Demo Client</field>
+        <field
+            name="description"
+        >Demo API client for testing QGIS plugin integration. Grants read access to GIS layers, reports, and statistics queries.</field>
+        <field name="partner_id" ref="base.main_partner" />
+        <field name="organization_type_id" ref="spp_consent.org_type_government" />
+        <field name="active" eval="True" />
+    </record>
 
-        <!-- GIS Read Scope - View layers, catalog, statistics -->
-        <record id="demo_api_client_qgis_scope_gis_read" model="spp.api.client.scope">
-            <field name="client_id" ref="demo_api_client_qgis" />
-            <field name="resource">gis</field>
-            <field name="action">read</field>
-            <field
-                name="description"
-            >Read access to GIS layers, reports catalog, and spatial statistics queries.</field>
-        </record>
+    <!-- GIS Read Scope - View layers, catalog, statistics -->
+    <record id="demo_api_client_qgis_scope_gis_read" model="spp.api.client.scope">
+        <field name="client_id" ref="demo_api_client_qgis" />
+        <field name="resource">gis</field>
+        <field name="action">read</field>
+        <field
+            name="description"
+        >Read access to GIS layers, reports catalog, and spatial statistics queries.</field>
+    </record>
 
-        <!-- GIS All Scope - Full GIS access including geofences -->
-        <record id="demo_api_client_qgis_scope_gis_all" model="spp.api.client.scope">
-            <field name="client_id" ref="demo_api_client_qgis" />
-            <field name="resource">gis</field>
-            <field name="action">all</field>
-            <field
-                name="description"
-            >Full GIS access including creating and managing geofences.</field>
-        </record>
+    <!-- GIS All Scope - Full GIS access including geofences -->
+    <record id="demo_api_client_qgis_scope_gis_all" model="spp.api.client.scope">
+        <field name="client_id" ref="demo_api_client_qgis" />
+        <field name="resource">gis</field>
+        <field name="action">all</field>
+        <field
+            name="description"
+        >Full GIS access including creating and managing geofences.</field>
+    </record>
 </odoo>

--- a/spp_mis_demo_v2/data/demo_api_client.xml
+++ b/spp_mis_demo_v2/data/demo_api_client.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Demo API Client for QGIS Plugin Testing
+
+    This creates a pre-configured API client with GIS scopes for testing
+    the QGIS plugin integration. The client_secret is displayed in the UI
+    after installation - use it to configure the QGIS plugin.
+
+    Scopes granted:
+    - gis:read - View layers, catalog, and query statistics
+    - gis:all - Full GIS access including geofence management
+
+    IMPORTANT: This is demo data for testing only. In production,
+    create API clients through the UI with proper access controls.
+-->
+<odoo>
+    <data noupdate="1">
+        <!-- Demo API Client for QGIS Plugin -->
+        <record id="demo_api_client_qgis" model="spp.api.client">
+            <field name="name">QGIS Demo Client</field>
+            <field
+                name="description"
+            >Demo API client for testing QGIS plugin integration. Grants read access to GIS layers, reports, and statistics queries.</field>
+            <field name="partner_id" ref="base.main_partner" />
+            <field name="organization_type_id" ref="spp_consent.org_type_government" />
+            <field name="active" eval="True" />
+        </record>
+
+        <!-- GIS Read Scope - View layers, catalog, statistics -->
+        <record id="demo_api_client_qgis_scope_gis_read" model="spp.api.client.scope">
+            <field name="client_id" ref="demo_api_client_qgis" />
+            <field name="resource">gis</field>
+            <field name="action">read</field>
+            <field
+                name="description"
+            >Read access to GIS layers, reports catalog, and spatial statistics queries.</field>
+        </record>
+
+        <!-- GIS All Scope - Full GIS access including geofences -->
+        <record id="demo_api_client_qgis_scope_gis_all" model="spp.api.client.scope">
+            <field name="client_id" ref="demo_api_client_qgis" />
+            <field name="resource">gis</field>
+            <field name="action">all</field>
+            <field
+                name="description"
+            >Full GIS access including creating and managing geofences.</field>
+        </record>
+    </data>
+</odoo>

--- a/spp_mis_demo_v2/data/demo_api_client.xml
+++ b/spp_mis_demo_v2/data/demo_api_client.xml
@@ -13,8 +13,7 @@
     IMPORTANT: This is demo data for testing only. In production,
     create API clients through the UI with proper access controls.
 -->
-<odoo>
-    <data noupdate="1">
+<odoo noupdate="1">
         <!-- Demo API Client for QGIS Plugin -->
         <record id="demo_api_client_qgis" model="spp.api.client">
             <field name="name">QGIS Demo Client</field>
@@ -45,5 +44,4 @@
                 name="description"
             >Full GIS access including creating and managing geofences.</field>
         </record>
-    </data>
 </odoo>

--- a/spp_mis_demo_v2/data/demo_statistics.xml
+++ b/spp_mis_demo_v2/data/demo_statistics.xml
@@ -9,259 +9,270 @@
     The separation allows the same underlying variable to be published
     to multiple contexts with different presentation settings.
 -->
-<odoo noupdate="0">
-    <!-- ═══════════════════════════════════════════════════════════════════════
+<odoo>
+    <data noupdate="1">
+        <!-- ═══════════════════════════════════════════════════════════════════════
          CEL VARIABLES - Define the computation logic
          ═══════════════════════════════════════════════════════════════════════ -->
 
-    <!-- Total Members - Aggregate count of all members -->
-    <record id="cel_var_total_members" model="spp.cel.variable">
-        <field name="name">demo_total_members</field>
-        <field name="cel_accessor">total_members</field>
-        <field name="source_type">aggregate</field>
-        <field name="aggregate_type">count</field>
-        <field name="aggregate_target">members</field>
-        <field name="aggregate_filter">true</field>
-        <field name="value_type">number</field>
-        <field name="applies_to">group</field>
-        <field name="category_id" ref="spp_studio.variable_category_demographics" />
-        <field name="state">active</field>
-        <field name="sequence">10</field>
-    </record>
+        <!-- Total Members - Aggregate count of all members -->
+        <record id="cel_var_total_members" model="spp.cel.variable">
+            <field name="name">demo_total_members</field>
+            <field name="cel_accessor">total_members</field>
+            <field name="source_type">aggregate</field>
+            <field name="aggregate_type">count</field>
+            <field name="aggregate_target">members</field>
+            <field name="aggregate_filter">true</field>
+            <field name="value_type">number</field>
+            <field name="applies_to">group</field>
+            <field name="category_id" ref="spp_studio.variable_category_demographics" />
+            <field name="state">active</field>
+            <field name="sequence">10</field>
+        </record>
 
-    <!-- Children Under 5: use spp_studio.var_children_under_5 (same cel_accessor + applies_to) -->
+        <!-- Children Under 5: use spp_studio.var_children_under_5 (same cel_accessor + applies_to) -->
 
-    <!-- Children Under 18 -->
-    <record id="cel_var_children_under_18" model="spp.cel.variable">
-        <field name="name">demo_children_under_18</field>
-        <field name="cel_accessor">children_under_18</field>
-        <field name="source_type">aggregate</field>
-        <field name="aggregate_type">count</field>
-        <field name="aggregate_target">members</field>
-        <field name="aggregate_filter">age_years(m.birthdate) &lt; 18</field>
-        <field name="value_type">number</field>
-        <field name="applies_to">group</field>
-        <field name="category_id" ref="spp_studio.variable_category_demographics" />
-        <field name="state">active</field>
-        <field name="sequence">30</field>
-    </record>
+        <!-- Children Under 18 -->
+        <record id="cel_var_children_under_18" model="spp.cel.variable">
+            <field name="name">demo_children_under_18</field>
+            <field name="cel_accessor">children_under_18</field>
+            <field name="source_type">aggregate</field>
+            <field name="aggregate_type">count</field>
+            <field name="aggregate_target">members</field>
+            <field name="aggregate_filter">age_years(m.birthdate) &lt; 18</field>
+            <field name="value_type">number</field>
+            <field name="applies_to">group</field>
+            <field name="category_id" ref="spp_studio.variable_category_demographics" />
+            <field name="state">active</field>
+            <field name="sequence">30</field>
+        </record>
 
-    <!-- Elderly 60+ -->
-    <record id="cel_var_elderly_60_plus" model="spp.cel.variable">
-        <field name="name">demo_elderly_60_plus</field>
-        <field name="cel_accessor">elderly_60_plus</field>
-        <field name="source_type">aggregate</field>
-        <field name="aggregate_type">count</field>
-        <field name="aggregate_target">members</field>
-        <field name="aggregate_filter">age_years(m.birthdate) >= 60</field>
-        <field name="value_type">number</field>
-        <field name="applies_to">group</field>
-        <field name="category_id" ref="spp_studio.variable_category_demographics" />
-        <field name="state">active</field>
-        <field name="sequence">40</field>
-    </record>
+        <!-- Elderly 60+ -->
+        <record id="cel_var_elderly_60_plus" model="spp.cel.variable">
+            <field name="name">demo_elderly_60_plus</field>
+            <field name="cel_accessor">elderly_60_plus</field>
+            <field name="source_type">aggregate</field>
+            <field name="aggregate_type">count</field>
+            <field name="aggregate_target">members</field>
+            <field name="aggregate_filter">age_years(m.birthdate) >= 60</field>
+            <field name="value_type">number</field>
+            <field name="applies_to">group</field>
+            <field name="category_id" ref="spp_studio.variable_category_demographics" />
+            <field name="state">active</field>
+            <field name="sequence">40</field>
+        </record>
 
-    <!-- Disabled Members -->
-    <record id="cel_var_disabled_members" model="spp.cel.variable">
-        <field name="name">demo_disabled_members</field>
-        <field name="cel_accessor">disabled_members</field>
-        <field name="source_type">aggregate</field>
-        <field name="aggregate_type">count</field>
-        <field name="aggregate_target">members</field>
-        <field name="aggregate_filter">m.disabled != null</field>
-        <field name="value_type">number</field>
-        <field name="applies_to">group</field>
-        <field name="category_id" ref="spp_studio.variable_category_characteristics" />
-        <field name="state">active</field>
-        <field name="sequence">50</field>
-    </record>
+        <!-- Disabled Members -->
+        <record id="cel_var_disabled_members" model="spp.cel.variable">
+            <field name="name">demo_disabled_members</field>
+            <field name="cel_accessor">disabled_members</field>
+            <field name="source_type">aggregate</field>
+            <field name="aggregate_type">count</field>
+            <field name="aggregate_target">members</field>
+            <field name="aggregate_filter">m.disabled != null</field>
+            <field name="value_type">number</field>
+            <field name="applies_to">group</field>
+            <field
+                name="category_id"
+                ref="spp_studio.variable_category_characteristics"
+            />
+            <field name="state">active</field>
+            <field name="sequence">50</field>
+        </record>
 
-    <!-- Female Members -->
-    <record id="cel_var_female_members" model="spp.cel.variable">
-        <field name="name">demo_female_members</field>
-        <field name="cel_accessor">female_members</field>
-        <field name="source_type">aggregate</field>
-        <field name="aggregate_type">count</field>
-        <field name="aggregate_target">members</field>
-        <field name="aggregate_filter">is_female(m.gender_id)</field>
-        <field name="value_type">number</field>
-        <field name="applies_to">group</field>
-        <field name="category_id" ref="spp_studio.variable_category_demographics" />
-        <field name="state">active</field>
-        <field name="sequence">45</field>
-    </record>
+        <!-- Female Members -->
+        <record id="cel_var_female_members" model="spp.cel.variable">
+            <field name="name">demo_female_members</field>
+            <field name="cel_accessor">female_members</field>
+            <field name="source_type">aggregate</field>
+            <field name="aggregate_type">count</field>
+            <field name="aggregate_target">members</field>
+            <field name="aggregate_filter">is_female(m.gender_id)</field>
+            <field name="value_type">number</field>
+            <field name="applies_to">group</field>
+            <field name="category_id" ref="spp_studio.variable_category_demographics" />
+            <field name="state">active</field>
+            <field name="sequence">45</field>
+        </record>
 
-    <!-- Male Members -->
-    <record id="cel_var_male_members" model="spp.cel.variable">
-        <field name="name">demo_male_members</field>
-        <field name="cel_accessor">male_members</field>
-        <field name="source_type">aggregate</field>
-        <field name="aggregate_type">count</field>
-        <field name="aggregate_target">members</field>
-        <field name="aggregate_filter">is_male(m.gender_id)</field>
-        <field name="value_type">number</field>
-        <field name="applies_to">group</field>
-        <field name="category_id" ref="spp_studio.variable_category_demographics" />
-        <field name="state">active</field>
-        <field name="sequence">46</field>
-    </record>
+        <!-- Male Members -->
+        <record id="cel_var_male_members" model="spp.cel.variable">
+            <field name="name">demo_male_members</field>
+            <field name="cel_accessor">male_members</field>
+            <field name="source_type">aggregate</field>
+            <field name="aggregate_type">count</field>
+            <field name="aggregate_target">members</field>
+            <field name="aggregate_filter">is_male(m.gender_id)</field>
+            <field name="value_type">number</field>
+            <field name="applies_to">group</field>
+            <field name="category_id" ref="spp_studio.variable_category_demographics" />
+            <field name="state">active</field>
+            <field name="sequence">46</field>
+        </record>
 
-    <!-- Total Households (computed - returns true for counting) -->
-    <record id="cel_var_total_households" model="spp.cel.variable">
-        <field name="name">demo_total_households</field>
-        <field name="cel_accessor">total_households</field>
-        <field name="source_type">computed</field>
-        <field name="cel_expression">true</field>
-        <field name="value_type">number</field>
-        <field name="applies_to">group</field>
-        <field name="category_id" ref="spp_studio.variable_category_demographics" />
-        <field name="state">active</field>
-        <field name="sequence">5</field>
-    </record>
+        <!-- Total Households (computed - returns true for counting) -->
+        <record id="cel_var_total_households" model="spp.cel.variable">
+            <field name="name">demo_total_households</field>
+            <field name="cel_accessor">total_households</field>
+            <field name="source_type">computed</field>
+            <field name="cel_expression">true</field>
+            <field name="value_type">number</field>
+            <field name="applies_to">group</field>
+            <field name="category_id" ref="spp_studio.variable_category_demographics" />
+            <field name="state">active</field>
+            <field name="sequence">5</field>
+        </record>
 
-    <!-- Program Enrollment (queries spp.program.membership via CEL enrollments symbol) -->
-    <record id="cel_var_enrolled_any_program" model="spp.cel.variable">
-        <field name="name">demo_enrolled_any_program</field>
-        <field name="cel_accessor">enrolled_any_program</field>
-        <field name="source_type">computed</field>
-        <field name="cel_expression">enrollments.exists(true)</field>
-        <field name="value_type">number</field>
-        <field name="applies_to">group</field>
-        <field name="category_id" ref="spp_studio.variable_category_program" />
-        <field name="state">active</field>
-        <field name="sequence">60</field>
-    </record>
+        <!-- Program Enrollment (queries spp.program.membership via CEL enrollments symbol) -->
+        <record id="cel_var_enrolled_any_program" model="spp.cel.variable">
+            <field name="name">demo_enrolled_any_program</field>
+            <field name="cel_accessor">enrolled_any_program</field>
+            <field name="source_type">computed</field>
+            <field name="cel_expression">enrollments.exists(true)</field>
+            <field name="value_type">number</field>
+            <field name="applies_to">group</field>
+            <field name="category_id" ref="spp_studio.variable_category_program" />
+            <field name="state">active</field>
+            <field name="sequence">60</field>
+        </record>
 
-    <!-- ═══════════════════════════════════════════════════════════════════════
+        <!-- ═══════════════════════════════════════════════════════════════════════
          STATISTICS - Publish variables to GIS, dashboards, etc.
          ═══════════════════════════════════════════════════════════════════════ -->
 
-    <!-- Total Households -->
-    <record id="stat_total_households" model="spp.statistic">
-        <field name="name">total_households</field>
-        <field name="label">Total Households</field>
-        <field name="description">Count of household groups in the selected area</field>
-        <field name="variable_id" ref="cel_var_total_households" />
-        <field name="format">count</field>
-        <field name="unit">households</field>
-        <field name="category_id" ref="spp_statistic.category_demographics" />
-        <field name="sequence">10</field>
-        <field name="is_published_gis" eval="True" />
-        <field name="is_published_dashboard" eval="True" />
-        <field name="is_published_api" eval="True" />
-    </record>
+        <!-- Total Households -->
+        <record id="stat_total_households" model="spp.statistic">
+            <field name="name">total_households</field>
+            <field name="label">Total Households</field>
+            <field
+                name="description"
+            >Count of household groups in the selected area</field>
+            <field name="variable_id" ref="cel_var_total_households" />
+            <field name="format">count</field>
+            <field name="unit">households</field>
+            <field name="category_id" ref="spp_statistic.category_demographics" />
+            <field name="sequence">10</field>
+            <field name="is_published_gis" eval="True" />
+            <field name="is_published_dashboard" eval="True" />
+            <field name="is_published_api" eval="True" />
+        </record>
 
-    <!-- Total Members -->
-    <record id="stat_total_members" model="spp.statistic">
-        <field name="name">total_members</field>
-        <field name="label">Total Members</field>
-        <field name="description">Total count of individual household members</field>
-        <field name="variable_id" ref="cel_var_total_members" />
-        <field name="format">count</field>
-        <field name="unit">people</field>
-        <field name="category_id" ref="spp_statistic.category_demographics" />
-        <field name="sequence">15</field>
-        <field name="is_published_gis" eval="True" />
-        <field name="is_published_dashboard" eval="True" />
-    </record>
+        <!-- Total Members -->
+        <record id="stat_total_members" model="spp.statistic">
+            <field name="name">total_members</field>
+            <field name="label">Total Members</field>
+            <field
+                name="description"
+            >Total count of individual household members</field>
+            <field name="variable_id" ref="cel_var_total_members" />
+            <field name="format">count</field>
+            <field name="unit">people</field>
+            <field name="category_id" ref="spp_statistic.category_demographics" />
+            <field name="sequence">15</field>
+            <field name="is_published_gis" eval="True" />
+            <field name="is_published_dashboard" eval="True" />
+        </record>
 
-    <!-- Children Under 5 -->
-    <record id="stat_children_under_5" model="spp.statistic">
-        <field name="name">children_under_5</field>
-        <field name="label">Children Under 5</field>
-        <field name="description">Count of children under 5 years old</field>
-        <field name="variable_id" ref="spp_studio.var_children_under_5" />
-        <field name="format">count</field>
-        <field name="unit">children</field>
-        <field name="category_id" ref="spp_statistic.category_demographics" />
-        <field name="sequence">20</field>
-        <field name="is_published_gis" eval="True" />
-        <field name="is_published_dashboard" eval="True" />
-    </record>
+        <!-- Children Under 5 -->
+        <record id="stat_children_under_5" model="spp.statistic">
+            <field name="name">children_under_5</field>
+            <field name="label">Children Under 5</field>
+            <field name="description">Count of children under 5 years old</field>
+            <field name="variable_id" ref="spp_studio.var_children_under_5" />
+            <field name="format">count</field>
+            <field name="unit">children</field>
+            <field name="category_id" ref="spp_statistic.category_demographics" />
+            <field name="sequence">20</field>
+            <field name="is_published_gis" eval="True" />
+            <field name="is_published_dashboard" eval="True" />
+        </record>
 
-    <!-- Children Under 18 -->
-    <record id="stat_children_under_18" model="spp.statistic">
-        <field name="name">children_under_18</field>
-        <field name="label">Children Under 18</field>
-        <field name="description">Count of children under 18 years old</field>
-        <field name="variable_id" ref="cel_var_children_under_18" />
-        <field name="format">count</field>
-        <field name="unit">children</field>
-        <field name="category_id" ref="spp_statistic.category_demographics" />
-        <field name="sequence">30</field>
-        <field name="is_published_gis" eval="True" />
-        <field name="is_published_dashboard" eval="True" />
-    </record>
+        <!-- Children Under 18 -->
+        <record id="stat_children_under_18" model="spp.statistic">
+            <field name="name">children_under_18</field>
+            <field name="label">Children Under 18</field>
+            <field name="description">Count of children under 18 years old</field>
+            <field name="variable_id" ref="cel_var_children_under_18" />
+            <field name="format">count</field>
+            <field name="unit">children</field>
+            <field name="category_id" ref="spp_statistic.category_demographics" />
+            <field name="sequence">30</field>
+            <field name="is_published_gis" eval="True" />
+            <field name="is_published_dashboard" eval="True" />
+        </record>
 
-    <!-- Elderly 60+ -->
-    <record id="stat_elderly_60_plus" model="spp.statistic">
-        <field name="name">elderly_60_plus</field>
-        <field name="label">Elderly (60+)</field>
-        <field name="description">Count of elderly persons aged 60 and above</field>
-        <field name="variable_id" ref="cel_var_elderly_60_plus" />
-        <field name="format">count</field>
-        <field name="unit">people</field>
-        <field name="category_id" ref="spp_statistic.category_demographics" />
-        <field name="sequence">40</field>
-        <field name="is_published_gis" eval="True" />
-        <field name="is_published_dashboard" eval="True" />
-    </record>
+        <!-- Elderly 60+ -->
+        <record id="stat_elderly_60_plus" model="spp.statistic">
+            <field name="name">elderly_60_plus</field>
+            <field name="label">Elderly (60+)</field>
+            <field name="description">Count of elderly persons aged 60 and above</field>
+            <field name="variable_id" ref="cel_var_elderly_60_plus" />
+            <field name="format">count</field>
+            <field name="unit">people</field>
+            <field name="category_id" ref="spp_statistic.category_demographics" />
+            <field name="sequence">40</field>
+            <field name="is_published_gis" eval="True" />
+            <field name="is_published_dashboard" eval="True" />
+        </record>
 
-    <!-- Female Members -->
-    <record id="stat_female_members" model="spp.statistic">
-        <field name="name">female_members</field>
-        <field name="label">Female Members</field>
-        <field name="description">Count of female household members</field>
-        <field name="variable_id" ref="cel_var_female_members" />
-        <field name="format">count</field>
-        <field name="unit">people</field>
-        <field name="category_id" ref="spp_statistic.category_demographics" />
-        <field name="sequence">45</field>
-        <field name="is_published_gis" eval="True" />
-        <field name="is_published_dashboard" eval="True" />
-    </record>
+        <!-- Female Members -->
+        <record id="stat_female_members" model="spp.statistic">
+            <field name="name">female_members</field>
+            <field name="label">Female Members</field>
+            <field name="description">Count of female household members</field>
+            <field name="variable_id" ref="cel_var_female_members" />
+            <field name="format">count</field>
+            <field name="unit">people</field>
+            <field name="category_id" ref="spp_statistic.category_demographics" />
+            <field name="sequence">45</field>
+            <field name="is_published_gis" eval="True" />
+            <field name="is_published_dashboard" eval="True" />
+        </record>
 
-    <!-- Male Members -->
-    <record id="stat_male_members" model="spp.statistic">
-        <field name="name">male_members</field>
-        <field name="label">Male Members</field>
-        <field name="description">Count of male household members</field>
-        <field name="variable_id" ref="cel_var_male_members" />
-        <field name="format">count</field>
-        <field name="unit">people</field>
-        <field name="category_id" ref="spp_statistic.category_demographics" />
-        <field name="sequence">46</field>
-        <field name="is_published_gis" eval="True" />
-        <field name="is_published_dashboard" eval="True" />
-    </record>
+        <!-- Male Members -->
+        <record id="stat_male_members" model="spp.statistic">
+            <field name="name">male_members</field>
+            <field name="label">Male Members</field>
+            <field name="description">Count of male household members</field>
+            <field name="variable_id" ref="cel_var_male_members" />
+            <field name="format">count</field>
+            <field name="unit">people</field>
+            <field name="category_id" ref="spp_statistic.category_demographics" />
+            <field name="sequence">46</field>
+            <field name="is_published_gis" eval="True" />
+            <field name="is_published_dashboard" eval="True" />
+        </record>
 
-    <!-- Disabled Members -->
-    <record id="stat_disabled_members" model="spp.statistic">
-        <field name="name">disabled_members</field>
-        <field name="label">Disabled Members</field>
-        <field name="description">Count of household members with disabilities</field>
-        <field name="variable_id" ref="cel_var_disabled_members" />
-        <field name="format">count</field>
-        <field name="unit">people</field>
-        <field name="category_id" ref="spp_statistic.category_vulnerability" />
-        <field name="sequence">50</field>
-        <field name="is_published_gis" eval="True" />
-        <field name="is_published_dashboard" eval="True" />
-    </record>
+        <!-- Disabled Members -->
+        <record id="stat_disabled_members" model="spp.statistic">
+            <field name="name">disabled_members</field>
+            <field name="label">Disabled Members</field>
+            <field
+                name="description"
+            >Count of household members with disabilities</field>
+            <field name="variable_id" ref="cel_var_disabled_members" />
+            <field name="format">count</field>
+            <field name="unit">people</field>
+            <field name="category_id" ref="spp_statistic.category_vulnerability" />
+            <field name="sequence">50</field>
+            <field name="is_published_gis" eval="True" />
+            <field name="is_published_dashboard" eval="True" />
+        </record>
 
-    <!-- Program Enrollment -->
-    <record id="stat_enrolled_any_program" model="spp.statistic">
-        <field name="name">enrolled_any_program</field>
-        <field name="label">Enrolled (Any Program)</field>
-        <field
-            name="description"
-        >Count of households enrolled in at least one program</field>
-        <field name="variable_id" ref="cel_var_enrolled_any_program" />
-        <field name="format">count</field>
-        <field name="unit">households</field>
-        <field name="category_id" ref="spp_statistic.category_programs" />
-        <field name="sequence">60</field>
-        <field name="is_published_gis" eval="True" />
-        <field name="is_published_dashboard" eval="True" />
-    </record>
+        <!-- Program Enrollment -->
+        <record id="stat_enrolled_any_program" model="spp.statistic">
+            <field name="name">enrolled_any_program</field>
+            <field name="label">Enrolled (Any Program)</field>
+            <field
+                name="description"
+            >Count of households enrolled in at least one program</field>
+            <field name="variable_id" ref="cel_var_enrolled_any_program" />
+            <field name="format">count</field>
+            <field name="unit">households</field>
+            <field name="category_id" ref="spp_statistic.category_programs" />
+            <field name="sequence">60</field>
+            <field name="is_published_gis" eval="True" />
+            <field name="is_published_dashboard" eval="True" />
+        </record>
+    </data>
 </odoo>

--- a/spp_mis_demo_v2/data/demo_statistics.xml
+++ b/spp_mis_demo_v2/data/demo_statistics.xml
@@ -1,0 +1,267 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Demo Statistics for GIS and Dashboard
+
+    This file creates:
+    1. CEL variables that define the computation logic
+    2. Statistics (spp.statistic) that publish those variables to GIS/dashboards
+
+    The separation allows the same underlying variable to be published
+    to multiple contexts with different presentation settings.
+-->
+<odoo noupdate="0">
+    <!-- ═══════════════════════════════════════════════════════════════════════
+         CEL VARIABLES - Define the computation logic
+         ═══════════════════════════════════════════════════════════════════════ -->
+
+    <!-- Total Members - Aggregate count of all members -->
+    <record id="cel_var_total_members" model="spp.cel.variable">
+        <field name="name">demo_total_members</field>
+        <field name="cel_accessor">total_members</field>
+        <field name="source_type">aggregate</field>
+        <field name="aggregate_type">count</field>
+        <field name="aggregate_target">members</field>
+        <field name="aggregate_filter">true</field>
+        <field name="value_type">number</field>
+        <field name="applies_to">group</field>
+        <field name="category_id" ref="spp_studio.variable_category_demographics" />
+        <field name="state">active</field>
+        <field name="sequence">10</field>
+    </record>
+
+    <!-- Children Under 5: use spp_studio.var_children_under_5 (same cel_accessor + applies_to) -->
+
+    <!-- Children Under 18 -->
+    <record id="cel_var_children_under_18" model="spp.cel.variable">
+        <field name="name">demo_children_under_18</field>
+        <field name="cel_accessor">children_under_18</field>
+        <field name="source_type">aggregate</field>
+        <field name="aggregate_type">count</field>
+        <field name="aggregate_target">members</field>
+        <field name="aggregate_filter">age_years(m.birthdate) &lt; 18</field>
+        <field name="value_type">number</field>
+        <field name="applies_to">group</field>
+        <field name="category_id" ref="spp_studio.variable_category_demographics" />
+        <field name="state">active</field>
+        <field name="sequence">30</field>
+    </record>
+
+    <!-- Elderly 60+ -->
+    <record id="cel_var_elderly_60_plus" model="spp.cel.variable">
+        <field name="name">demo_elderly_60_plus</field>
+        <field name="cel_accessor">elderly_60_plus</field>
+        <field name="source_type">aggregate</field>
+        <field name="aggregate_type">count</field>
+        <field name="aggregate_target">members</field>
+        <field name="aggregate_filter">age_years(m.birthdate) >= 60</field>
+        <field name="value_type">number</field>
+        <field name="applies_to">group</field>
+        <field name="category_id" ref="spp_studio.variable_category_demographics" />
+        <field name="state">active</field>
+        <field name="sequence">40</field>
+    </record>
+
+    <!-- Disabled Members -->
+    <record id="cel_var_disabled_members" model="spp.cel.variable">
+        <field name="name">demo_disabled_members</field>
+        <field name="cel_accessor">disabled_members</field>
+        <field name="source_type">aggregate</field>
+        <field name="aggregate_type">count</field>
+        <field name="aggregate_target">members</field>
+        <field name="aggregate_filter">m.disabled != null</field>
+        <field name="value_type">number</field>
+        <field name="applies_to">group</field>
+        <field name="category_id" ref="spp_studio.variable_category_characteristics" />
+        <field name="state">active</field>
+        <field name="sequence">50</field>
+    </record>
+
+    <!-- Female Members -->
+    <record id="cel_var_female_members" model="spp.cel.variable">
+        <field name="name">demo_female_members</field>
+        <field name="cel_accessor">female_members</field>
+        <field name="source_type">aggregate</field>
+        <field name="aggregate_type">count</field>
+        <field name="aggregate_target">members</field>
+        <field name="aggregate_filter">is_female(m.gender_id)</field>
+        <field name="value_type">number</field>
+        <field name="applies_to">group</field>
+        <field name="category_id" ref="spp_studio.variable_category_demographics" />
+        <field name="state">active</field>
+        <field name="sequence">45</field>
+    </record>
+
+    <!-- Male Members -->
+    <record id="cel_var_male_members" model="spp.cel.variable">
+        <field name="name">demo_male_members</field>
+        <field name="cel_accessor">male_members</field>
+        <field name="source_type">aggregate</field>
+        <field name="aggregate_type">count</field>
+        <field name="aggregate_target">members</field>
+        <field name="aggregate_filter">is_male(m.gender_id)</field>
+        <field name="value_type">number</field>
+        <field name="applies_to">group</field>
+        <field name="category_id" ref="spp_studio.variable_category_demographics" />
+        <field name="state">active</field>
+        <field name="sequence">46</field>
+    </record>
+
+    <!-- Total Households (computed - returns true for counting) -->
+    <record id="cel_var_total_households" model="spp.cel.variable">
+        <field name="name">demo_total_households</field>
+        <field name="cel_accessor">total_households</field>
+        <field name="source_type">computed</field>
+        <field name="cel_expression">true</field>
+        <field name="value_type">number</field>
+        <field name="applies_to">group</field>
+        <field name="category_id" ref="spp_studio.variable_category_demographics" />
+        <field name="state">active</field>
+        <field name="sequence">5</field>
+    </record>
+
+    <!-- Program Enrollment (queries spp.program.membership via CEL enrollments symbol) -->
+    <record id="cel_var_enrolled_any_program" model="spp.cel.variable">
+        <field name="name">demo_enrolled_any_program</field>
+        <field name="cel_accessor">enrolled_any_program</field>
+        <field name="source_type">computed</field>
+        <field name="cel_expression">enrollments.exists(true)</field>
+        <field name="value_type">number</field>
+        <field name="applies_to">group</field>
+        <field name="category_id" ref="spp_studio.variable_category_program" />
+        <field name="state">active</field>
+        <field name="sequence">60</field>
+    </record>
+
+    <!-- ═══════════════════════════════════════════════════════════════════════
+         STATISTICS - Publish variables to GIS, dashboards, etc.
+         ═══════════════════════════════════════════════════════════════════════ -->
+
+    <!-- Total Households -->
+    <record id="stat_total_households" model="spp.statistic">
+        <field name="name">total_households</field>
+        <field name="label">Total Households</field>
+        <field name="description">Count of household groups in the selected area</field>
+        <field name="variable_id" ref="cel_var_total_households" />
+        <field name="format">count</field>
+        <field name="unit">households</field>
+        <field name="category_id" ref="spp_statistic.category_demographics" />
+        <field name="sequence">10</field>
+        <field name="is_published_gis" eval="True" />
+        <field name="is_published_dashboard" eval="True" />
+        <field name="is_published_api" eval="True" />
+    </record>
+
+    <!-- Total Members -->
+    <record id="stat_total_members" model="spp.statistic">
+        <field name="name">total_members</field>
+        <field name="label">Total Members</field>
+        <field name="description">Total count of individual household members</field>
+        <field name="variable_id" ref="cel_var_total_members" />
+        <field name="format">count</field>
+        <field name="unit">people</field>
+        <field name="category_id" ref="spp_statistic.category_demographics" />
+        <field name="sequence">15</field>
+        <field name="is_published_gis" eval="True" />
+        <field name="is_published_dashboard" eval="True" />
+    </record>
+
+    <!-- Children Under 5 -->
+    <record id="stat_children_under_5" model="spp.statistic">
+        <field name="name">children_under_5</field>
+        <field name="label">Children Under 5</field>
+        <field name="description">Count of children under 5 years old</field>
+        <field name="variable_id" ref="spp_studio.var_children_under_5" />
+        <field name="format">count</field>
+        <field name="unit">children</field>
+        <field name="category_id" ref="spp_statistic.category_demographics" />
+        <field name="sequence">20</field>
+        <field name="is_published_gis" eval="True" />
+        <field name="is_published_dashboard" eval="True" />
+    </record>
+
+    <!-- Children Under 18 -->
+    <record id="stat_children_under_18" model="spp.statistic">
+        <field name="name">children_under_18</field>
+        <field name="label">Children Under 18</field>
+        <field name="description">Count of children under 18 years old</field>
+        <field name="variable_id" ref="cel_var_children_under_18" />
+        <field name="format">count</field>
+        <field name="unit">children</field>
+        <field name="category_id" ref="spp_statistic.category_demographics" />
+        <field name="sequence">30</field>
+        <field name="is_published_gis" eval="True" />
+        <field name="is_published_dashboard" eval="True" />
+    </record>
+
+    <!-- Elderly 60+ -->
+    <record id="stat_elderly_60_plus" model="spp.statistic">
+        <field name="name">elderly_60_plus</field>
+        <field name="label">Elderly (60+)</field>
+        <field name="description">Count of elderly persons aged 60 and above</field>
+        <field name="variable_id" ref="cel_var_elderly_60_plus" />
+        <field name="format">count</field>
+        <field name="unit">people</field>
+        <field name="category_id" ref="spp_statistic.category_demographics" />
+        <field name="sequence">40</field>
+        <field name="is_published_gis" eval="True" />
+        <field name="is_published_dashboard" eval="True" />
+    </record>
+
+    <!-- Female Members -->
+    <record id="stat_female_members" model="spp.statistic">
+        <field name="name">female_members</field>
+        <field name="label">Female Members</field>
+        <field name="description">Count of female household members</field>
+        <field name="variable_id" ref="cel_var_female_members" />
+        <field name="format">count</field>
+        <field name="unit">people</field>
+        <field name="category_id" ref="spp_statistic.category_demographics" />
+        <field name="sequence">45</field>
+        <field name="is_published_gis" eval="True" />
+        <field name="is_published_dashboard" eval="True" />
+    </record>
+
+    <!-- Male Members -->
+    <record id="stat_male_members" model="spp.statistic">
+        <field name="name">male_members</field>
+        <field name="label">Male Members</field>
+        <field name="description">Count of male household members</field>
+        <field name="variable_id" ref="cel_var_male_members" />
+        <field name="format">count</field>
+        <field name="unit">people</field>
+        <field name="category_id" ref="spp_statistic.category_demographics" />
+        <field name="sequence">46</field>
+        <field name="is_published_gis" eval="True" />
+        <field name="is_published_dashboard" eval="True" />
+    </record>
+
+    <!-- Disabled Members -->
+    <record id="stat_disabled_members" model="spp.statistic">
+        <field name="name">disabled_members</field>
+        <field name="label">Disabled Members</field>
+        <field name="description">Count of household members with disabilities</field>
+        <field name="variable_id" ref="cel_var_disabled_members" />
+        <field name="format">count</field>
+        <field name="unit">people</field>
+        <field name="category_id" ref="spp_statistic.category_vulnerability" />
+        <field name="sequence">50</field>
+        <field name="is_published_gis" eval="True" />
+        <field name="is_published_dashboard" eval="True" />
+    </record>
+
+    <!-- Program Enrollment -->
+    <record id="stat_enrolled_any_program" model="spp.statistic">
+        <field name="name">enrolled_any_program</field>
+        <field name="label">Enrolled (Any Program)</field>
+        <field
+            name="description"
+        >Count of households enrolled in at least one program</field>
+        <field name="variable_id" ref="cel_var_enrolled_any_program" />
+        <field name="format">count</field>
+        <field name="unit">households</field>
+        <field name="category_id" ref="spp_statistic.category_programs" />
+        <field name="sequence">60</field>
+        <field name="is_published_gis" eval="True" />
+        <field name="is_published_dashboard" eval="True" />
+    </record>
+</odoo>

--- a/spp_mis_demo_v2/data/demo_statistics.xml
+++ b/spp_mis_demo_v2/data/demo_statistics.xml
@@ -10,267 +10,258 @@
     to multiple contexts with different presentation settings.
 -->
 <odoo noupdate="1">
-        <!-- ═══════════════════════════════════════════════════════════════════════
+    <!-- ═══════════════════════════════════════════════════════════════════════
          CEL VARIABLES - Define the computation logic
          ═══════════════════════════════════════════════════════════════════════ -->
 
-        <!-- Total Members - Aggregate count of all members -->
-        <record id="cel_var_total_members" model="spp.cel.variable">
-            <field name="name">demo_total_members</field>
-            <field name="cel_accessor">total_members</field>
-            <field name="source_type">aggregate</field>
-            <field name="aggregate_type">count</field>
-            <field name="aggregate_target">members</field>
-            <field name="aggregate_filter">true</field>
-            <field name="value_type">number</field>
-            <field name="applies_to">group</field>
-            <field name="category_id" ref="spp_studio.variable_category_demographics" />
-            <field name="state">active</field>
-            <field name="sequence">10</field>
-        </record>
+    <!-- Total Members - Aggregate count of all members -->
+    <record id="cel_var_total_members" model="spp.cel.variable">
+        <field name="name">demo_total_members</field>
+        <field name="cel_accessor">total_members</field>
+        <field name="source_type">aggregate</field>
+        <field name="aggregate_type">count</field>
+        <field name="aggregate_target">members</field>
+        <field name="aggregate_filter">true</field>
+        <field name="value_type">number</field>
+        <field name="applies_to">group</field>
+        <field name="category_id" ref="spp_studio.variable_category_demographics" />
+        <field name="state">active</field>
+        <field name="sequence">10</field>
+    </record>
 
-        <!-- Children Under 5: use spp_studio.var_children_under_5 (same cel_accessor + applies_to) -->
+    <!-- Children Under 5: use spp_studio.var_children_under_5 (same cel_accessor + applies_to) -->
 
-        <!-- Children Under 18 -->
-        <record id="cel_var_children_under_18" model="spp.cel.variable">
-            <field name="name">demo_children_under_18</field>
-            <field name="cel_accessor">children_under_18</field>
-            <field name="source_type">aggregate</field>
-            <field name="aggregate_type">count</field>
-            <field name="aggregate_target">members</field>
-            <field name="aggregate_filter">age_years(m.birthdate) &lt; 18</field>
-            <field name="value_type">number</field>
-            <field name="applies_to">group</field>
-            <field name="category_id" ref="spp_studio.variable_category_demographics" />
-            <field name="state">active</field>
-            <field name="sequence">30</field>
-        </record>
+    <!-- Children Under 18 -->
+    <record id="cel_var_children_under_18" model="spp.cel.variable">
+        <field name="name">demo_children_under_18</field>
+        <field name="cel_accessor">children_under_18</field>
+        <field name="source_type">aggregate</field>
+        <field name="aggregate_type">count</field>
+        <field name="aggregate_target">members</field>
+        <field name="aggregate_filter">age_years(m.birthdate) &lt; 18</field>
+        <field name="value_type">number</field>
+        <field name="applies_to">group</field>
+        <field name="category_id" ref="spp_studio.variable_category_demographics" />
+        <field name="state">active</field>
+        <field name="sequence">30</field>
+    </record>
 
-        <!-- Elderly 60+ -->
-        <record id="cel_var_elderly_60_plus" model="spp.cel.variable">
-            <field name="name">demo_elderly_60_plus</field>
-            <field name="cel_accessor">elderly_60_plus</field>
-            <field name="source_type">aggregate</field>
-            <field name="aggregate_type">count</field>
-            <field name="aggregate_target">members</field>
-            <field name="aggregate_filter">age_years(m.birthdate) >= 60</field>
-            <field name="value_type">number</field>
-            <field name="applies_to">group</field>
-            <field name="category_id" ref="spp_studio.variable_category_demographics" />
-            <field name="state">active</field>
-            <field name="sequence">40</field>
-        </record>
+    <!-- Elderly 60+ -->
+    <record id="cel_var_elderly_60_plus" model="spp.cel.variable">
+        <field name="name">demo_elderly_60_plus</field>
+        <field name="cel_accessor">elderly_60_plus</field>
+        <field name="source_type">aggregate</field>
+        <field name="aggregate_type">count</field>
+        <field name="aggregate_target">members</field>
+        <field name="aggregate_filter">age_years(m.birthdate) >= 60</field>
+        <field name="value_type">number</field>
+        <field name="applies_to">group</field>
+        <field name="category_id" ref="spp_studio.variable_category_demographics" />
+        <field name="state">active</field>
+        <field name="sequence">40</field>
+    </record>
 
-        <!-- Disabled Members -->
-        <record id="cel_var_disabled_members" model="spp.cel.variable">
-            <field name="name">demo_disabled_members</field>
-            <field name="cel_accessor">disabled_members</field>
-            <field name="source_type">aggregate</field>
-            <field name="aggregate_type">count</field>
-            <field name="aggregate_target">members</field>
-            <field name="aggregate_filter">m.disabled != null</field>
-            <field name="value_type">number</field>
-            <field name="applies_to">group</field>
-            <field
-                name="category_id"
-                ref="spp_studio.variable_category_characteristics"
-            />
-            <field name="state">active</field>
-            <field name="sequence">50</field>
-        </record>
+    <!-- Disabled Members -->
+    <record id="cel_var_disabled_members" model="spp.cel.variable">
+        <field name="name">demo_disabled_members</field>
+        <field name="cel_accessor">disabled_members</field>
+        <field name="source_type">aggregate</field>
+        <field name="aggregate_type">count</field>
+        <field name="aggregate_target">members</field>
+        <field name="aggregate_filter">m.disabled != null</field>
+        <field name="value_type">number</field>
+        <field name="applies_to">group</field>
+        <field name="category_id" ref="spp_studio.variable_category_characteristics" />
+        <field name="state">active</field>
+        <field name="sequence">50</field>
+    </record>
 
-        <!-- Female Members -->
-        <record id="cel_var_female_members" model="spp.cel.variable">
-            <field name="name">demo_female_members</field>
-            <field name="cel_accessor">female_members</field>
-            <field name="source_type">aggregate</field>
-            <field name="aggregate_type">count</field>
-            <field name="aggregate_target">members</field>
-            <field name="aggregate_filter">is_female(m.gender_id)</field>
-            <field name="value_type">number</field>
-            <field name="applies_to">group</field>
-            <field name="category_id" ref="spp_studio.variable_category_demographics" />
-            <field name="state">active</field>
-            <field name="sequence">45</field>
-        </record>
+    <!-- Female Members -->
+    <record id="cel_var_female_members" model="spp.cel.variable">
+        <field name="name">demo_female_members</field>
+        <field name="cel_accessor">female_members</field>
+        <field name="source_type">aggregate</field>
+        <field name="aggregate_type">count</field>
+        <field name="aggregate_target">members</field>
+        <field name="aggregate_filter">is_female(m.gender_id)</field>
+        <field name="value_type">number</field>
+        <field name="applies_to">group</field>
+        <field name="category_id" ref="spp_studio.variable_category_demographics" />
+        <field name="state">active</field>
+        <field name="sequence">45</field>
+    </record>
 
-        <!-- Male Members -->
-        <record id="cel_var_male_members" model="spp.cel.variable">
-            <field name="name">demo_male_members</field>
-            <field name="cel_accessor">male_members</field>
-            <field name="source_type">aggregate</field>
-            <field name="aggregate_type">count</field>
-            <field name="aggregate_target">members</field>
-            <field name="aggregate_filter">is_male(m.gender_id)</field>
-            <field name="value_type">number</field>
-            <field name="applies_to">group</field>
-            <field name="category_id" ref="spp_studio.variable_category_demographics" />
-            <field name="state">active</field>
-            <field name="sequence">46</field>
-        </record>
+    <!-- Male Members -->
+    <record id="cel_var_male_members" model="spp.cel.variable">
+        <field name="name">demo_male_members</field>
+        <field name="cel_accessor">male_members</field>
+        <field name="source_type">aggregate</field>
+        <field name="aggregate_type">count</field>
+        <field name="aggregate_target">members</field>
+        <field name="aggregate_filter">is_male(m.gender_id)</field>
+        <field name="value_type">number</field>
+        <field name="applies_to">group</field>
+        <field name="category_id" ref="spp_studio.variable_category_demographics" />
+        <field name="state">active</field>
+        <field name="sequence">46</field>
+    </record>
 
-        <!-- Total Households (computed - returns true for counting) -->
-        <record id="cel_var_total_households" model="spp.cel.variable">
-            <field name="name">demo_total_households</field>
-            <field name="cel_accessor">total_households</field>
-            <field name="source_type">computed</field>
-            <field name="cel_expression">true</field>
-            <field name="value_type">number</field>
-            <field name="applies_to">group</field>
-            <field name="category_id" ref="spp_studio.variable_category_demographics" />
-            <field name="state">active</field>
-            <field name="sequence">5</field>
-        </record>
+    <!-- Total Households (computed - returns true for counting) -->
+    <record id="cel_var_total_households" model="spp.cel.variable">
+        <field name="name">demo_total_households</field>
+        <field name="cel_accessor">total_households</field>
+        <field name="source_type">computed</field>
+        <field name="cel_expression">true</field>
+        <field name="value_type">number</field>
+        <field name="applies_to">group</field>
+        <field name="category_id" ref="spp_studio.variable_category_demographics" />
+        <field name="state">active</field>
+        <field name="sequence">5</field>
+    </record>
 
-        <!-- Program Enrollment (queries spp.program.membership via CEL enrollments symbol) -->
-        <record id="cel_var_enrolled_any_program" model="spp.cel.variable">
-            <field name="name">demo_enrolled_any_program</field>
-            <field name="cel_accessor">enrolled_any_program</field>
-            <field name="source_type">computed</field>
-            <field name="cel_expression">enrollments.exists(true)</field>
-            <field name="value_type">number</field>
-            <field name="applies_to">group</field>
-            <field name="category_id" ref="spp_studio.variable_category_program" />
-            <field name="state">active</field>
-            <field name="sequence">60</field>
-        </record>
+    <!-- Program Enrollment (queries spp.program.membership via CEL enrollments symbol) -->
+    <record id="cel_var_enrolled_any_program" model="spp.cel.variable">
+        <field name="name">demo_enrolled_any_program</field>
+        <field name="cel_accessor">enrolled_any_program</field>
+        <field name="source_type">computed</field>
+        <field name="cel_expression">enrollments.exists(true)</field>
+        <field name="value_type">number</field>
+        <field name="applies_to">group</field>
+        <field name="category_id" ref="spp_studio.variable_category_program" />
+        <field name="state">active</field>
+        <field name="sequence">60</field>
+    </record>
 
-        <!-- ═══════════════════════════════════════════════════════════════════════
+    <!-- ═══════════════════════════════════════════════════════════════════════
          STATISTICS - Publish variables to GIS, dashboards, etc.
          ═══════════════════════════════════════════════════════════════════════ -->
 
-        <!-- Total Households -->
-        <record id="stat_total_households" model="spp.statistic">
-            <field name="name">total_households</field>
-            <field name="label">Total Households</field>
-            <field
-                name="description"
-            >Count of household groups in the selected area</field>
-            <field name="variable_id" ref="cel_var_total_households" />
-            <field name="format">count</field>
-            <field name="unit">households</field>
-            <field name="category_id" ref="spp_statistic.category_demographics" />
-            <field name="sequence">10</field>
-            <field name="is_published_gis" eval="True" />
-            <field name="is_published_dashboard" eval="True" />
-            <field name="is_published_api" eval="True" />
-        </record>
+    <!-- Total Households -->
+    <record id="stat_total_households" model="spp.statistic">
+        <field name="name">total_households</field>
+        <field name="label">Total Households</field>
+        <field name="description">Count of household groups in the selected area</field>
+        <field name="variable_id" ref="cel_var_total_households" />
+        <field name="format">count</field>
+        <field name="unit">households</field>
+        <field name="category_id" ref="spp_statistic.category_demographics" />
+        <field name="sequence">10</field>
+        <field name="is_published_gis" eval="True" />
+        <field name="is_published_dashboard" eval="True" />
+        <field name="is_published_api" eval="True" />
+    </record>
 
-        <!-- Total Members -->
-        <record id="stat_total_members" model="spp.statistic">
-            <field name="name">total_members</field>
-            <field name="label">Total Members</field>
-            <field
-                name="description"
-            >Total count of individual household members</field>
-            <field name="variable_id" ref="cel_var_total_members" />
-            <field name="format">count</field>
-            <field name="unit">people</field>
-            <field name="category_id" ref="spp_statistic.category_demographics" />
-            <field name="sequence">15</field>
-            <field name="is_published_gis" eval="True" />
-            <field name="is_published_dashboard" eval="True" />
-        </record>
+    <!-- Total Members -->
+    <record id="stat_total_members" model="spp.statistic">
+        <field name="name">total_members</field>
+        <field name="label">Total Members</field>
+        <field name="description">Total count of individual household members</field>
+        <field name="variable_id" ref="cel_var_total_members" />
+        <field name="format">count</field>
+        <field name="unit">people</field>
+        <field name="category_id" ref="spp_statistic.category_demographics" />
+        <field name="sequence">15</field>
+        <field name="is_published_gis" eval="True" />
+        <field name="is_published_dashboard" eval="True" />
+    </record>
 
-        <!-- Children Under 5 -->
-        <record id="stat_children_under_5" model="spp.statistic">
-            <field name="name">children_under_5</field>
-            <field name="label">Children Under 5</field>
-            <field name="description">Count of children under 5 years old</field>
-            <field name="variable_id" ref="spp_studio.var_children_under_5" />
-            <field name="format">count</field>
-            <field name="unit">children</field>
-            <field name="category_id" ref="spp_statistic.category_demographics" />
-            <field name="sequence">20</field>
-            <field name="is_published_gis" eval="True" />
-            <field name="is_published_dashboard" eval="True" />
-        </record>
+    <!-- Children Under 5 -->
+    <record id="stat_children_under_5" model="spp.statistic">
+        <field name="name">children_under_5</field>
+        <field name="label">Children Under 5</field>
+        <field name="description">Count of children under 5 years old</field>
+        <field name="variable_id" ref="spp_studio.var_children_under_5" />
+        <field name="format">count</field>
+        <field name="unit">children</field>
+        <field name="category_id" ref="spp_statistic.category_demographics" />
+        <field name="sequence">20</field>
+        <field name="is_published_gis" eval="True" />
+        <field name="is_published_dashboard" eval="True" />
+    </record>
 
-        <!-- Children Under 18 -->
-        <record id="stat_children_under_18" model="spp.statistic">
-            <field name="name">children_under_18</field>
-            <field name="label">Children Under 18</field>
-            <field name="description">Count of children under 18 years old</field>
-            <field name="variable_id" ref="cel_var_children_under_18" />
-            <field name="format">count</field>
-            <field name="unit">children</field>
-            <field name="category_id" ref="spp_statistic.category_demographics" />
-            <field name="sequence">30</field>
-            <field name="is_published_gis" eval="True" />
-            <field name="is_published_dashboard" eval="True" />
-        </record>
+    <!-- Children Under 18 -->
+    <record id="stat_children_under_18" model="spp.statistic">
+        <field name="name">children_under_18</field>
+        <field name="label">Children Under 18</field>
+        <field name="description">Count of children under 18 years old</field>
+        <field name="variable_id" ref="cel_var_children_under_18" />
+        <field name="format">count</field>
+        <field name="unit">children</field>
+        <field name="category_id" ref="spp_statistic.category_demographics" />
+        <field name="sequence">30</field>
+        <field name="is_published_gis" eval="True" />
+        <field name="is_published_dashboard" eval="True" />
+    </record>
 
-        <!-- Elderly 60+ -->
-        <record id="stat_elderly_60_plus" model="spp.statistic">
-            <field name="name">elderly_60_plus</field>
-            <field name="label">Elderly (60+)</field>
-            <field name="description">Count of elderly persons aged 60 and above</field>
-            <field name="variable_id" ref="cel_var_elderly_60_plus" />
-            <field name="format">count</field>
-            <field name="unit">people</field>
-            <field name="category_id" ref="spp_statistic.category_demographics" />
-            <field name="sequence">40</field>
-            <field name="is_published_gis" eval="True" />
-            <field name="is_published_dashboard" eval="True" />
-        </record>
+    <!-- Elderly 60+ -->
+    <record id="stat_elderly_60_plus" model="spp.statistic">
+        <field name="name">elderly_60_plus</field>
+        <field name="label">Elderly (60+)</field>
+        <field name="description">Count of elderly persons aged 60 and above</field>
+        <field name="variable_id" ref="cel_var_elderly_60_plus" />
+        <field name="format">count</field>
+        <field name="unit">people</field>
+        <field name="category_id" ref="spp_statistic.category_demographics" />
+        <field name="sequence">40</field>
+        <field name="is_published_gis" eval="True" />
+        <field name="is_published_dashboard" eval="True" />
+    </record>
 
-        <!-- Female Members -->
-        <record id="stat_female_members" model="spp.statistic">
-            <field name="name">female_members</field>
-            <field name="label">Female Members</field>
-            <field name="description">Count of female household members</field>
-            <field name="variable_id" ref="cel_var_female_members" />
-            <field name="format">count</field>
-            <field name="unit">people</field>
-            <field name="category_id" ref="spp_statistic.category_demographics" />
-            <field name="sequence">45</field>
-            <field name="is_published_gis" eval="True" />
-            <field name="is_published_dashboard" eval="True" />
-        </record>
+    <!-- Female Members -->
+    <record id="stat_female_members" model="spp.statistic">
+        <field name="name">female_members</field>
+        <field name="label">Female Members</field>
+        <field name="description">Count of female household members</field>
+        <field name="variable_id" ref="cel_var_female_members" />
+        <field name="format">count</field>
+        <field name="unit">people</field>
+        <field name="category_id" ref="spp_statistic.category_demographics" />
+        <field name="sequence">45</field>
+        <field name="is_published_gis" eval="True" />
+        <field name="is_published_dashboard" eval="True" />
+    </record>
 
-        <!-- Male Members -->
-        <record id="stat_male_members" model="spp.statistic">
-            <field name="name">male_members</field>
-            <field name="label">Male Members</field>
-            <field name="description">Count of male household members</field>
-            <field name="variable_id" ref="cel_var_male_members" />
-            <field name="format">count</field>
-            <field name="unit">people</field>
-            <field name="category_id" ref="spp_statistic.category_demographics" />
-            <field name="sequence">46</field>
-            <field name="is_published_gis" eval="True" />
-            <field name="is_published_dashboard" eval="True" />
-        </record>
+    <!-- Male Members -->
+    <record id="stat_male_members" model="spp.statistic">
+        <field name="name">male_members</field>
+        <field name="label">Male Members</field>
+        <field name="description">Count of male household members</field>
+        <field name="variable_id" ref="cel_var_male_members" />
+        <field name="format">count</field>
+        <field name="unit">people</field>
+        <field name="category_id" ref="spp_statistic.category_demographics" />
+        <field name="sequence">46</field>
+        <field name="is_published_gis" eval="True" />
+        <field name="is_published_dashboard" eval="True" />
+    </record>
 
-        <!-- Disabled Members -->
-        <record id="stat_disabled_members" model="spp.statistic">
-            <field name="name">disabled_members</field>
-            <field name="label">Disabled Members</field>
-            <field
-                name="description"
-            >Count of household members with disabilities</field>
-            <field name="variable_id" ref="cel_var_disabled_members" />
-            <field name="format">count</field>
-            <field name="unit">people</field>
-            <field name="category_id" ref="spp_statistic.category_vulnerability" />
-            <field name="sequence">50</field>
-            <field name="is_published_gis" eval="True" />
-            <field name="is_published_dashboard" eval="True" />
-        </record>
+    <!-- Disabled Members -->
+    <record id="stat_disabled_members" model="spp.statistic">
+        <field name="name">disabled_members</field>
+        <field name="label">Disabled Members</field>
+        <field name="description">Count of household members with disabilities</field>
+        <field name="variable_id" ref="cel_var_disabled_members" />
+        <field name="format">count</field>
+        <field name="unit">people</field>
+        <field name="category_id" ref="spp_statistic.category_vulnerability" />
+        <field name="sequence">50</field>
+        <field name="is_published_gis" eval="True" />
+        <field name="is_published_dashboard" eval="True" />
+    </record>
 
-        <!-- Program Enrollment -->
-        <record id="stat_enrolled_any_program" model="spp.statistic">
-            <field name="name">enrolled_any_program</field>
-            <field name="label">Enrolled (Any Program)</field>
-            <field
-                name="description"
-            >Count of households enrolled in at least one program</field>
-            <field name="variable_id" ref="cel_var_enrolled_any_program" />
-            <field name="format">count</field>
-            <field name="unit">households</field>
-            <field name="category_id" ref="spp_statistic.category_programs" />
-            <field name="sequence">60</field>
-            <field name="is_published_gis" eval="True" />
-            <field name="is_published_dashboard" eval="True" />
-        </record>
+    <!-- Program Enrollment -->
+    <record id="stat_enrolled_any_program" model="spp.statistic">
+        <field name="name">enrolled_any_program</field>
+        <field name="label">Enrolled (Any Program)</field>
+        <field
+            name="description"
+        >Count of households enrolled in at least one program</field>
+        <field name="variable_id" ref="cel_var_enrolled_any_program" />
+        <field name="format">count</field>
+        <field name="unit">households</field>
+        <field name="category_id" ref="spp_statistic.category_programs" />
+        <field name="sequence">60</field>
+        <field name="is_published_gis" eval="True" />
+        <field name="is_published_dashboard" eval="True" />
+    </record>
 </odoo>

--- a/spp_mis_demo_v2/data/demo_statistics.xml
+++ b/spp_mis_demo_v2/data/demo_statistics.xml
@@ -9,8 +9,7 @@
     The separation allows the same underlying variable to be published
     to multiple contexts with different presentation settings.
 -->
-<odoo>
-    <data noupdate="1">
+<odoo noupdate="1">
         <!-- ═══════════════════════════════════════════════════════════════════════
          CEL VARIABLES - Define the computation logic
          ═══════════════════════════════════════════════════════════════════════ -->
@@ -274,5 +273,4 @@
             <field name="is_published_gis" eval="True" />
             <field name="is_published_dashboard" eval="True" />
         </record>
-    </data>
 </odoo>

--- a/spp_mis_demo_v2/models/indicator_providers.py
+++ b/spp_mis_demo_v2/models/indicator_providers.py
@@ -41,6 +41,7 @@ STANDARD_VARIABLES = [
     # Household composition (aggregate)
     "spp_studio.var_hh_size",
     "spp_studio.var_child_count",
+    "spp_studio.var_children_under_5",
     "spp_studio.var_elderly_count",
     "spp_studio.var_working_age_count",
     # Household characteristics (computed)

--- a/spp_mis_demo_v2/models/mis_demo_generator.py
+++ b/spp_mis_demo_v2/models/mis_demo_generator.py
@@ -181,6 +181,23 @@ class SPPMISDemoGenerator(models.TransientModel):
         help="Generate QR credentials for demo story personas (Maria Santos, etc.)",
     )
 
+    # Geographic data options
+    load_geographic_data = fields.Boolean(
+        string="Load Geographic Data",
+        default=True,
+        help="Load area data with GIS shapes and assign GPS coordinates to registrants for QGIS plugin demo",
+    )
+    country_code = fields.Selection(
+        [
+            ("phl", "Philippines"),
+            ("lka", "Sri Lanka"),
+            ("tgo", "Togo"),
+        ],
+        string="Country",
+        default="phl",
+        help="Country for geographic data (areas and GIS shapes)",
+    )
+
     # Locale settings
     locale_origin = fields.Many2one(
         "res.country",
@@ -256,6 +273,8 @@ class SPPMISDemoGenerator(models.TransientModel):
                 "case_volume_count": 10,
                 "generate_claim169_demo": True,
                 "generate_credentials_for_stories": True,
+                "load_geographic_data": True,
+                "country_code": "phl",
             },
             "training": {
                 "create_demo_programs": True,
@@ -278,6 +297,8 @@ class SPPMISDemoGenerator(models.TransientModel):
                 "case_volume_count": 25,
                 "generate_claim169_demo": True,
                 "generate_credentials_for_stories": True,
+                "load_geographic_data": True,
+                "country_code": "phl",
             },
             "testing": {
                 "create_demo_programs": True,
@@ -300,6 +321,8 @@ class SPPMISDemoGenerator(models.TransientModel):
                 "case_volume_count": 200,
                 "generate_claim169_demo": True,
                 "generate_credentials_for_stories": True,
+                "load_geographic_data": True,
+                "country_code": "phl",
             },
             "complete": {
                 "create_demo_programs": True,
@@ -322,6 +345,8 @@ class SPPMISDemoGenerator(models.TransientModel):
                 "case_volume_count": 50,
                 "generate_claim169_demo": True,
                 "generate_credentials_for_stories": True,
+                "load_geographic_data": True,
+                "country_code": "phl",
             },
         }
         defaults = mode_defaults.get(self.demo_mode, mode_defaults["sales"])
@@ -453,6 +478,13 @@ class SPPMISDemoGenerator(models.TransientModel):
                 self._create_test_personas()
                 stats["test_personas_created"] = True
 
+            # Step 0.4: Load geographic data (if enabled)
+            if self.load_geographic_data:
+                _logger.info(f"Loading geographic data for {self.country_code}...")
+                geo_result = self._load_geographic_data(stats)
+                if geo_result:
+                    stats["areas_loaded"] = geo_result.get("shapes_loaded", 0)
+
             # Step 0.5: Ensure demo stories exist (auto-generate if needed)
             stories_created = self._ensure_demo_stories_exist(stats)
             if stories_created:
@@ -521,6 +553,16 @@ class SPPMISDemoGenerator(models.TransientModel):
             if self.generate_claim169_demo:
                 _logger.info("Generating Claim 169 demo data...")
                 self._generate_claim169_demo(stats)
+
+            # Step 11: Assign areas and generate GPS coordinates (if geographic data loaded)
+            if self.load_geographic_data:
+                _logger.info("Assigning areas to registrants...")
+                self._assign_registrant_areas(stats)
+                _logger.info("Generating GPS coordinates for registrants...")
+                self._generate_coordinates(stats)
+
+            # Step 12: Refresh GIS reports so map data is available immediately
+            self._refresh_gis_reports(stats)
 
             self.state = "completed"
 
@@ -3618,6 +3660,9 @@ class SPPMISDemoGenerator(models.TransientModel):
                 if claim169_parts:
                     message_parts.append(_("QR Credentials: %s created") % ", ".join(claim169_parts))
 
+        # Geographic Data
+        self._append_geographic_summary(stats, message_parts)
+
         # Warnings
         if stats["missing_registrants"]:
             message_parts.append("")
@@ -3659,6 +3704,217 @@ class SPPMISDemoGenerator(models.TransientModel):
                 },
             },
         }
+
+    def _append_geographic_summary(self, stats, message_parts):
+        """Append geographic data summary to notification message parts."""
+        if not self.load_geographic_data:
+            return
+        geo_parts = []
+        if stats.get("areas_loaded", 0) > 0:
+            geo_parts.append(_("%(count)s areas with GIS shapes", count=stats["areas_loaded"]))
+        if stats.get("areas_assigned", 0) > 0:
+            geo_parts.append(_("%(count)s groups assigned to areas", count=stats["areas_assigned"]))
+        if stats.get("coordinates_generated", 0) > 0:
+            geo_parts.append(_("%(count)s registrants with GPS coordinates", count=stats["coordinates_generated"]))
+        if geo_parts:
+            message_parts.append(_("Geographic Data: %s") % ", ".join(geo_parts))
+
+    def _load_geographic_data(self, stats):
+        """Load geographic area data with GIS shapes.
+
+        Uses the DemoAreaLoader from spp_demo to load country-specific
+        area hierarchies with GIS polygon data for spatial queries.
+
+        Args:
+            stats: Statistics dictionary to update
+
+        Returns:
+            dict: Result with counts of loaded data
+        """
+        try:
+            loader = self.env["spp.demo.area.loader"]
+            result = loader.load_country_areas(self.country_code, load_shapes=True)
+            _logger.info(
+                "[spp.mis.demo] Loaded geographic data for %s: %d areas with GIS shapes",
+                self.country_code,
+                result.get("shapes_loaded", 0),
+            )
+            return result
+        except Exception as e:
+            _logger.warning("[spp.mis.demo] Failed to load geographic data: %s", e)
+            return None
+
+    def _assign_registrant_areas(self, stats):
+        """Assign geographic areas to registrants.
+
+        Strategy:
+        - Get all municipalities (level 3 areas) from the loaded country
+        - For each group, assign a random municipality to area_id
+        - Individual members inherit area_id from their group
+
+        Args:
+            stats: Statistics dictionary to update
+        """
+        Area = self.env["spp.area"]
+        Partner = self.env["res.partner"]
+
+        # Get all level 3 areas (municipalities) that have geo_polygon data
+        municipalities = Area.search([("area_level", "=", 3), ("geo_polygon", "!=", False)])
+
+        if not municipalities:
+            _logger.warning("[spp.mis.demo] No municipalities with GIS data found, skipping area assignment")
+            stats["areas_assigned"] = 0
+            return
+
+        _logger.info("[spp.mis.demo] Found %d municipalities with GIS data", len(municipalities))
+
+        # Get all groups (households)
+        groups = Partner.search([("is_group", "=", True), ("is_registrant", "=", True)])
+
+        if not groups:
+            _logger.warning("[spp.mis.demo] No groups found, skipping area assignment")
+            stats["areas_assigned"] = 0
+            return
+
+        # Assign random municipality to each group
+        groups_assigned = 0
+        for group in groups:
+            municipality = random.choice(municipalities)
+            group.write({"area_id": municipality.id})
+            groups_assigned += 1
+
+            # Members inherit area from group
+            members = Partner.search([("group_membership_ids.group", "=", group.id)])
+            if members:
+                members.write({"area_id": municipality.id})
+
+        stats["areas_assigned"] = groups_assigned
+        _logger.info("[spp.mis.demo] Assigned areas to %d groups", groups_assigned)
+
+    def _generate_coordinates(self, stats):
+        """Generate GPS coordinates for registrants.
+
+        For each registrant with an area_id that has geo_polygon data,
+        generates a random point within the area polygon and sets
+        the coordinates field (if spp_registrant_gis is installed).
+
+        Uses shapely to generate random points within polygons.
+
+        Args:
+            stats: Statistics dictionary to update
+        """
+        # Check if spp_registrant_gis is installed
+        if "coordinates" not in self.env["res.partner"]._fields:
+            _logger.info("[spp.mis.demo] spp_registrant_gis not installed, skipping coordinate generation")
+            stats["coordinates_generated"] = 0
+            return
+
+        try:
+            from shapely.geometry import shape
+            from shapely.wkb import loads as wkbloads
+        except ImportError:
+            _logger.warning("[spp.mis.demo] shapely not available, skipping coordinate generation")
+            stats["coordinates_generated"] = 0
+            return
+
+        Partner = self.env["res.partner"]
+        Area = self.env["spp.area"]
+
+        # Get all registrants with an area_id
+        registrants = Partner.search(
+            [
+                ("is_registrant", "=", True),
+                ("area_id", "!=", False),
+            ]
+        )
+
+        if not registrants:
+            _logger.warning("[spp.mis.demo] No registrants with areas found")
+            stats["coordinates_generated"] = 0
+            return
+
+        _logger.info("[spp.mis.demo] Generating coordinates for %d registrants", len(registrants))
+
+        coordinates_generated = 0
+
+        # Group registrants by area to minimize queries
+        registrants_by_area = {}
+        for registrant in registrants:
+            area_id = registrant.area_id.id
+            if area_id not in registrants_by_area:
+                registrants_by_area[area_id] = []
+            registrants_by_area[area_id].append(registrant)
+
+        # Process each area
+        for area_id, area_registrants in registrants_by_area.items():
+            area = Area.browse(area_id)
+
+            # Skip if no polygon data
+            if not area.geo_polygon:
+                continue
+
+            try:
+                # Convert WKB to shapely polygon
+                polygon = wkbloads(bytes(area.geo_polygon.data))
+
+                # Generate random points for all registrants in this area
+                minx, miny, maxx, maxy = polygon.bounds
+
+                for registrant in area_registrants:
+                    # Generate random point within bounding box, retry if outside polygon
+                    max_attempts = 10
+                    for _attempt in range(max_attempts):
+                        point_x = random.uniform(minx, maxx)
+                        point_y = random.uniform(miny, maxy)
+                        point = shape({"type": "Point", "coordinates": [point_x, point_y]})
+
+                        if polygon.contains(point):
+                            # Set the coordinates field (GeoPointField expects WKB)
+                            registrant.write(
+                                {
+                                    "coordinates": f"POINT({point_x} {point_y})",
+                                }
+                            )
+                            coordinates_generated += 1
+                            break
+                    else:
+                        # If we couldn't find a point inside after max_attempts, use centroid
+                        centroid = polygon.centroid
+                        registrant.write(
+                            {
+                                "coordinates": f"POINT({centroid.x} {centroid.y})",
+                            }
+                        )
+                        coordinates_generated += 1
+
+            except Exception as e:
+                _logger.warning("[spp.mis.demo] Failed to generate coordinates for area %s: %s", area.name, e)
+                continue
+
+        stats["coordinates_generated"] = coordinates_generated
+        _logger.info("[spp.mis.demo] Generated coordinates for %d registrants", coordinates_generated)
+
+    def _refresh_gis_reports(self, stats):
+        """Refresh all active GIS reports so map data is available immediately."""
+        GISReport = self.env["spp.gis.report"]
+        reports = GISReport.search([("active", "=", True)])
+
+        if not reports:
+            _logger.info("[spp.mis.demo] No active GIS reports found to refresh")
+            stats["gis_reports_refreshed"] = 0
+            return
+
+        refreshed = 0
+        for report in reports:
+            try:
+                report._refresh_data()
+                refreshed += 1
+                _logger.info("[spp.mis.demo] Refreshed GIS report: %s", report.name)
+            except Exception:
+                _logger.exception("[spp.mis.demo] Failed to refresh GIS report: %s", report.name)
+
+        stats["gis_reports_refreshed"] = refreshed
+        _logger.info("[spp.mis.demo] Refreshed %d GIS reports", refreshed)
 
 
 class SPPMISDemoWizard(models.TransientModel):

--- a/spp_mis_demo_v2/models/mis_demo_generator.py
+++ b/spp_mis_demo_v2/models/mis_demo_generator.py
@@ -3908,9 +3908,9 @@ class SPPMISDemoGenerator(models.TransientModel):
             try:
                 report._refresh_data()
                 refreshed += 1
-                _logger.info("[spp.mis.demo] Refreshed GIS report: %s", report.name)
+                _logger.info("[spp.mis.demo] Refreshed GIS report: %s", report.id)
             except Exception:
-                _logger.exception("[spp.mis.demo] Failed to refresh GIS report: %s", report.name)
+                _logger.exception("[spp.mis.demo] Failed to refresh GIS report: %s", report.id)
 
         stats["gis_reports_refreshed"] = refreshed
         _logger.info("[spp.mis.demo] Refreshed %d GIS reports", refreshed)

--- a/spp_mis_demo_v2/models/mis_demo_generator.py
+++ b/spp_mis_demo_v2/models/mis_demo_generator.py
@@ -3887,7 +3887,7 @@ class SPPMISDemoGenerator(models.TransientModel):
                         coordinates_generated += 1
 
             except Exception as e:
-                _logger.warning("[spp.mis.demo] Failed to generate coordinates for area %s: %s", area.name, e)
+                _logger.warning("[spp.mis.demo] Failed to generate coordinates for area %s: %s", area.id, e)
                 continue
 
         stats["coordinates_generated"] = coordinates_generated

--- a/spp_mis_demo_v2/models/mis_demo_generator.py
+++ b/spp_mis_demo_v2/models/mis_demo_generator.py
@@ -3811,7 +3811,6 @@ class SPPMISDemoGenerator(models.TransientModel):
 
         try:
             from shapely.geometry import shape
-            from shapely.wkb import loads as wkbloads
         except ImportError:
             _logger.warning("[spp.mis.demo] shapely not available, skipping coordinate generation")
             stats["coordinates_generated"] = 0
@@ -3854,8 +3853,8 @@ class SPPMISDemoGenerator(models.TransientModel):
                 continue
 
             try:
-                # Convert WKB to shapely polygon
-                polygon = wkbloads(bytes(area.geo_polygon.data))
+                # The ORM returns geo_polygon as a Shapely geometry object
+                polygon = area.geo_polygon
 
                 # Generate random points for all registrants in this area
                 minx, miny, maxx, maxy = polygon.bounds

--- a/spp_mis_demo_v2/tests/__init__.py
+++ b/spp_mis_demo_v2/tests/__init__.py
@@ -8,3 +8,4 @@ from . import test_demo_programs
 from . import test_formula_configuration
 from . import test_mis_demo_generator
 from . import test_registry_variables
+from . import test_demo_statistics

--- a/spp_mis_demo_v2/tests/test_demo_programs.py
+++ b/spp_mis_demo_v2/tests/test_demo_programs.py
@@ -8,6 +8,7 @@ class TestDemoPrograms(TransactionCase):
 
     The demo programs use activated registry variables for CEL expressions:
     - Universal Child Grant: child_count variable
+    - Conditional Child Grant: members.exists() for first 1,000 days
     - Elderly Social Pension: age + retirement_age variables
     - Emergency Relief Fund: dependency_ratio, is_female_headed, elderly_count
     - Cash Transfer Program: hh_total_income, poverty_line, hh_size
@@ -16,16 +17,17 @@ class TestDemoPrograms(TransactionCase):
     """
 
     def test_get_all_demo_programs(self):
-        """Test that all 6 demo programs are returned."""
+        """Test that all 7 demo programs are returned."""
         from odoo.addons.spp_mis_demo_v2.models import demo_programs
 
         programs = demo_programs.get_all_demo_programs()
         self.assertIsInstance(programs, list)
-        self.assertEqual(len(programs), 6, "Expected exactly 6 demo programs")
+        self.assertEqual(len(programs), 7, "Expected exactly 7 demo programs")
 
         # Check expected programs exist (V3 names)
         program_names = [p["name"] for p in programs]
         self.assertIn("Universal Child Grant", program_names)
+        self.assertIn("Conditional Child Grant", program_names)
         self.assertIn("Elderly Social Pension", program_names)
         self.assertIn("Emergency Relief Fund", program_names)
         self.assertIn("Cash Transfer Program", program_names)
@@ -348,8 +350,10 @@ class TestDemoPrograms(TransactionCase):
         from odoo.addons.spp_mis_demo_v2.models import demo_programs
 
         programs = demo_programs.get_programs_by_pack("child_benefit")
-        self.assertEqual(len(programs), 1)
-        self.assertEqual(programs[0]["name"], "Universal Child Grant")
+        self.assertEqual(len(programs), 2)
+        program_names = [p["name"] for p in programs]
+        self.assertIn("Universal Child Grant", program_names)
+        self.assertIn("Conditional Child Grant", program_names)
 
         # Non-existent pack should return empty
         programs = demo_programs.get_programs_by_pack("nonexistent")
@@ -460,11 +464,20 @@ class TestDemoPrograms(TransactionCase):
                 )
 
     def test_all_programs_have_enrolled_stories(self):
-        """Test that every demo program has at least one enrolled story."""
+        """Test that demo programs have at least one enrolled story.
+
+        Conditional Child Grant is excluded: it demonstrates compliance
+        features and members.exists() CEL patterns without persona stories.
+        """
         from odoo.addons.spp_mis_demo_v2.models import demo_programs
+
+        # Programs that intentionally have no story personas
+        programs_without_stories = {"Conditional Child Grant"}
 
         for program in demo_programs.get_all_demo_programs():
             program_name = program["name"]
+            if program_name in programs_without_stories:
+                continue
             stories = program.get("stories", [])
             self.assertGreater(
                 len(stories),

--- a/spp_mis_demo_v2/tests/test_demo_statistics.py
+++ b/spp_mis_demo_v2/tests/test_demo_statistics.py
@@ -18,7 +18,6 @@ class TestDemoStatistics(TransactionCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.stat_model = cls.env["spp.statistic"]
-        cls.aggregation_service = cls.env["spp.aggregation.service"]
 
         # Required statistics that should be in the database
         cls.required_stats = [
@@ -70,39 +69,25 @@ class TestDemoStatistics(TransactionCase):
                         f"Statistic '{stat_name}' not published to GIS",
                     )
 
-    def test_statistics_accessible_via_aggregation_service(self):
-        """Verify statistics can be computed via aggregation service."""
-        # Get some test registrants (limit to 10 for performance)
-        registrants = self.env["res.partner"].search([("is_group", "=", True)], limit=10)
-
-        if not registrants:
-            self.skipTest("No registrants found in database for testing")
-
-        registrant_ids = registrants.ids
-
-        # Test a subset of statistics for performance
+    def test_statistics_have_valid_cel_accessors(self):
+        """Verify statistics have variables with valid CEL accessors for aggregation."""
+        # Test a subset of statistics
         test_stats = ["total_households", "total_members", "children_under_5"]
 
         for stat_name in test_stats:
             with self.subTest(statistic=stat_name):
-                # Verify statistic exists first
                 stat = self.stat_model.search([("name", "=", stat_name)], limit=1)
                 if not stat:
                     self.skipTest(f"Statistic '{stat_name}' not found in database")
 
-                # Compute via aggregation service
-                result = self.aggregation_service.compute_aggregation(
-                    registrant_ids=registrant_ids, statistics=[stat_name]
+                self.assertTrue(
+                    stat.variable_id,
+                    f"Statistic '{stat_name}' has no variable_id",
                 )
-
-                self.assertIn(
-                    stat_name,
-                    result,
-                    f"Statistic '{stat_name}' not in aggregation result",
-                )
-                self.assertIsNotNone(
-                    result[stat_name],
-                    f"Statistic '{stat_name}' returned None. Check variable configuration and CEL expression.",
+                self.assertTrue(
+                    stat.variable_id.cel_accessor,
+                    f"Variable for statistic '{stat_name}' has no cel_accessor. "
+                    "A cel_accessor is required for aggregation computation.",
                 )
 
     def test_statistics_categories_exist(self):

--- a/spp_mis_demo_v2/tests/test_demo_statistics.py
+++ b/spp_mis_demo_v2/tests/test_demo_statistics.py
@@ -1,0 +1,155 @@
+# Part of OpenSPP. See LICENSE file for full copyright and licensing details.
+"""Test demo statistics configuration and accessibility.
+
+These tests verify that:
+1. All demo statistics are properly loaded into the database
+2. Each statistic has a valid CEL variable reference
+3. Statistics are published to GIS context
+4. Statistics can be computed via the aggregation service
+"""
+
+from odoo.tests.common import TransactionCase
+
+
+class TestDemoStatistics(TransactionCase):
+    """Test that demo statistics are properly loaded and accessible."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.stat_model = cls.env["spp.statistic"]
+        cls.aggregation_service = cls.env["spp.aggregation.service"]
+
+        # Required statistics that should be in the database
+        cls.required_stats = [
+            "total_households",
+            "total_members",
+            "children_under_5",
+            "children_under_18",
+            "elderly_60_plus",
+            "female_members",
+            "male_members",
+            "disabled_members",
+            "enrolled_any_program",
+        ]
+
+    def test_all_demo_statistics_exist(self):
+        """Verify all 9 demo statistics are in the database."""
+        for stat_name in self.required_stats:
+            with self.subTest(statistic=stat_name):
+                stat = self.stat_model.search([("name", "=", stat_name)], limit=1)
+                self.assertTrue(
+                    stat,
+                    f"Statistic '{stat_name}' not found in database. Check that demo_statistics.xml was loaded.",
+                )
+
+    def test_statistics_have_variables(self):
+        """Verify each statistic has a valid CEL variable reference."""
+        for stat_name in self.required_stats:
+            with self.subTest(statistic=stat_name):
+                stat = self.stat_model.search([("name", "=", stat_name)], limit=1)
+                if stat:  # Only test if statistic exists
+                    self.assertTrue(
+                        stat.variable_id,
+                        f"Statistic '{stat_name}' has no variable_id",
+                    )
+                    self.assertEqual(
+                        stat.variable_id.state,
+                        "active",
+                        f"Variable for '{stat_name}' is not active",
+                    )
+
+    def test_statistics_published_to_gis(self):
+        """Verify statistics are published to GIS context."""
+        for stat_name in self.required_stats:
+            with self.subTest(statistic=stat_name):
+                stat = self.stat_model.search([("name", "=", stat_name)], limit=1)
+                if stat:  # Only test if statistic exists
+                    self.assertTrue(
+                        stat.is_published_gis,
+                        f"Statistic '{stat_name}' not published to GIS",
+                    )
+
+    def test_statistics_accessible_via_aggregation_service(self):
+        """Verify statistics can be computed via aggregation service."""
+        # Get some test registrants (limit to 10 for performance)
+        registrants = self.env["res.partner"].search([("is_group", "=", True)], limit=10)
+
+        if not registrants:
+            self.skipTest("No registrants found in database for testing")
+
+        registrant_ids = registrants.ids
+
+        # Test a subset of statistics for performance
+        test_stats = ["total_households", "total_members", "children_under_5"]
+
+        for stat_name in test_stats:
+            with self.subTest(statistic=stat_name):
+                # Verify statistic exists first
+                stat = self.stat_model.search([("name", "=", stat_name)], limit=1)
+                if not stat:
+                    self.skipTest(f"Statistic '{stat_name}' not found in database")
+
+                # Compute via aggregation service
+                result = self.aggregation_service.compute_aggregation(
+                    registrant_ids=registrant_ids, statistics=[stat_name]
+                )
+
+                self.assertIn(
+                    stat_name,
+                    result,
+                    f"Statistic '{stat_name}' not in aggregation result",
+                )
+                self.assertIsNotNone(
+                    result[stat_name],
+                    f"Statistic '{stat_name}' returned None. Check variable configuration and CEL expression.",
+                )
+
+    def test_statistics_categories_exist(self):
+        """Verify statistics are assigned to categories."""
+        category_mapping = {
+            "demographics": [
+                "total_households",
+                "total_members",
+                "children_under_5",
+                "children_under_18",
+                "elderly_60_plus",
+                "female_members",
+                "male_members",
+            ],
+            "vulnerability": ["disabled_members"],
+            "programs": ["enrolled_any_program"],
+        }
+
+        for category_code, stat_names in category_mapping.items():
+            for stat_name in stat_names:
+                with self.subTest(statistic=stat_name, category=category_code):
+                    stat = self.stat_model.search([("name", "=", stat_name)], limit=1)
+                    if stat:  # Only test if statistic exists
+                        self.assertTrue(
+                            stat.category_id,
+                            f"Statistic '{stat_name}' has no category",
+                        )
+                        self.assertEqual(
+                            stat.category_id.code,
+                            category_code,
+                            f"Statistic '{stat_name}' in wrong category. "
+                            f"Expected '{category_code}', got '{stat.category_id.code}'",
+                        )
+
+    def test_gis_discovery_endpoint_returns_statistics(self):
+        """Verify GIS statistics discovery returns our demo statistics."""
+        # Get all GIS-published statistics
+        gis_stats = self.stat_model.get_published_for_context("gis")
+
+        # Extract names
+        gis_stat_names = [stat.name for stat in gis_stats]
+
+        # Verify our required statistics are included
+        for stat_name in self.required_stats:
+            with self.subTest(statistic=stat_name):
+                self.assertIn(
+                    stat_name,
+                    gis_stat_names,
+                    f"Statistic '{stat_name}' not in GIS discovery endpoint. Check is_published_gis flag.",
+                )

--- a/spp_mis_demo_v2/views/mis_demo_wizard_view.xml
+++ b/spp_mis_demo_v2/views/mis_demo_wizard_view.xml
@@ -25,8 +25,11 @@
                         </ul>
                     </div>
                     <group string="Geographic Data">
-                        <field name="load_geographic_data"/>
-                        <field name="country_code" invisible="not load_geographic_data"/>
+                        <field name="load_geographic_data" />
+                        <field
+                            name="country_code"
+                            invisible="not load_geographic_data"
+                        />
                     </group>
                 </sheet>
                 <footer>

--- a/spp_mis_demo_v2/views/mis_demo_wizard_view.xml
+++ b/spp_mis_demo_v2/views/mis_demo_wizard_view.xml
@@ -24,6 +24,10 @@
                             <li>Fairness analysis data</li>
                         </ul>
                     </div>
+                    <group string="Geographic Data">
+                        <field name="load_geographic_data"/>
+                        <field name="country_code" invisible="not load_geographic_data"/>
+                    </group>
                 </sheet>
                 <footer>
                     <button


### PR DESCRIPTION
## Summary

- Add `demo_api_client.xml`: pre-configured QGIS API client with GIS read/all scopes
- Add `demo_statistics.xml`: 9 CEL variables + statistics for GIS/dashboard (total households, members, children, elderly, disabled, gender, enrollment)
- Add `test_demo_statistics.py`: tests for statistics loading, variable refs, GIS publishing, and aggregation
- Add `spp_statistic`, `spp_aggregation`, `spp_studio` as dependencies

## Test plan

- [ ] Run `./scripts/test_single_module.sh spp_mis_demo_v2`
- [ ] Verify demo statistics appear after module install
- [ ] Verify QGIS demo client is created with correct scopes