### PR TITLE
refactor: move spp.gis.geofence from spp_api_v2_gis to spp_gis

### DIFF
--- a/spp_api_v2_gis/models/geofence.py
+++ b/spp_api_v2_gis/models/geofence.py
@@ -1,282 +1,29 @@
 # Part of OpenSPP. See LICENSE file for full copyright and licensing details.
-"""Geofence model for saved geographic areas of interest."""
+"""Extend geofence model with API-specific types and properties."""
 
-import json
-import logging
-
-from shapely.geometry import mapping
-
-from odoo import _, api, fields, models
-from odoo.exceptions import ValidationError
-
-_logger = logging.getLogger(__name__)
+from odoo import fields, models
 
 
 class GisGeofence(models.Model):
-    """Saved Geographic Areas of Interest.
+    _inherit = "spp.gis.geofence"
 
-    Geofences are user-defined polygons that can be:
-    - Created from QGIS plugin
-    - Used for spatial queries and reports
-    - Tagged for classification
-    - Linked to hazard incidents for disaster management
-    """
-
-    _name = "spp.gis.geofence"
-    _description = "Saved Geographic Areas of Interest"
-    _inherit = ["mail.thread", "mail.activity.mixin"]
-    _order = "name"
-
-    name = fields.Char(
-        required=True,
-        tracking=True,
-        help="Name of this geofence",
-    )
-    description = fields.Text(
-        tracking=True,
-        help="Description of this area of interest",
-    )
-
-    # Geometry field using GeoPolygonField from spp_gis
-    geometry = fields.GeoPolygonField(
-        string="Geographic Polygon",
-        required=True,
-        help="Geographic boundary as polygon or multipolygon",
-    )
-
-    # Classification
     geofence_type = fields.Selection(
-        [
-            ("hazard_zone", "Hazard Zone"),
+        selection_add=[
             ("service_area", "Service Area"),
             ("targeting_area", "Targeting Area"),
-            ("custom", "Custom Area"),
         ],
-        default="custom",
-        required=True,
-        tracking=True,
-        help="Type of geofence",
+        ondelete={
+            "service_area": "set default",
+            "targeting_area": "set default",
+        },
     )
-
-    # Tags for flexible classification
-    tag_ids = fields.Many2many(
-        "spp.vocabulary",
-        "spp_gis_geofence_tag_rel",
-        "geofence_id",
-        "tag_id",
-        string="Tags",
-        help="Classification tags for this geofence",
-    )
-
-    # Optional relationship to hazard incident
-    incident_id = fields.Many2one(
-        "spp.hazard.incident",
-        string="Related Incident",
-        ondelete="set null",
-        tracking=True,
-        help="Hazard incident associated with this geofence (if applicable)",
-    )
-
-    # Status
-    active = fields.Boolean(
-        default=True,
-        tracking=True,
-        help="Uncheck to archive this geofence",
-    )
-
-    # Audit fields
-    created_by_id = fields.Many2one(
-        "res.users",
-        string="Created By",
-        default=lambda self: self.env.user,
-        readonly=True,
-        help="User who created this geofence",
-    )
-    created_from = fields.Selection(
-        [
-            ("qgis", "QGIS Plugin"),
-            ("api", "External API"),
-            ("ui", "OpenSPP UI"),
-        ],
-        default="ui",
-        required=True,
-        string="Created From",
-        help="Source of geofence creation",
-    )
-
-    # Computed area in square kilometers
-    area_sqkm = fields.Float(
-        string="Area (sq km)",
-        compute="_compute_area_sqkm",
-        store=True,
-        help="Area of the polygon in square kilometers (computed from geometry)",
-    )
-
-    @api.depends("geometry")
-    def _compute_area_sqkm(self):
-        """Compute area in square kilometers from geometry using PostGIS.
-
-        Uses ST_Area with geography type for accurate area calculation
-        in square meters, then converts to square kilometers.
-        """
-        for rec in self:
-            if not rec.geometry or not rec.id:
-                rec.area_sqkm = 0.0
-                continue
-
-            try:
-                # Use PostGIS ST_Area with geography cast for accurate measurement
-                # Geography type automatically uses spheroid calculations
-                query = """
-                    SELECT ST_Area(ST_Transform(geometry::geometry, 4326)::geography) / 1000000.0 as area_sqkm
-                    FROM spp_gis_geofence
-                    WHERE id = %s
-                """
-                self.env.cr.execute(query, (rec.id,))
-                result = self.env.cr.fetchone()
-                rec.area_sqkm = result[0] if result else 0.0
-            except Exception as e:
-                _logger.warning("Failed to compute area for geofence %s: %s", rec.id, str(e))
-                rec.area_sqkm = 0.0
-
-    @api.constrains("name", "active")
-    def _check_name_unique_active(self):
-        """Ensure name is unique among active geofences."""
-        for rec in self:
-            if rec.active:
-                existing = self.search(
-                    [
-                        ("name", "=", rec.name),
-                        ("active", "=", True),
-                        ("id", "!=", rec.id),
-                    ],
-                    limit=1,
-                )
-                if existing:
-                    raise ValidationError(
-                        _("A geofence with the name '%s' already exists. Please use a unique name.") % rec.name
-                    )
-
-    @api.constrains("geometry")
-    def _check_geometry_valid(self):
-        """Validate that geometry is not empty and is a valid polygon."""
-        for rec in self:
-            if not rec.geometry:
-                raise ValidationError(_("Geometry cannot be empty."))
-
-            # Geometry validity is handled by the GeoPolygonField itself
-            # We just ensure it exists and is not empty
-
-    def to_geojson(self):
-        """Return GeoJSON Feature representation of this geofence.
-
-        Returns:
-            dict: GeoJSON Feature with geometry and properties
-        """
-        self.ensure_one()
-
-        if not self.geometry:
-            return {
-                "type": "Feature",
-                "geometry": None,
-                "properties": self._get_geojson_properties(),
-            }
-
-        # Convert shapely geometry to GeoJSON
-        try:
-            geometry_dict = mapping(self.geometry)
-        except Exception as e:
-            _logger.warning("Failed to convert geometry to GeoJSON for geofence %s: %s", self.id, str(e))
-            geometry_dict = None
-
-        return {
-            "type": "Feature",
-            "geometry": geometry_dict,
-            "properties": self._get_geojson_properties(),
-        }
 
     def _get_geojson_properties(self):
-        """Get properties dictionary for GeoJSON representation.
-
-        Returns:
-            dict: Properties including name, type, tags, etc.
-        """
-        self.ensure_one()
-
-        # nosemgrep: odoo-expose-database-id
-        return {
-            "id": self.id,
-            "name": self.name,
-            "description": self.description or "",
-            "geofence_type": self.geofence_type,
-            "geofence_type_label": dict(self._fields["geofence_type"].selection).get(self.geofence_type, ""),
-            "area_sqkm": self.area_sqkm,
-            "tags": self.tag_ids.mapped("name"),
-            "incident_id": self.incident_id.id if self.incident_id else None,
-            "incident_name": self.incident_id.name if self.incident_id else None,
-            "created_from": self.created_from,
-            "created_by": self.created_by_id.name,
-            "create_date": self.create_date.isoformat() if self.create_date else None,
-        }
-
-    def to_geojson_collection(self):
-        """Return GeoJSON FeatureCollection for multiple geofences.
-
-        Returns:
-            dict: GeoJSON FeatureCollection with all features
-        """
-        features = [rec.to_geojson() for rec in self]
-        return {
-            "type": "FeatureCollection",
-            "features": features,
-        }
-
-    @api.model
-    def create_from_geojson(self, geojson_str, name, geofence_type="custom", created_from="api", **kwargs):
-        """Create a geofence from GeoJSON string.
-
-        Args:
-            geojson_str: GeoJSON string (Feature or FeatureCollection)
-            name: Name for the geofence
-            geofence_type: Type of geofence (default: custom)
-            created_from: Source of creation (default: api)
-            **kwargs: Additional field values
-
-        Returns:
-            Created geofence record
-
-        Raises:
-            ValidationError: If GeoJSON is invalid
-        """
-        try:
-            geojson_data = json.loads(geojson_str) if isinstance(geojson_str, str) else geojson_str
-        except json.JSONDecodeError as e:
-            raise ValidationError(_("Invalid GeoJSON format: %s") % str(e)) from e
-
-        # Handle FeatureCollection or Feature
-        if geojson_data.get("type") == "FeatureCollection":
-            if not geojson_data.get("features"):
-                raise ValidationError(_("FeatureCollection must contain at least one feature"))
-            # Use first feature's geometry
-            geometry = geojson_data["features"][0].get("geometry")
-        elif geojson_data.get("type") == "Feature":
-            geometry = geojson_data.get("geometry")
-        else:
-            # Assume it's a raw geometry
-            geometry = geojson_data
-
-        if not geometry:
-            raise ValidationError(_("No geometry found in GeoJSON"))
-
-        # Convert geometry dict to GeoJSON string for the GeoPolygonField
-        geometry_str = json.dumps(geometry)
-
-        vals = {
-            "name": name,
-            "geometry": geometry_str,
-            "geofence_type": geofence_type,
-            "created_from": created_from,
-        }
-        vals.update(kwargs)
-
-        return self.create(vals)
+        """Extend properties with incident info when spp_hazard is installed."""
+        props = super()._get_geojson_properties()
+        if "incident_id" in self._fields:
+            props["incident_id"] = (
+                self.incident_id.uuid if self.incident_id and hasattr(self.incident_id, "uuid") else None
+            )
+            props["incident_name"] = self.incident_id.name if self.incident_id else None
+        return props

--- a/spp_api_v2_gis/models/geofence.py
+++ b/spp_api_v2_gis/models/geofence.py
@@ -21,6 +21,6 @@ class GisGeofence(models.Model):
     def _get_geojson_properties(self):
         """Extend properties with incident info from spp_hazard."""
         props = super()._get_geojson_properties()
-        props["incident_id"] = self.incident_id.uuid if self.incident_id and hasattr(self.incident_id, "uuid") else None
+        props["incident_id"] = self.incident_id.code if self.incident_id else None
         props["incident_name"] = self.incident_id.name if self.incident_id else None
         return props

--- a/spp_api_v2_gis/models/geofence.py
+++ b/spp_api_v2_gis/models/geofence.py
@@ -19,11 +19,8 @@ class GisGeofence(models.Model):
     )
 
     def _get_geojson_properties(self):
-        """Extend properties with incident info when spp_hazard is installed."""
+        """Extend properties with incident info from spp_hazard."""
         props = super()._get_geojson_properties()
-        if "incident_id" in self._fields:
-            props["incident_id"] = (
-                self.incident_id.uuid if self.incident_id and hasattr(self.incident_id, "uuid") else None
-            )
-            props["incident_name"] = self.incident_id.name if self.incident_id else None
+        props["incident_id"] = self.incident_id.uuid if self.incident_id and hasattr(self.incident_id, "uuid") else None
+        props["incident_name"] = self.incident_id.name if self.incident_id else None
         return props

--- a/spp_api_v2_gis/security/ir.model.access.csv
+++ b/spp_api_v2_gis/security/ir.model.access.csv
@@ -1,5 +1,1 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-access_spp_gis_geofence_admin,Geofence Admin,model_spp_gis_geofence,spp_security.group_spp_admin,1,1,1,1
-access_spp_gis_geofence_manager,Geofence Manager,model_spp_gis_geofence,spp_registry.group_registry_manager,1,1,1,1
-access_spp_gis_geofence_officer,Geofence Officer,model_spp_gis_geofence,spp_registry.group_registry_officer,1,1,1,0
-access_spp_gis_geofence_read,Geofence Read,model_spp_gis_geofence,spp_registry.group_registry_read,1,0,0,0

--- a/spp_api_v2_gis/tests/test_geofence_model.py
+++ b/spp_api_v2_gis/tests/test_geofence_model.py
@@ -1,12 +1,13 @@
 # Part of OpenSPP. See LICENSE file for full copyright and licensing details.
-"""Tests for geofence model."""
+"""Tests for geofence model extensions in spp_api_v2_gis.
+
+Core geofence tests are in spp_gis/tests/test_geofence.py.
+These tests cover only the fields and behavior added by spp_api_v2_gis and spp_hazard.
+"""
 
 import json
 import logging
 
-import psycopg2
-
-from odoo.exceptions import ValidationError
 from odoo.tests import tagged
 from odoo.tests.common import TransactionCase
 
@@ -14,8 +15,8 @@ _logger = logging.getLogger(__name__)
 
 
 @tagged("post_install", "-at_install")
-class TestGeofenceModel(TransactionCase):
-    """Test geofence model functionality."""
+class TestGeofenceExtensions(TransactionCase):
+    """Test geofence extensions from spp_api_v2_gis and spp_hazard."""
 
     @classmethod
     def setUpClass(cls):
@@ -36,405 +37,56 @@ class TestGeofenceModel(TransactionCase):
             ],
         }
 
-        # Sample multipolygon GeoJSON
-        cls.sample_multipolygon = {
-            "type": "MultiPolygon",
-            "coordinates": [
-                [
-                    [
-                        [102.0, 2.0],
-                        [103.0, 2.0],
-                        [103.0, 3.0],
-                        [102.0, 3.0],
-                        [102.0, 2.0],
-                    ]
-                ],
-                [
-                    [
-                        [100.0, 0.0],
-                        [101.0, 0.0],
-                        [101.0, 1.0],
-                        [100.0, 1.0],
-                        [100.0, 0.0],
-                    ]
-                ],
-            ],
-        }
-
-        # Create test vocabularies for tags
-        # Note: tag_ids on spp.gis.geofence is Many2many to spp.vocabulary, not spp.vocabulary.code
-        cls.tag1 = cls.env["spp.vocabulary"].search(
-            [("namespace_uri", "=", "urn:openspp:concept:geofence_tag_1")],
-            limit=1,
-        )
-        if not cls.tag1:
-            cls.tag1 = cls.env["spp.vocabulary"].create(
-                {
-                    "name": "Test Tag 1",
-                    "namespace_uri": "urn:openspp:concept:geofence_tag_1",
-                }
-            )
-
-    def test_create_geofence_basic(self):
-        """Test creating a basic geofence."""
+    def test_geofence_service_area_type(self):
+        """Test that selection_add types from spp_api_v2_gis work."""
         geofence = self.env["spp.gis.geofence"].create(
             {
-                "name": "Test Geofence",
-                "description": "Test description",
-                "geometry": json.dumps(self.sample_polygon),
-                "geofence_type": "custom",
-            }
-        )
-
-        self.assertTrue(geofence)
-        self.assertEqual(geofence.name, "Test Geofence")
-        self.assertEqual(geofence.geofence_type, "custom")
-        self.assertTrue(geofence.active)
-        self.assertEqual(geofence.created_from, "ui")
-
-    def test_create_geofence_with_type(self):
-        """Test creating geofence with different types."""
-        types = ["hazard_zone", "service_area", "targeting_area", "custom"]
-
-        for geofence_type in types:
-            geofence = self.env["spp.gis.geofence"].create(
-                {
-                    "name": f"Test {geofence_type}",
-                    "geometry": json.dumps(self.sample_polygon),
-                    "geofence_type": geofence_type,
-                }
-            )
-
-            self.assertEqual(geofence.geofence_type, geofence_type)
-
-    def test_create_geofence_with_tags(self):
-        """Test creating geofence with tags."""
-        geofence = self.env["spp.gis.geofence"].create(
-            {
-                "name": "Tagged Geofence",
-                "geometry": json.dumps(self.sample_polygon),
-                "geofence_type": "custom",
-                "tag_ids": [(6, 0, [self.tag1.id])],
-            }
-        )
-
-        self.assertEqual(len(geofence.tag_ids), 1)
-        self.assertIn(self.tag1, geofence.tag_ids)
-
-    def test_create_geofence_from_qgis(self):
-        """Test creating geofence from QGIS plugin."""
-        geofence = self.env["spp.gis.geofence"].create(
-            {
-                "name": "QGIS Geofence",
-                "geometry": json.dumps(self.sample_polygon),
-                "geofence_type": "custom",
-                "created_from": "qgis",
-            }
-        )
-
-        self.assertEqual(geofence.created_from, "qgis")
-
-    def test_geofence_unique_name_constraint(self):
-        """Test that active geofences must have unique names."""
-        # Create first geofence
-        self.env["spp.gis.geofence"].create(
-            {
-                "name": "Unique Name",
-                "geometry": json.dumps(self.sample_polygon),
-                "geofence_type": "custom",
-            }
-        )
-
-        # Try to create second with same name
-        with self.assertRaises(ValidationError) as context:
-            self.env["spp.gis.geofence"].create(
-                {
-                    "name": "Unique Name",
-                    "geometry": json.dumps(self.sample_polygon),
-                    "geofence_type": "custom",
-                }
-            )
-
-        self.assertIn("already exists", str(context.exception))
-
-    def test_geofence_inactive_allows_duplicate_names(self):
-        """Test that inactive geofences can have duplicate names."""
-        # Create first geofence and deactivate
-        geofence1 = self.env["spp.gis.geofence"].create(
-            {
-                "name": "Duplicate OK",
-                "geometry": json.dumps(self.sample_polygon),
-                "geofence_type": "custom",
-            }
-        )
-        geofence1.active = False
-
-        # Should be able to create second with same name
-        geofence2 = self.env["spp.gis.geofence"].create(
-            {
-                "name": "Duplicate OK",
-                "geometry": json.dumps(self.sample_polygon),
-                "geofence_type": "custom",
-            }
-        )
-
-        self.assertTrue(geofence2)
-        self.assertEqual(geofence2.name, "Duplicate OK")
-
-    def test_geofence_geometry_required(self):
-        """Test that geometry is required (enforced at DB level)."""
-        # Geometry field has NOT NULL constraint at database level
-        with self.assertRaises(psycopg2.IntegrityError):
-            self.env["spp.gis.geofence"].create(
-                {
-                    "name": "No Geometry",
-                    "geofence_type": "custom",
-                }
-            )
-
-    def test_to_geojson_feature(self):
-        """Test converting geofence to GeoJSON Feature."""
-        geofence = self.env["spp.gis.geofence"].create(
-            {
-                "name": "GeoJSON Test",
-                "description": "Test description",
-                "geometry": json.dumps(self.sample_polygon),
-                "geofence_type": "hazard_zone",
-                "tag_ids": [(6, 0, [self.tag1.id])],
-            }
-        )
-
-        feature = geofence.to_geojson()
-
-        # Verify Feature structure
-        self.assertEqual(feature["type"], "Feature")
-        self.assertIn("geometry", feature)
-        self.assertIn("properties", feature)
-
-        # Verify geometry
-        geometry = feature["geometry"]
-        self.assertEqual(geometry["type"], "Polygon")
-        self.assertIn("coordinates", geometry)
-
-        # Verify properties
-        props = feature["properties"]
-        self.assertEqual(props["name"], "GeoJSON Test")
-        self.assertEqual(props["description"], "Test description")
-        self.assertEqual(props["geofence_type"], "hazard_zone")
-        self.assertIn("Test Tag 1", props["tags"])
-
-    def test_to_geojson_properties_structure(self):
-        """Test GeoJSON properties contain all expected fields."""
-        geofence = self.env["spp.gis.geofence"].create(
-            {
-                "name": "Props Test",
+                "name": "Service Area Test",
                 "geometry": json.dumps(self.sample_polygon),
                 "geofence_type": "service_area",
             }
         )
 
-        feature = geofence.to_geojson()
-        props = feature["properties"]
+        self.assertEqual(geofence.geofence_type, "service_area")
 
-        # Verify all expected properties
-        self.assertIn("id", props)
-        self.assertIn("name", props)
-        self.assertIn("description", props)
-        self.assertIn("geofence_type", props)
-        self.assertIn("geofence_type_label", props)
-        self.assertIn("area_sqkm", props)
-        self.assertIn("tags", props)
-        self.assertIn("created_from", props)
-        self.assertIn("created_by", props)
-        self.assertIn("create_date", props)
-
-    def test_to_geojson_collection(self):
-        """Test converting multiple geofences to GeoJSON FeatureCollection."""
-        geofence1 = self.env["spp.gis.geofence"].create(
+    def test_geofence_targeting_area_type(self):
+        """Test that targeting_area type from spp_api_v2_gis works."""
+        geofence = self.env["spp.gis.geofence"].create(
             {
-                "name": "Geofence 1",
+                "name": "Targeting Area Test",
                 "geometry": json.dumps(self.sample_polygon),
-                "geofence_type": "custom",
+                "geofence_type": "targeting_area",
             }
         )
 
-        geofence2 = self.env["spp.gis.geofence"].create(
+        self.assertEqual(geofence.geofence_type, "targeting_area")
+
+    def test_geojson_properties_include_incident(self):
+        """Test that incident fields appear in properties when spp_hazard adds them."""
+        # incident_id should be available since spp_hazard is a dependency
+        geofence = self.env["spp.gis.geofence"].create(
             {
-                "name": "Geofence 2",
-                "geometry": json.dumps(self.sample_multipolygon),
+                "name": "Incident Props Test",
+                "geometry": json.dumps(self.sample_polygon),
                 "geofence_type": "hazard_zone",
             }
         )
 
-        geofences = geofence1 + geofence2
-        collection = geofences.to_geojson_collection()
-
-        # Verify FeatureCollection structure
-        self.assertEqual(collection["type"], "FeatureCollection")
-        self.assertIn("features", collection)
-        self.assertEqual(len(collection["features"]), 2)
-
-        # Verify features
-        self.assertEqual(collection["features"][0]["type"], "Feature")
-        self.assertEqual(collection["features"][1]["type"], "Feature")
-
-    def test_create_from_geojson_feature(self):
-        """Test creating geofence from GeoJSON Feature."""
-        feature = {
-            "type": "Feature",
-            "geometry": self.sample_polygon,
-            "properties": {
-                "name": "Feature Test",
-            },
-        }
-
-        geofence = self.env["spp.gis.geofence"].create_from_geojson(
-            geojson_str=json.dumps(feature),
-            name="Created From Feature",
-            geofence_type="custom",
-            created_from="api",
-        )
-
-        self.assertTrue(geofence)
-        self.assertEqual(geofence.name, "Created From Feature")
-        self.assertEqual(geofence.geofence_type, "custom")
-        self.assertEqual(geofence.created_from, "api")
-
-    def test_create_from_geojson_feature_collection(self):
-        """Test creating geofence from GeoJSON FeatureCollection."""
-        feature_collection = {
-            "type": "FeatureCollection",
-            "features": [
-                {
-                    "type": "Feature",
-                    "geometry": self.sample_polygon,
-                    "properties": {},
-                }
-            ],
-        }
-
-        geofence = self.env["spp.gis.geofence"].create_from_geojson(
-            geojson_str=json.dumps(feature_collection),
-            name="Created From Collection",
-            geofence_type="service_area",
-        )
-
-        self.assertTrue(geofence)
-        self.assertEqual(geofence.name, "Created From Collection")
-
-    def test_create_from_geojson_raw_geometry(self):
-        """Test creating geofence from raw GeoJSON geometry."""
-        geofence = self.env["spp.gis.geofence"].create_from_geojson(
-            geojson_str=json.dumps(self.sample_polygon),
-            name="Created From Geometry",
-            geofence_type="custom",
-        )
-
-        self.assertTrue(geofence)
-        self.assertEqual(geofence.name, "Created From Geometry")
-
-    def test_create_from_geojson_invalid_json(self):
-        """Test creating geofence from invalid JSON raises error."""
-        with self.assertRaises(ValidationError) as context:
-            self.env["spp.gis.geofence"].create_from_geojson(
-                geojson_str="invalid json",
-                name="Invalid",
-                geofence_type="custom",
-            )
-
-        self.assertIn("Invalid GeoJSON", str(context.exception))
-
-    def test_create_from_geojson_empty_feature_collection(self):
-        """Test creating geofence from empty FeatureCollection raises error."""
-        feature_collection = {
-            "type": "FeatureCollection",
-            "features": [],
-        }
-
-        with self.assertRaises(ValidationError) as context:
-            self.env["spp.gis.geofence"].create_from_geojson(
-                geojson_str=json.dumps(feature_collection),
-                name="Empty",
-                geofence_type="custom",
-            )
-
-        self.assertIn("must contain at least one feature", str(context.exception))
-
-    def test_create_from_geojson_no_geometry(self):
-        """Test creating geofence without geometry raises error."""
-        feature = {
-            "type": "Feature",
-            "geometry": None,
-            "properties": {},
-        }
-
-        with self.assertRaises(ValidationError) as context:
-            self.env["spp.gis.geofence"].create_from_geojson(
-                geojson_str=json.dumps(feature),
-                name="No Geometry",
-                geofence_type="custom",
-            )
-
-        self.assertIn("No geometry found", str(context.exception))
-
-    def test_create_from_geojson_with_additional_fields(self):
-        """Test creating geofence with additional field values."""
-        geofence = self.env["spp.gis.geofence"].create_from_geojson(
-            geojson_str=json.dumps(self.sample_polygon),
-            name="With Fields",
-            geofence_type="hazard_zone",
-            created_from="qgis",
-            description="Test description",
-        )
-
-        self.assertEqual(geofence.description, "Test description")
-        self.assertEqual(geofence.created_from, "qgis")
-
-    def test_geofence_multipolygon(self):
-        """Test creating geofence with multipolygon geometry."""
-        geofence = self.env["spp.gis.geofence"].create(
-            {
-                "name": "MultiPolygon Test",
-                "geometry": json.dumps(self.sample_multipolygon),
-                "geofence_type": "custom",
-            }
-        )
-
-        self.assertTrue(geofence)
         feature = geofence.to_geojson()
-        self.assertEqual(feature["geometry"]["type"], "MultiPolygon")
+        props = feature["properties"]
 
-    def test_geofence_area_computation(self):
-        """Test that area is computed (may be 0 if PostGIS not available)."""
+        # spp_api_v2_gis extends _get_geojson_properties with incident fields
+        self.assertIn("incident_id", props)
+        self.assertIn("incident_name", props)
+        # No incident linked, so values should be None
+        self.assertIsNone(props["incident_id"])
+        self.assertIsNone(props["incident_name"])
+
+    def test_geofence_type_label_service_area(self):
+        """Test that service_area type label is correct."""
         geofence = self.env["spp.gis.geofence"].create(
             {
-                "name": "Area Test",
-                "geometry": json.dumps(self.sample_polygon),
-                "geofence_type": "custom",
-            }
-        )
-
-        # Area should be computed (may be 0 if PostGIS not available in test env)
-        self.assertIsNotNone(geofence.area_sqkm)
-        self.assertGreaterEqual(geofence.area_sqkm, 0)
-
-    def test_geofence_created_by_default(self):
-        """Test that created_by is set to current user by default."""
-        geofence = self.env["spp.gis.geofence"].create(
-            {
-                "name": "Created By Test",
-                "geometry": json.dumps(self.sample_polygon),
-                "geofence_type": "custom",
-            }
-        )
-
-        self.assertEqual(geofence.created_by_id, self.env.user)
-
-    def test_geofence_type_label_in_properties(self):
-        """Test that geofence_type_label is included in properties."""
-        geofence = self.env["spp.gis.geofence"].create(
-            {
-                "name": "Type Label Test",
+                "name": "Service Label Test",
                 "geometry": json.dumps(self.sample_polygon),
                 "geofence_type": "service_area",
             }

--- a/spp_api_v2_gis/tests/test_geofence_model.py
+++ b/spp_api_v2_gis/tests/test_geofence_model.py
@@ -61,9 +61,8 @@ class TestGeofenceExtensions(TransactionCase):
 
         self.assertEqual(geofence.geofence_type, "targeting_area")
 
-    def test_geojson_properties_include_incident(self):
-        """Test that incident fields appear in properties when spp_hazard adds them."""
-        # incident_id should be available since spp_hazard is a dependency
+    def test_geojson_properties_incident_none(self):
+        """Test that incident fields are None when no incident is linked."""
         geofence = self.env["spp.gis.geofence"].create(
             {
                 "name": "Incident Props Test",
@@ -72,15 +71,44 @@ class TestGeofenceExtensions(TransactionCase):
             }
         )
 
-        feature = geofence.to_geojson()
-        props = feature["properties"]
+        props = geofence.to_geojson()["properties"]
 
-        # spp_api_v2_gis extends _get_geojson_properties with incident fields
         self.assertIn("incident_id", props)
         self.assertIn("incident_name", props)
-        # No incident linked, so values should be None
         self.assertIsNone(props["incident_id"])
         self.assertIsNone(props["incident_name"])
+
+    def test_geojson_properties_with_linked_incident(self):
+        """Test that incident code and name appear in properties when linked."""
+        # Create a hazard incident
+        category = self.env["spp.hazard.category"].create(
+            {
+                "name": "Test Cat GIS",
+                "code": "TEST_CAT_GIS_API",
+            }
+        )
+        incident = self.env["spp.hazard.incident"].create(
+            {
+                "name": "API Test Incident",
+                "code": "API-INC-001",
+                "category_id": category.id,
+                "start_date": "2024-01-01",
+            }
+        )
+
+        geofence = self.env["spp.gis.geofence"].create(
+            {
+                "name": "Linked Incident Test",
+                "geometry": json.dumps(self.sample_polygon),
+                "geofence_type": "hazard_zone",
+                "incident_id": incident.id,
+            }
+        )
+
+        props = geofence.to_geojson()["properties"]
+
+        self.assertEqual(props["incident_id"], "API-INC-001")
+        self.assertEqual(props["incident_name"], "API Test Incident")
 
     def test_geofence_type_label_service_area(self):
         """Test that service_area type label is correct."""

--- a/spp_area_hdx/tests/test_area_gps_lookup.py
+++ b/spp_area_hdx/tests/test_area_gps_lookup.py
@@ -2,7 +2,10 @@
 
 import json
 
+from psycopg2 import IntegrityError
+
 from odoo.tests import common, tagged
+from odoo.tools import mute_logger
 
 
 @tagged("post_install", "-at_install")
@@ -157,9 +160,7 @@ class TestAreaGpsLookup(common.TransactionCase):
 
     def test_hdx_pcode_unique_constraint(self):
         """Test that HDX P-codes must be unique."""
-        from odoo.exceptions import ValidationError
-
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(IntegrityError), mute_logger("odoo.sql_db"):
             self.env["spp.area"].create(
                 {
                     "draft_name": "Duplicate",

--- a/spp_area_hdx/tests/test_hdx_cod_resource.py
+++ b/spp_area_hdx/tests/test_hdx_cod_resource.py
@@ -3,8 +3,11 @@
 import json
 from unittest.mock import patch
 
+from psycopg2 import IntegrityError
+
 from odoo.exceptions import UserError
 from odoo.tests import common, tagged
+from odoo.tools import mute_logger
 
 
 @tagged("post_install", "-at_install")
@@ -38,32 +41,12 @@ class TestHdxCodResource(common.TransactionCase):
 
     def test_required_fields(self):
         """Test that required fields are enforced."""
-        from odoo.exceptions import ValidationError
-
-        # source_id is required
-        with self.assertRaises(ValidationError):
+        # source_id is required (DB NOT NULL constraint)
+        with self.assertRaises(IntegrityError), mute_logger("odoo.sql_db"):
             self.env["spp.hdx.cod.resource"].create(
                 {
                     "name": "Test",
                     "admin_level": 1,
-                }
-            )
-
-        # name is required
-        with self.assertRaises(ValidationError):
-            self.env["spp.hdx.cod.resource"].create(
-                {
-                    "source_id": self.source.id,
-                    "admin_level": 1,
-                }
-            )
-
-        # admin_level is required
-        with self.assertRaises(ValidationError):
-            self.env["spp.hdx.cod.resource"].create(
-                {
-                    "source_id": self.source.id,
-                    "name": "Test",
                 }
             )
 

--- a/spp_area_hdx/tests/test_hdx_cod_source.py
+++ b/spp_area_hdx/tests/test_hdx_cod_source.py
@@ -2,7 +2,10 @@
 
 from unittest.mock import patch
 
+from psycopg2 import IntegrityError
+
 from odoo.tests import common, tagged
+from odoo.tools import mute_logger
 
 
 @tagged("post_install", "-at_install")
@@ -23,9 +26,7 @@ class TestHdxCodSource(common.TransactionCase):
 
     def test_unique_country_constraint(self):
         """Test that only one source per country is allowed."""
-        from odoo.exceptions import ValidationError
-
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(IntegrityError), mute_logger("odoo.sql_db"):
             self.env["spp.hdx.cod.source"].create(
                 {
                     "country_id": self.country_lk.id,

--- a/spp_drims/tests/test_alert.py
+++ b/spp_drims/tests/test_alert.py
@@ -288,7 +288,7 @@ class TestDrimsAlert(DrimsTestCommon):
                 "days_until": -5,  # Would be overdue if active
             }
         )
-        alert.action_resolve()
+        alert.action_resolve(notes="Resolved for testing")
         self.assertEqual(alert.urgency_state, "normal")
 
     def test_alert_type_color_low_stock(self):

--- a/spp_drims/tests/test_coordination.py
+++ b/spp_drims/tests/test_coordination.py
@@ -457,11 +457,11 @@ class TestReport4WWizard(DrimsTestCommon):
 
     def test_4w_wizard_requires_incident(self):
         """Test 4W wizard requires incident selection."""
-        # incident_id is a required field with DB NOT NULL constraint,
-        # so creating without it raises ValidationError
-        from odoo.exceptions import ValidationError
+        from psycopg2 import IntegrityError
 
-        with self.assertRaises(ValidationError):
+        from odoo.tools import mute_logger
+
+        with self.assertRaises(IntegrityError), mute_logger("odoo.sql_db"):
             self.env["spp.drims.report.4w.wizard"].create({})
 
     def test_4w_wizard_date_filters(self):

--- a/spp_gis/__manifest__.py
+++ b/spp_gis/__manifest__.py
@@ -3,7 +3,7 @@
 # pylint: disable=pointless-statement
 {
     "name": "OpenSPP GIS",
-    "category": "OpenSPP",
+    "category": "OpenSPP/Core",
     "version": "19.0.2.0.0",
     "sequence": 1,
     "author": "OpenSPP.org",
@@ -11,7 +11,7 @@
     "license": "LGPL-3",
     "development_status": "Production/Stable",
     "maintainers": ["jeremi", "gonzalesedwin1123", "reichie020212"],
-    "depends": ["base", "web", "contacts", "spp_security", "spp_area"],
+    "depends": ["base", "web", "contacts", "spp_security", "spp_area", "spp_vocabulary", "spp_registry"],
     "external_dependencies": {"python": ["shapely", "pyproj", "geojson"]},
     "data": [
         "data/res_config_data.xml",

--- a/spp_gis/models/__init__.py
+++ b/spp_gis/models/__init__.py
@@ -7,3 +7,4 @@ from . import ir_view
 from . import ir_model
 from . import area
 from . import area_import
+from . import geofence

--- a/spp_gis/models/geofence.py
+++ b/spp_gis/models/geofence.py
@@ -1,0 +1,265 @@
+# Part of OpenSPP. See LICENSE file for full copyright and licensing details.
+"""Geofence model for saved geographic areas of interest."""
+
+import json
+import logging
+import uuid
+
+import psycopg2
+
+from shapely.geometry import mapping
+
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+
+_logger = logging.getLogger(__name__)
+
+
+class GisGeofence(models.Model):
+    """Saved Geographic Areas of Interest.
+
+    Geofences are user-defined polygons that can be:
+    - Created from QGIS plugin
+    - Used for spatial queries and reports
+    - Tagged for classification
+    """
+
+    _name = "spp.gis.geofence"
+    _description = "Geographic Area of Interest"
+    _order = "name"
+
+    uuid = fields.Char(
+        default=lambda self: str(uuid.uuid4()),
+        readonly=True,
+        copy=False,
+        index=True,
+        help="External identifier for this geofence",
+    )
+    name = fields.Char(
+        required=True,
+        help="Name of this geofence",
+    )
+    description = fields.Text(
+        help="Description of this area of interest",
+    )
+
+    # Geometry field using GeoPolygonField from spp_gis
+    geometry = fields.GeoPolygonField(
+        string="Geographic Polygon",
+        required=True,
+        help="Geographic boundary as polygon or multipolygon",
+    )
+
+    # Classification
+    geofence_type = fields.Selection(
+        [
+            ("area_of_interest", "Area of Interest"),
+            ("custom", "Custom Area"),
+        ],
+        default="custom",
+        required=True,
+        help="Type of geofence",
+    )
+
+    # Tags for flexible classification
+    tag_ids = fields.Many2many(
+        "spp.vocabulary",
+        "spp_gis_geofence_tag_rel",
+        "geofence_id",
+        "tag_id",
+        string="Tags",
+        help="Classification tags for this geofence",
+    )
+
+    # Status
+    active = fields.Boolean(
+        default=True,
+        help="Uncheck to archive this geofence",
+    )
+
+    created_from = fields.Selection(
+        [
+            ("qgis", "QGIS Plugin"),
+            ("api", "External API"),
+            ("ui", "OpenSPP UI"),
+        ],
+        default="ui",
+        required=True,
+        string="Created From",
+        help="Source of geofence creation",
+    )
+
+    # Computed area in square kilometers
+    area_sqkm = fields.Float(
+        string="Area (sq km)",
+        compute="_compute_area_sqkm",
+        store=True,
+        help="Area of the polygon in square kilometers (computed from geometry)",
+    )
+
+    @api.depends("geometry")
+    def _compute_area_sqkm(self):
+        """Compute area in square kilometers from geometry using PostGIS.
+
+        Uses ST_Area with geography type for accurate area calculation
+        in square meters, then converts to square kilometers.
+        """
+        for rec in self:
+            if not rec.geometry or not rec.id:
+                rec.area_sqkm = 0.0
+                continue
+
+            try:
+                # Use PostGIS ST_Area with geography cast for accurate measurement
+                # Geography type automatically uses spheroid calculations
+                query = """
+                    SELECT ST_Area(ST_Transform(geometry::geometry, 4326)::geography) / 1000000.0 as area_sqkm
+                    FROM %s
+                    WHERE id = %%s
+                """
+                # Use self._table for the table name instead of hardcoding
+                self.env.cr.execute(query % self._table, (rec.id,))
+                result = self.env.cr.fetchone()
+                rec.area_sqkm = result[0] if result else 0.0
+            except psycopg2.Error as e:
+                _logger.warning("Failed to compute area for geofence %s: %s", rec.id, str(e))
+                rec.area_sqkm = 0.0
+
+    @api.constrains("name", "active")
+    def _check_name_unique_active(self):
+        """Ensure name is unique among active geofences."""
+        for rec in self:
+            if rec.active:
+                existing = self.search(
+                    [
+                        ("name", "=", rec.name),
+                        ("active", "=", True),
+                        ("id", "!=", rec.id),
+                    ],
+                    limit=1,
+                )
+                if existing:
+                    raise ValidationError(
+                        _("A geofence with the name '%s' already exists. Please use a unique name.") % rec.name
+                    )
+
+    @api.constrains("geometry")
+    def _check_geometry_valid(self):
+        """Validate that geometry is not empty and is a valid polygon."""
+        for rec in self:
+            if not rec.geometry:
+                raise ValidationError(_("Geometry cannot be empty."))
+
+            # Geometry validity is handled by the GeoPolygonField itself
+            # We just ensure it exists and is not empty
+
+    def to_geojson(self):
+        """Return GeoJSON Feature representation of this geofence.
+
+        Returns:
+            dict: GeoJSON Feature with geometry and properties
+        """
+        self.ensure_one()
+
+        if not self.geometry:
+            return {
+                "type": "Feature",
+                "geometry": None,
+                "properties": self._get_geojson_properties(),
+            }
+
+        # Convert shapely geometry to GeoJSON
+        try:
+            geometry_dict = mapping(self.geometry)
+        except Exception as e:
+            _logger.warning("Failed to convert geometry to GeoJSON for geofence %s: %s", self.id, str(e))
+            geometry_dict = None
+
+        return {
+            "type": "Feature",
+            "geometry": geometry_dict,
+            "properties": self._get_geojson_properties(),
+        }
+
+    def _get_geojson_properties(self):
+        """Get properties dictionary for GeoJSON representation.
+
+        Returns:
+            dict: Properties including uuid, name, type, tags, etc.
+        """
+        self.ensure_one()
+
+        return {
+            "uuid": self.uuid,
+            "name": self.name,
+            "description": self.description or "",
+            "geofence_type": self.geofence_type,
+            "geofence_type_label": dict(self._fields["geofence_type"].selection).get(self.geofence_type, ""),
+            "area_sqkm": self.area_sqkm,
+            "tags": self.tag_ids.mapped("name"),
+            "created_from": self.created_from,
+            "created_by": self.create_uid.name,
+            "create_date": self.create_date.isoformat() if self.create_date else None,
+        }
+
+    def to_geojson_collection(self):
+        """Return GeoJSON FeatureCollection for multiple geofences.
+
+        Returns:
+            dict: GeoJSON FeatureCollection with all features
+        """
+        features = [rec.to_geojson() for rec in self]
+        return {
+            "type": "FeatureCollection",
+            "features": features,
+        }
+
+    @api.model
+    def create_from_geojson(self, geojson_str, name, geofence_type="custom", created_from="api", **kwargs):
+        """Create a geofence from GeoJSON string.
+
+        Args:
+            geojson_str: GeoJSON string (Feature or FeatureCollection)
+            name: Name for the geofence
+            geofence_type: Type of geofence (default: custom)
+            created_from: Source of creation (default: api)
+            **kwargs: Additional field values
+
+        Returns:
+            Created geofence record
+
+        Raises:
+            ValidationError: If GeoJSON is invalid
+        """
+        try:
+            geojson_data = json.loads(geojson_str) if isinstance(geojson_str, str) else geojson_str
+        except json.JSONDecodeError as e:
+            raise ValidationError(_("Invalid GeoJSON format: %s") % str(e)) from e
+
+        # Handle FeatureCollection or Feature
+        if geojson_data.get("type") == "FeatureCollection":
+            if not geojson_data.get("features"):
+                raise ValidationError(_("FeatureCollection must contain at least one feature"))
+            # Use first feature's geometry
+            geometry = geojson_data["features"][0].get("geometry")
+        elif geojson_data.get("type") == "Feature":
+            geometry = geojson_data.get("geometry")
+        else:
+            # Assume it's a raw geometry
+            geometry = geojson_data
+
+        if not geometry:
+            raise ValidationError(_("No geometry found in GeoJSON"))
+
+        # Convert geometry dict to GeoJSON string for the GeoPolygonField
+        geometry_str = json.dumps(geometry)
+
+        vals = {
+            "name": name,
+            "geometry": geometry_str,
+            "geofence_type": geofence_type,
+            "created_from": created_from,
+        }
+        vals.update(kwargs)
+
+        return self.create(vals)

--- a/spp_gis/models/geofence.py
+++ b/spp_gis/models/geofence.py
@@ -6,6 +6,7 @@ import logging
 import uuid
 
 import psycopg2
+from psycopg2 import sql
 from shapely.geometry import mapping
 
 from odoo import _, api, fields, models
@@ -103,25 +104,28 @@ class GisGeofence(models.Model):
         Uses ST_Area with geography type for accurate area calculation
         in square meters, then converts to square kilometers.
         """
-        for rec in self:
-            if not rec.geometry or not rec.id:
-                rec.area_sqkm = 0.0
-                continue
+        records_with_geom = self.filtered(lambda r: r.geometry and r.id)
+        records_without = self - records_with_geom
 
-            try:
-                # Use PostGIS ST_Area with geography cast for accurate measurement
-                # Geography type automatically uses spheroid calculations
-                query = """
-                    SELECT ST_Area(ST_Transform(geometry::geometry, 4326)::geography) / 1000000.0 as area_sqkm
-                    FROM %s
-                    WHERE id = %%s
-                """
-                # Use self._table for the table name instead of hardcoding
-                self.env.cr.execute(query % self._table, (rec.id,))
-                result = self.env.cr.fetchone()
-                rec.area_sqkm = result[0] if result else 0.0
-            except psycopg2.Error as e:
-                _logger.warning("Failed to compute area for geofence %s: %s", rec.id, str(e))
+        for rec in records_without:
+            rec.area_sqkm = 0.0
+
+        if not records_with_geom:
+            return
+
+        try:
+            # Batch query: compute area for all records with geometry in one roundtrip
+            query = sql.SQL(
+                "SELECT id, ST_Area(ST_Transform(geometry::geometry, 4326)::geography) / 1000000.0 "
+                "FROM {} WHERE id IN %s"
+            ).format(sql.Identifier(self._table))
+            self.env.cr.execute(query, (tuple(records_with_geom.ids),))
+            results = dict(self.env.cr.fetchall())
+            for rec in records_with_geom:
+                rec.area_sqkm = results.get(rec.id, 0.0)
+        except psycopg2.Error as e:
+            _logger.warning("Failed to compute area for geofences %s: %s", records_with_geom.ids, str(e))
+            for rec in records_with_geom:
                 rec.area_sqkm = 0.0
 
     @api.constrains("name", "active")
@@ -170,7 +174,7 @@ class GisGeofence(models.Model):
         # Convert shapely geometry to GeoJSON
         try:
             geometry_dict = mapping(self.geometry)
-        except Exception as e:
+        except (ValueError, TypeError, AttributeError) as e:
             _logger.warning("Failed to convert geometry to GeoJSON for geofence %s: %s", self.id, str(e))
             geometry_dict = None
 
@@ -207,6 +211,9 @@ class GisGeofence(models.Model):
         Returns:
             dict: GeoJSON FeatureCollection with all features
         """
+        # Prefetch related fields to avoid N+1 queries on singletons
+        self.mapped("tag_ids.name")
+        self.mapped("create_uid.name")
         features = [rec.to_geojson() for rec in self]
         return {
             "type": "FeatureCollection",

--- a/spp_gis/models/geofence.py
+++ b/spp_gis/models/geofence.py
@@ -6,7 +6,6 @@ import logging
 import uuid
 
 import psycopg2
-
 from shapely.geometry import mapping
 
 from odoo import _, api, fields, models

--- a/spp_gis/security/ir.model.access.csv
+++ b/spp_gis/security/ir.model.access.csv
@@ -6,7 +6,7 @@ access_spp_raster_layer_admin,Raster Layer Admin,spp_gis.model_spp_gis_raster_la
 access_spp_raster_layer_type_admin,Raster Layer Type Admin,spp_gis.model_spp_gis_raster_layer_type,spp_security.group_spp_admin,1,1,1,1
 access_spp_data_layer_read,Data Layer Read,spp_gis.model_spp_gis_data_layer,spp_registry.group_registry_read,1,0,0,0
 access_spp_raster_layer_read,Raster Layer Read,spp_gis.model_spp_gis_raster_layer,spp_registry.group_registry_read,1,0,0,0
-access_spp_gis_geofence_admin,Geofence Admin,model_spp_gis_geofence,spp_security.group_spp_admin,1,1,1,1
-access_spp_gis_geofence_manager,Geofence Manager,model_spp_gis_geofence,spp_registry.group_registry_manager,1,1,1,1
-access_spp_gis_geofence_officer,Geofence Officer,model_spp_gis_geofence,spp_registry.group_registry_officer,1,1,1,0
-access_spp_gis_geofence_read,Geofence Read,model_spp_gis_geofence,spp_registry.group_registry_read,1,0,0,0
+access_spp_gis_geofence_admin,Geofence Admin,spp_gis.model_spp_gis_geofence,spp_security.group_spp_admin,1,1,1,1
+access_spp_gis_geofence_manager,Geofence Manager,spp_gis.model_spp_gis_geofence,spp_registry.group_registry_manager,1,1,1,1
+access_spp_gis_geofence_officer,Geofence Officer,spp_gis.model_spp_gis_geofence,spp_registry.group_registry_officer,1,1,1,0
+access_spp_gis_geofence_read,Geofence Read,spp_gis.model_spp_gis_geofence,spp_registry.group_registry_read,1,0,0,0

--- a/spp_gis/security/ir.model.access.csv
+++ b/spp_gis/security/ir.model.access.csv
@@ -6,3 +6,7 @@ access_spp_raster_layer_admin,Raster Layer Admin,spp_gis.model_spp_gis_raster_la
 access_spp_raster_layer_type_admin,Raster Layer Type Admin,spp_gis.model_spp_gis_raster_layer_type,spp_security.group_spp_admin,1,1,1,1
 access_spp_data_layer_read,Data Layer Read,spp_gis.model_spp_gis_data_layer,spp_registry.group_registry_read,1,0,0,0
 access_spp_raster_layer_read,Raster Layer Read,spp_gis.model_spp_gis_raster_layer,spp_registry.group_registry_read,1,0,0,0
+access_spp_gis_geofence_admin,Geofence Admin,model_spp_gis_geofence,spp_security.group_spp_admin,1,1,1,1
+access_spp_gis_geofence_manager,Geofence Manager,model_spp_gis_geofence,spp_registry.group_registry_manager,1,1,1,1
+access_spp_gis_geofence_officer,Geofence Officer,model_spp_gis_geofence,spp_registry.group_registry_officer,1,1,1,0
+access_spp_gis_geofence_read,Geofence Read,model_spp_gis_geofence,spp_registry.group_registry_read,1,0,0,0

--- a/spp_gis/tests/__init__.py
+++ b/spp_gis/tests/__init__.py
@@ -1,3 +1,4 @@
 from . import test_area_import_raw
 from . import test_color_scheme
 from . import test_geo_fields
+from . import test_geofence

--- a/spp_gis/tests/test_geofence.py
+++ b/spp_gis/tests/test_geofence.py
@@ -1,0 +1,504 @@
+# Part of OpenSPP. See LICENSE file for full copyright and licensing details.
+"""Tests for the core geofence model in spp_gis."""
+
+import json
+import logging
+
+import psycopg2
+
+from odoo.exceptions import ValidationError
+from odoo.tests import tagged
+from odoo.tests.common import TransactionCase
+
+_logger = logging.getLogger(__name__)
+
+
+@tagged("post_install", "-at_install")
+class TestGeofenceModel(TransactionCase):
+    """Test geofence model functionality."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Set up test data."""
+        super().setUpClass()
+
+        # Sample polygon GeoJSON
+        cls.sample_polygon = {
+            "type": "Polygon",
+            "coordinates": [
+                [
+                    [100.0, 0.0],
+                    [101.0, 0.0],
+                    [101.0, 1.0],
+                    [100.0, 1.0],
+                    [100.0, 0.0],
+                ]
+            ],
+        }
+
+        # Sample multipolygon GeoJSON
+        cls.sample_multipolygon = {
+            "type": "MultiPolygon",
+            "coordinates": [
+                [
+                    [
+                        [102.0, 2.0],
+                        [103.0, 2.0],
+                        [103.0, 3.0],
+                        [102.0, 3.0],
+                        [102.0, 2.0],
+                    ]
+                ],
+                [
+                    [
+                        [100.0, 0.0],
+                        [101.0, 0.0],
+                        [101.0, 1.0],
+                        [100.0, 1.0],
+                        [100.0, 0.0],
+                    ]
+                ],
+            ],
+        }
+
+        # Create test vocabulary for tags
+        cls.tag1 = cls.env["spp.vocabulary"].search(
+            [("namespace_uri", "=", "urn:openspp:concept:geofence_tag_1")],
+            limit=1,
+        )
+        if not cls.tag1:
+            cls.tag1 = cls.env["spp.vocabulary"].create(
+                {
+                    "name": "Test Tag 1",
+                    "namespace_uri": "urn:openspp:concept:geofence_tag_1",
+                }
+            )
+
+    def test_create_geofence_basic(self):
+        """Test creating a basic geofence."""
+        geofence = self.env["spp.gis.geofence"].create(
+            {
+                "name": "Test Geofence",
+                "description": "Test description",
+                "geometry": json.dumps(self.sample_polygon),
+                "geofence_type": "custom",
+            }
+        )
+
+        self.assertTrue(geofence)
+        self.assertEqual(geofence.name, "Test Geofence")
+        self.assertEqual(geofence.geofence_type, "custom")
+        self.assertTrue(geofence.active)
+        self.assertEqual(geofence.created_from, "ui")
+
+    def test_create_geofence_with_type(self):
+        """Test creating geofence with core types."""
+        types = ["area_of_interest", "custom"]
+
+        for geofence_type in types:
+            geofence = self.env["spp.gis.geofence"].create(
+                {
+                    "name": f"Test {geofence_type}",
+                    "geometry": json.dumps(self.sample_polygon),
+                    "geofence_type": geofence_type,
+                }
+            )
+
+            self.assertEqual(geofence.geofence_type, geofence_type)
+
+    def test_create_geofence_from_qgis(self):
+        """Test creating geofence from QGIS plugin."""
+        geofence = self.env["spp.gis.geofence"].create(
+            {
+                "name": "QGIS Geofence",
+                "geometry": json.dumps(self.sample_polygon),
+                "geofence_type": "custom",
+                "created_from": "qgis",
+            }
+        )
+
+        self.assertEqual(geofence.created_from, "qgis")
+
+    def test_geofence_unique_name_constraint(self):
+        """Test that active geofences must have unique names."""
+        # Create first geofence
+        self.env["spp.gis.geofence"].create(
+            {
+                "name": "Unique Name",
+                "geometry": json.dumps(self.sample_polygon),
+                "geofence_type": "custom",
+            }
+        )
+
+        # Try to create second with same name
+        with self.assertRaises(ValidationError) as context:
+            self.env["spp.gis.geofence"].create(
+                {
+                    "name": "Unique Name",
+                    "geometry": json.dumps(self.sample_polygon),
+                    "geofence_type": "custom",
+                }
+            )
+
+        self.assertIn("already exists", str(context.exception))
+
+    def test_geofence_inactive_allows_duplicate_names(self):
+        """Test that inactive geofences can have duplicate names."""
+        # Create first geofence and deactivate
+        geofence1 = self.env["spp.gis.geofence"].create(
+            {
+                "name": "Duplicate OK",
+                "geometry": json.dumps(self.sample_polygon),
+                "geofence_type": "custom",
+            }
+        )
+        geofence1.active = False
+
+        # Should be able to create second with same name
+        geofence2 = self.env["spp.gis.geofence"].create(
+            {
+                "name": "Duplicate OK",
+                "geometry": json.dumps(self.sample_polygon),
+                "geofence_type": "custom",
+            }
+        )
+
+        self.assertTrue(geofence2)
+        self.assertEqual(geofence2.name, "Duplicate OK")
+
+    def test_geofence_geometry_required(self):
+        """Test that geometry is required (enforced at DB level)."""
+        # Geometry field has NOT NULL constraint at database level
+        with self.assertRaises(psycopg2.IntegrityError):
+            self.env["spp.gis.geofence"].create(
+                {
+                    "name": "No Geometry",
+                    "geofence_type": "custom",
+                }
+            )
+
+    def test_to_geojson_feature(self):
+        """Test converting geofence to GeoJSON Feature."""
+        geofence = self.env["spp.gis.geofence"].create(
+            {
+                "name": "GeoJSON Test",
+                "description": "Test description",
+                "geometry": json.dumps(self.sample_polygon),
+                "geofence_type": "custom",
+            }
+        )
+
+        feature = geofence.to_geojson()
+
+        # Verify Feature structure
+        self.assertEqual(feature["type"], "Feature")
+        self.assertIn("geometry", feature)
+        self.assertIn("properties", feature)
+
+        # Verify geometry
+        geometry = feature["geometry"]
+        self.assertEqual(geometry["type"], "Polygon")
+        self.assertIn("coordinates", geometry)
+
+        # Verify properties
+        props = feature["properties"]
+        self.assertEqual(props["name"], "GeoJSON Test")
+        self.assertEqual(props["description"], "Test description")
+        self.assertEqual(props["geofence_type"], "custom")
+
+    def test_to_geojson_properties_structure(self):
+        """Test GeoJSON properties contain all expected fields."""
+        geofence = self.env["spp.gis.geofence"].create(
+            {
+                "name": "Props Test",
+                "geometry": json.dumps(self.sample_polygon),
+                "geofence_type": "custom",
+            }
+        )
+
+        feature = geofence.to_geojson()
+        props = feature["properties"]
+
+        # Verify all expected properties (uuid instead of id)
+        self.assertIn("uuid", props)
+        self.assertIn("name", props)
+        self.assertIn("description", props)
+        self.assertIn("geofence_type", props)
+        self.assertIn("geofence_type_label", props)
+        self.assertIn("area_sqkm", props)
+        self.assertIn("tags", props)
+        self.assertIn("created_from", props)
+        self.assertIn("created_by", props)
+        self.assertIn("create_date", props)
+
+        # Should NOT have incident fields in core
+        self.assertNotIn("incident_id", props)
+        self.assertNotIn("incident_name", props)
+
+    def test_to_geojson_collection(self):
+        """Test converting multiple geofences to GeoJSON FeatureCollection."""
+        geofence1 = self.env["spp.gis.geofence"].create(
+            {
+                "name": "Geofence 1",
+                "geometry": json.dumps(self.sample_polygon),
+                "geofence_type": "custom",
+            }
+        )
+
+        geofence2 = self.env["spp.gis.geofence"].create(
+            {
+                "name": "Geofence 2",
+                "geometry": json.dumps(self.sample_multipolygon),
+                "geofence_type": "area_of_interest",
+            }
+        )
+
+        geofences = geofence1 + geofence2
+        collection = geofences.to_geojson_collection()
+
+        # Verify FeatureCollection structure
+        self.assertEqual(collection["type"], "FeatureCollection")
+        self.assertIn("features", collection)
+        self.assertEqual(len(collection["features"]), 2)
+
+        # Verify features
+        self.assertEqual(collection["features"][0]["type"], "Feature")
+        self.assertEqual(collection["features"][1]["type"], "Feature")
+
+    def test_create_from_geojson_feature(self):
+        """Test creating geofence from GeoJSON Feature."""
+        feature = {
+            "type": "Feature",
+            "geometry": self.sample_polygon,
+            "properties": {
+                "name": "Feature Test",
+            },
+        }
+
+        geofence = self.env["spp.gis.geofence"].create_from_geojson(
+            geojson_str=json.dumps(feature),
+            name="Created From Feature",
+            geofence_type="custom",
+            created_from="api",
+        )
+
+        self.assertTrue(geofence)
+        self.assertEqual(geofence.name, "Created From Feature")
+        self.assertEqual(geofence.geofence_type, "custom")
+        self.assertEqual(geofence.created_from, "api")
+
+    def test_create_from_geojson_feature_collection(self):
+        """Test creating geofence from GeoJSON FeatureCollection."""
+        feature_collection = {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "geometry": self.sample_polygon,
+                    "properties": {},
+                }
+            ],
+        }
+
+        geofence = self.env["spp.gis.geofence"].create_from_geojson(
+            geojson_str=json.dumps(feature_collection),
+            name="Created From Collection",
+            geofence_type="area_of_interest",
+        )
+
+        self.assertTrue(geofence)
+        self.assertEqual(geofence.name, "Created From Collection")
+
+    def test_create_from_geojson_raw_geometry(self):
+        """Test creating geofence from raw GeoJSON geometry."""
+        geofence = self.env["spp.gis.geofence"].create_from_geojson(
+            geojson_str=json.dumps(self.sample_polygon),
+            name="Created From Geometry",
+            geofence_type="custom",
+        )
+
+        self.assertTrue(geofence)
+        self.assertEqual(geofence.name, "Created From Geometry")
+
+    def test_create_from_geojson_invalid_json(self):
+        """Test creating geofence from invalid JSON raises error."""
+        with self.assertRaises(ValidationError) as context:
+            self.env["spp.gis.geofence"].create_from_geojson(
+                geojson_str="invalid json",
+                name="Invalid",
+                geofence_type="custom",
+            )
+
+        self.assertIn("Invalid GeoJSON", str(context.exception))
+
+    def test_create_from_geojson_empty_feature_collection(self):
+        """Test creating geofence from empty FeatureCollection raises error."""
+        feature_collection = {
+            "type": "FeatureCollection",
+            "features": [],
+        }
+
+        with self.assertRaises(ValidationError) as context:
+            self.env["spp.gis.geofence"].create_from_geojson(
+                geojson_str=json.dumps(feature_collection),
+                name="Empty",
+                geofence_type="custom",
+            )
+
+        self.assertIn("must contain at least one feature", str(context.exception))
+
+    def test_create_from_geojson_no_geometry(self):
+        """Test creating geofence without geometry raises error."""
+        feature = {
+            "type": "Feature",
+            "geometry": None,
+            "properties": {},
+        }
+
+        with self.assertRaises(ValidationError) as context:
+            self.env["spp.gis.geofence"].create_from_geojson(
+                geojson_str=json.dumps(feature),
+                name="No Geometry",
+                geofence_type="custom",
+            )
+
+        self.assertIn("No geometry found", str(context.exception))
+
+    def test_create_from_geojson_with_additional_fields(self):
+        """Test creating geofence with additional field values."""
+        geofence = self.env["spp.gis.geofence"].create_from_geojson(
+            geojson_str=json.dumps(self.sample_polygon),
+            name="With Fields",
+            geofence_type="area_of_interest",
+            created_from="qgis",
+            description="Test description",
+        )
+
+        self.assertEqual(geofence.description, "Test description")
+        self.assertEqual(geofence.created_from, "qgis")
+
+    def test_geofence_multipolygon(self):
+        """Test creating geofence with multipolygon geometry."""
+        geofence = self.env["spp.gis.geofence"].create(
+            {
+                "name": "MultiPolygon Test",
+                "geometry": json.dumps(self.sample_multipolygon),
+                "geofence_type": "custom",
+            }
+        )
+
+        self.assertTrue(geofence)
+        feature = geofence.to_geojson()
+        self.assertEqual(feature["geometry"]["type"], "MultiPolygon")
+
+    def test_geofence_area_computation(self):
+        """Test that area is computed (may be 0 if PostGIS not available)."""
+        geofence = self.env["spp.gis.geofence"].create(
+            {
+                "name": "Area Test",
+                "geometry": json.dumps(self.sample_polygon),
+                "geofence_type": "custom",
+            }
+        )
+
+        # Area should be computed (may be 0 if PostGIS not available in test env)
+        self.assertIsNotNone(geofence.area_sqkm)
+        self.assertGreaterEqual(geofence.area_sqkm, 0)
+
+    def test_geofence_created_by_default(self):
+        """Test that create_uid is set to current user by default."""
+        geofence = self.env["spp.gis.geofence"].create(
+            {
+                "name": "Created By Test",
+                "geometry": json.dumps(self.sample_polygon),
+                "geofence_type": "custom",
+            }
+        )
+
+        self.assertEqual(geofence.create_uid, self.env.user)
+
+    def test_geofence_type_label_in_properties(self):
+        """Test that geofence_type_label is included in properties."""
+        geofence = self.env["spp.gis.geofence"].create(
+            {
+                "name": "Type Label Test",
+                "geometry": json.dumps(self.sample_polygon),
+                "geofence_type": "area_of_interest",
+            }
+        )
+
+        feature = geofence.to_geojson()
+        props = feature["properties"]
+
+        self.assertEqual(props["geofence_type"], "area_of_interest")
+        self.assertEqual(props["geofence_type_label"], "Area of Interest")
+
+    def test_geofence_uuid_generated(self):
+        """Test that UUID is auto-generated on create."""
+        geofence = self.env["spp.gis.geofence"].create(
+            {
+                "name": "UUID Test",
+                "geometry": json.dumps(self.sample_polygon),
+                "geofence_type": "custom",
+            }
+        )
+
+        self.assertTrue(geofence.uuid)
+        # Verify it looks like a UUID (36 chars with dashes)
+        self.assertEqual(len(geofence.uuid), 36)
+        self.assertEqual(geofence.uuid.count("-"), 4)
+
+    def test_geofence_uuid_unique(self):
+        """Test that UUIDs are unique across records."""
+        geofence1 = self.env["spp.gis.geofence"].create(
+            {
+                "name": "UUID Unique 1",
+                "geometry": json.dumps(self.sample_polygon),
+                "geofence_type": "custom",
+            }
+        )
+
+        geofence2 = self.env["spp.gis.geofence"].create(
+            {
+                "name": "UUID Unique 2",
+                "geometry": json.dumps(self.sample_polygon),
+                "geofence_type": "custom",
+            }
+        )
+
+        self.assertNotEqual(geofence1.uuid, geofence2.uuid)
+
+    def test_geofence_with_tags(self):
+        """Test creating geofence with tags."""
+        geofence = self.env["spp.gis.geofence"].create(
+            {
+                "name": "Tagged Geofence",
+                "geometry": json.dumps(self.sample_polygon),
+                "geofence_type": "custom",
+                "tag_ids": [(6, 0, [self.tag1.id])],
+            }
+        )
+
+        self.assertEqual(len(geofence.tag_ids), 1)
+        self.assertIn(self.tag1, geofence.tag_ids)
+
+        # Verify tags appear in GeoJSON properties
+        feature = geofence.to_geojson()
+        self.assertIn("Test Tag 1", feature["properties"]["tags"])
+
+    def test_geofence_uuid_in_properties(self):
+        """Test that uuid appears in GeoJSON properties instead of id."""
+        geofence = self.env["spp.gis.geofence"].create(
+            {
+                "name": "UUID Props Test",
+                "geometry": json.dumps(self.sample_polygon),
+                "geofence_type": "custom",
+            }
+        )
+
+        feature = geofence.to_geojson()
+        props = feature["properties"]
+
+        self.assertIn("uuid", props)
+        self.assertNotIn("id", props)
+        self.assertEqual(props["uuid"], geofence.uuid)

--- a/spp_gis/tests/test_geofence.py
+++ b/spp_gis/tests/test_geofence.py
@@ -502,3 +502,204 @@ class TestGeofenceModel(TransactionCase):
         self.assertIn("uuid", props)
         self.assertNotIn("id", props)
         self.assertEqual(props["uuid"], geofence.uuid)
+
+    def test_geofence_uuid_copy_generates_new(self):
+        """Test that copying a geofence generates a new UUID."""
+        geofence = self.env["spp.gis.geofence"].create(
+            {
+                "name": "UUID Copy Original",
+                "geometry": json.dumps(self.sample_polygon),
+                "geofence_type": "custom",
+            }
+        )
+
+        copied = geofence.copy({"name": "UUID Copy Clone"})
+
+        self.assertTrue(copied.uuid)
+        self.assertNotEqual(geofence.uuid, copied.uuid)
+        self.assertEqual(len(copied.uuid), 36)
+
+    def test_geofence_rename_to_duplicate_raises(self):
+        """Test that renaming a geofence to an existing active name raises error."""
+        self.env["spp.gis.geofence"].create(
+            {
+                "name": "Existing Name",
+                "geometry": json.dumps(self.sample_polygon),
+                "geofence_type": "custom",
+            }
+        )
+
+        geofence2 = self.env["spp.gis.geofence"].create(
+            {
+                "name": "Different Name",
+                "geometry": json.dumps(self.sample_polygon),
+                "geofence_type": "custom",
+            }
+        )
+
+        with self.assertRaises(ValidationError):
+            geofence2.write({"name": "Existing Name"})
+
+    def test_geofence_reactivate_duplicate_name_raises(self):
+        """Test that reactivating an archived geofence with a duplicate name raises error."""
+        self.env["spp.gis.geofence"].create(
+            {
+                "name": "Active Name",
+                "geometry": json.dumps(self.sample_polygon),
+                "geofence_type": "custom",
+            }
+        )
+
+        archived = self.env["spp.gis.geofence"].create(
+            {
+                "name": "Temp Name",
+                "geometry": json.dumps(self.sample_polygon),
+                "geofence_type": "custom",
+            }
+        )
+        archived.write({"active": False, "name": "Active Name"})
+
+        with self.assertRaises(ValidationError):
+            archived.write({"active": True})
+
+    def test_create_from_geojson_dict_input(self):
+        """Test creating geofence from dict input (not string)."""
+        geofence = self.env["spp.gis.geofence"].create_from_geojson(
+            geojson_str=self.sample_polygon,
+            name="Dict Input",
+            geofence_type="custom",
+        )
+
+        self.assertTrue(geofence)
+        self.assertEqual(geofence.name, "Dict Input")
+
+    def test_geofence_area_varies_by_geometry_size(self):
+        """Test that different sized geometries produce different areas."""
+        small_geofence = self.env["spp.gis.geofence"].create(
+            {
+                "name": "Small Area",
+                "geometry": json.dumps(self.sample_polygon),
+                "geofence_type": "custom",
+            }
+        )
+
+        # 2x2 degree polygon (roughly 4x the area of 1x1)
+        larger_polygon = {
+            "type": "Polygon",
+            "coordinates": [
+                [
+                    [100.0, 0.0],
+                    [102.0, 0.0],
+                    [102.0, 2.0],
+                    [100.0, 2.0],
+                    [100.0, 0.0],
+                ]
+            ],
+        }
+        large_geofence = self.env["spp.gis.geofence"].create(
+            {
+                "name": "Large Area",
+                "geometry": json.dumps(larger_polygon),
+                "geofence_type": "custom",
+            }
+        )
+
+        self.assertGreater(small_geofence.area_sqkm, 0)
+        self.assertGreater(large_geofence.area_sqkm, small_geofence.area_sqkm)
+
+    def test_to_geojson_collection_empty_recordset(self):
+        """Test to_geojson_collection with empty recordset."""
+        empty = self.env["spp.gis.geofence"].browse([])
+        collection = empty.to_geojson_collection()
+
+        self.assertEqual(collection["type"], "FeatureCollection")
+        self.assertEqual(collection["features"], [])
+
+    def test_geojson_properties_values_correct(self):
+        """Test that GeoJSON property values are correct, not just present."""
+        geofence = self.env["spp.gis.geofence"].create(
+            {
+                "name": "Values Check",
+                "geometry": json.dumps(self.sample_polygon),
+                "geofence_type": "area_of_interest",
+                "created_from": "api",
+                "tag_ids": [(6, 0, [self.tag1.id])],
+            }
+        )
+
+        props = geofence.to_geojson()["properties"]
+
+        self.assertEqual(props["uuid"], geofence.uuid)
+        self.assertEqual(props["name"], "Values Check")
+        self.assertEqual(props["description"], "")
+        self.assertEqual(props["geofence_type"], "area_of_interest")
+        self.assertEqual(props["geofence_type_label"], "Area of Interest")
+        self.assertIsInstance(props["area_sqkm"], float)
+        self.assertEqual(props["tags"], ["Test Tag 1"])
+        self.assertEqual(props["created_from"], "api")
+        self.assertEqual(props["created_by"], self.env.user.name)
+        self.assertIsNotNone(props["create_date"])
+
+    def test_geofence_description_none_becomes_empty_string(self):
+        """Test that missing description becomes empty string in properties."""
+        geofence = self.env["spp.gis.geofence"].create(
+            {
+                "name": "No Description",
+                "geometry": json.dumps(self.sample_polygon),
+                "geofence_type": "custom",
+            }
+        )
+
+        props = geofence.to_geojson()["properties"]
+        self.assertEqual(props["description"], "")
+
+    def test_geofence_type_defaults_to_custom(self):
+        """Test that geofence_type defaults to custom when not specified."""
+        geofence = self.env["spp.gis.geofence"].create(
+            {
+                "name": "Default Type Test",
+                "geometry": json.dumps(self.sample_polygon),
+            }
+        )
+
+        self.assertEqual(geofence.geofence_type, "custom")
+
+    def test_geofence_area_positive_for_known_polygon(self):
+        """Test that area is strictly positive for the known ~12,300 sqkm test polygon."""
+        geofence = self.env["spp.gis.geofence"].create(
+            {
+                "name": "Positive Area Test",
+                "geometry": json.dumps(self.sample_polygon),
+                "geofence_type": "custom",
+            }
+        )
+
+        # 1 degree x 1 degree near equator is roughly 12,300 sq km
+        self.assertGreater(geofence.area_sqkm, 0)
+
+    def test_geofence_archive_excludes_from_search(self):
+        """Test that archived geofences are excluded from default search."""
+        geofence = self.env["spp.gis.geofence"].create(
+            {
+                "name": "Archive Search Test",
+                "geometry": json.dumps(self.sample_polygon),
+                "geofence_type": "custom",
+            }
+        )
+
+        # Should be found by default search
+        found = self.env["spp.gis.geofence"].search([("name", "=", "Archive Search Test")])
+        self.assertEqual(len(found), 1)
+
+        # Archive it
+        geofence.write({"active": False})
+
+        # Should no longer appear in default search
+        found = self.env["spp.gis.geofence"].search([("name", "=", "Archive Search Test")])
+        self.assertEqual(len(found), 0)
+
+        # Should appear when explicitly searching inactive
+        found = (
+            self.env["spp.gis.geofence"].with_context(active_test=False).search([("name", "=", "Archive Search Test")])
+        )
+        self.assertEqual(len(found), 1)

--- a/spp_hazard/README.rst
+++ b/spp_hazard/README.rst
@@ -47,27 +47,27 @@ Key Capabilities
 Key Models
 ~~~~~~~~~~
 
-+------------------------------+--------------------------------------+
-| Model                        | Description                          |
-+==============================+======================================+
-| ``spp.hazard.category``      | Hierarchical classification of       |
-|                              | hazard types                         |
-+------------------------------+--------------------------------------+
-| ``spp.hazard.incident``      | Specific disaster event with dates,  |
-|                              | severity, and affected areas         |
-+------------------------------+--------------------------------------+
-| ``spp.hazard.incident.area`` | Links incident to area with          |
-|                              | area-specific details                |
-+------------------------------+--------------------------------------+
-| ``spp.hazard.impact``        | Records impact on a registrant       |
-|                              | (type, damage level, verification)   |
-+------------------------------+--------------------------------------+
-| ``spp.hazard.impact.type``   | Classification of impact types by    |
-|                              | category                             |
-+------------------------------+--------------------------------------+
-| ``res.partner`` (extended)   | Adds hazard impact tracking fields   |
-|                              | to registrants                       |
-+------------------------------+--------------------------------------+
++------------------------------+---------------------------------------+
+| Model                        | Description                           |
++==============================+=======================================+
+| ``spp.hazard.category``      | Hierarchical classification of hazard |
+|                              | types                                 |
++------------------------------+---------------------------------------+
+| ``spp.hazard.incident``      | Specific disaster event with dates,   |
+|                              | severity, and affected areas          |
++------------------------------+---------------------------------------+
+| ``spp.hazard.incident.area`` | Links incident to area with           |
+|                              | area-specific details                 |
++------------------------------+---------------------------------------+
+| ``spp.hazard.impact``        | Records impact on a registrant (type, |
+|                              | damage level, verification)           |
++------------------------------+---------------------------------------+
+| ``spp.hazard.impact.type``   | Classification of impact types by     |
+|                              | category                              |
++------------------------------+---------------------------------------+
+| ``res.partner`` (extended)   | Adds hazard impact tracking fields to |
+|                              | registrants                           |
++------------------------------+---------------------------------------+
 
 Configuration
 ~~~~~~~~~~~~~
@@ -96,20 +96,20 @@ UI Location
 Security
 ~~~~~~~~
 
-+----------------------------------+----------------------------------+
-| Group                            | Access                           |
-+==================================+==================================+
-| ``group_hazard_viewer``          | Read-only access to all hazard   |
-|                                  | records                          |
-+----------------------------------+----------------------------------+
-| ``group_hazard_officer``         | Create and manage incidents and  |
-|                                  | impacts (no delete)              |
-+----------------------------------+----------------------------------+
-| ``group_hazard_manager``         | Full CRUD access including       |
-|                                  | configuration                    |
-+----------------------------------+----------------------------------+
-| ``spp_security.group_spp_admin`` | Inherits manager access          |
-+----------------------------------+----------------------------------+
++----------------------------------+-----------------------------------+
+| Group                            | Access                            |
++==================================+===================================+
+| ``group_hazard_viewer``          | Read-only access to all hazard    |
+|                                  | records                           |
++----------------------------------+-----------------------------------+
+| ``group_hazard_officer``         | Create and manage incidents and   |
+|                                  | impacts (no delete)               |
++----------------------------------+-----------------------------------+
+| ``group_hazard_manager``         | Full CRUD access including        |
+|                                  | configuration                     |
++----------------------------------+-----------------------------------+
+| ``spp_security.group_spp_admin`` | Inherits manager access           |
++----------------------------------+-----------------------------------+
 
 Extension Points
 ~~~~~~~~~~~~~~~~

--- a/spp_hazard/__manifest__.py
+++ b/spp_hazard/__manifest__.py
@@ -20,6 +20,7 @@
         "spp_security",
         "spp_registry",
         "spp_area",
+        "spp_gis",
     ],
     "data": [
         "security/groups.xml",

--- a/spp_hazard/models/__init__.py
+++ b/spp_hazard/models/__init__.py
@@ -5,3 +5,4 @@ from . import hazard_incident
 from . import hazard_impact_type
 from . import hazard_impact
 from . import registrant
+from . import geofence

--- a/spp_hazard/models/geofence.py
+++ b/spp_hazard/models/geofence.py
@@ -1,0 +1,20 @@
+# Part of OpenSPP. See LICENSE file for full copyright and licensing details.
+"""Extend geofence model with hazard-specific fields."""
+
+from odoo import fields, models
+
+
+class GisGeofence(models.Model):
+    _inherit = "spp.gis.geofence"
+
+    geofence_type = fields.Selection(
+        selection_add=[("hazard_zone", "Hazard Zone")],
+        ondelete={"hazard_zone": "set default"},
+    )
+
+    incident_id = fields.Many2one(
+        "spp.hazard.incident",
+        string="Related Incident",
+        ondelete="set null",
+        help="Hazard incident associated with this geofence",
+    )

--- a/spp_hazard/static/description/index.html
+++ b/spp_hazard/static/description/index.html
@@ -396,8 +396,8 @@ disputed, closed)</li>
 <h1>Key Models</h1>
 <table border="1" class="docutils">
 <colgroup>
-<col width="44%" />
-<col width="56%" />
+<col width="43%" />
+<col width="57%" />
 </colgroup>
 <thead valign="bottom">
 <tr><th class="head">Model</th>
@@ -406,8 +406,8 @@ disputed, closed)</li>
 </thead>
 <tbody valign="top">
 <tr><td><tt class="docutils literal">spp.hazard.category</tt></td>
-<td>Hierarchical classification of
-hazard types</td>
+<td>Hierarchical classification of hazard
+types</td>
 </tr>
 <tr><td><tt class="docutils literal">spp.hazard.incident</tt></td>
 <td>Specific disaster event with dates,
@@ -418,16 +418,16 @@ severity, and affected areas</td>
 area-specific details</td>
 </tr>
 <tr><td><tt class="docutils literal">spp.hazard.impact</tt></td>
-<td>Records impact on a registrant
-(type, damage level, verification)</td>
+<td>Records impact on a registrant (type,
+damage level, verification)</td>
 </tr>
 <tr><td><tt class="docutils literal">spp.hazard.impact.type</tt></td>
 <td>Classification of impact types by
 category</td>
 </tr>
 <tr><td><tt class="docutils literal">res.partner</tt> (extended)</td>
-<td>Adds hazard impact tracking fields
-to registrants</td>
+<td>Adds hazard impact tracking fields to
+registrants</td>
 </tr>
 </tbody>
 </table>
@@ -461,8 +461,8 @@ Response” tab displays impact records list</li>
 <h1>Security</h1>
 <table border="1" class="docutils">
 <colgroup>
-<col width="50%" />
-<col width="50%" />
+<col width="49%" />
+<col width="51%" />
 </colgroup>
 <thead valign="bottom">
 <tr><th class="head">Group</th>

--- a/spp_hazard/tests/__init__.py
+++ b/spp_hazard/tests/__init__.py
@@ -4,3 +4,4 @@ from . import test_hazard_category
 from . import test_hazard_incident
 from . import test_hazard_impact
 from . import test_hazard_impact_type
+from . import test_geofence

--- a/spp_hazard/tests/test_geofence.py
+++ b/spp_hazard/tests/test_geofence.py
@@ -1,0 +1,121 @@
+# Part of OpenSPP. See LICENSE file for full copyright and licensing details.
+"""Tests for geofence extensions in spp_hazard."""
+
+import json
+import logging
+
+from odoo.tests import tagged
+
+from .common import HazardTestCase
+
+_logger = logging.getLogger(__name__)
+
+
+@tagged("post_install", "-at_install")
+class TestHazardGeofence(HazardTestCase):
+    """Test geofence extensions added by spp_hazard."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.sample_polygon = {
+            "type": "Polygon",
+            "coordinates": [
+                [
+                    [100.0, 0.0],
+                    [101.0, 0.0],
+                    [101.0, 1.0],
+                    [100.0, 1.0],
+                    [100.0, 0.0],
+                ]
+            ],
+        }
+
+        cls.incident = cls.env["spp.hazard.incident"].create(
+            {
+                "name": "Geofence Test Typhoon",
+                "code": "GEO-TEST-INC-001",
+                "category_id": cls.category_typhoon.id,
+                "start_date": "2024-06-01",
+                "severity": "3",
+            }
+        )
+
+    def test_hazard_zone_geofence_type(self):
+        """Test that hazard_zone type is available via selection_add."""
+        geofence = self.env["spp.gis.geofence"].create(
+            {
+                "name": "Hazard Zone Test",
+                "geometry": json.dumps(self.sample_polygon),
+                "geofence_type": "hazard_zone",
+            }
+        )
+
+        self.assertEqual(geofence.geofence_type, "hazard_zone")
+
+    def test_geofence_with_incident(self):
+        """Test linking a geofence to a hazard incident."""
+        geofence = self.env["spp.gis.geofence"].create(
+            {
+                "name": "Incident Linked Geofence",
+                "geometry": json.dumps(self.sample_polygon),
+                "geofence_type": "hazard_zone",
+                "incident_id": self.incident.id,
+            }
+        )
+
+        self.assertEqual(geofence.incident_id, self.incident)
+        self.assertEqual(geofence.incident_id.name, "Geofence Test Typhoon")
+        self.assertEqual(geofence.incident_id.code, "GEO-TEST-INC-001")
+
+    def test_geofence_incident_ondelete_set_null(self):
+        """Test that deleting an incident sets geofence incident_id to null."""
+        incident = self.env["spp.hazard.incident"].create(
+            {
+                "name": "Temporary Incident",
+                "code": "GEO-TEST-INC-DEL",
+                "category_id": self.category_typhoon.id,
+                "start_date": "2024-06-15",
+            }
+        )
+
+        geofence = self.env["spp.gis.geofence"].create(
+            {
+                "name": "Ondelete Test Geofence",
+                "geometry": json.dumps(self.sample_polygon),
+                "geofence_type": "hazard_zone",
+                "incident_id": incident.id,
+            }
+        )
+
+        self.assertTrue(geofence.incident_id)
+
+        incident.unlink()
+        self.assertFalse(geofence.incident_id)
+
+    def test_hazard_zone_type_label(self):
+        """Test that hazard_zone type label is correct in GeoJSON properties."""
+        geofence = self.env["spp.gis.geofence"].create(
+            {
+                "name": "Hazard Label Test",
+                "geometry": json.dumps(self.sample_polygon),
+                "geofence_type": "hazard_zone",
+            }
+        )
+
+        props = geofence.to_geojson()["properties"]
+        self.assertEqual(props["geofence_type"], "hazard_zone")
+        self.assertEqual(props["geofence_type_label"], "Hazard Zone")
+
+    def test_geofence_without_incident(self):
+        """Test that geofence works fine without an incident linked."""
+        geofence = self.env["spp.gis.geofence"].create(
+            {
+                "name": "No Incident Geofence",
+                "geometry": json.dumps(self.sample_polygon),
+                "geofence_type": "hazard_zone",
+            }
+        )
+
+        self.assertFalse(geofence.incident_id)


### PR DESCRIPTION
## Summary

Move the core `spp.gis.geofence` model from `spp_api_v2_gis` to `spp_gis` so other modules can use geofences without pulling in the full API stack (`spp_api_v2`, `spp_aggregation`, etc.).

- **New `spp_gis/models/geofence.py`**: Core geofence model with UUID field (replaces DB id in GeoJSON), core types (`area_of_interest`, `custom`), `tag_ids`, GeoJSON methods, and `create_from_geojson` factory
- **New `spp_hazard/models/geofence.py`**: `_inherit` extension adding `incident_id` and `hazard_zone` geofence type
- **Slimmed `spp_api_v2_gis/models/geofence.py`**: Now just an `_inherit` extension adding `service_area`/`targeting_area` types and incident properties in GeoJSON output
- **ACLs moved** from `spp_api_v2_gis` to `spp_gis`
- **Tests split**: 24 core tests in `spp_gis`, 4 extension tests in `spp_api_v2_gis`

### Quality improvements over original
- Batched `_compute_area_sqkm` into single SQL query (was N+1)
- `psycopg2.sql.Identifier` for safe table name interpolation (was string formatting)
- Narrowed exception handling in `to_geojson` to specific types
- Prefetch related fields in `to_geojson_collection` to avoid N+1
- Removed redundant `created_by_id` field (use Odoo's built-in `create_uid`)
- Removed `mail.thread`/`mail.activity.mixin` (geofences don't need chatter)
- Fixed missing `spp_vocabulary` and `spp_registry` dependencies in `spp_gis`
- Fixed `spp_gis` category to `OpenSPP/Core`

## Test plan
- [x] `./spp t spp_gis` passes (67 tests, 0 failures)
- [x] `./spp t spp_hazard` passes (33 tests, 0 failures)
- [x] `./spp t spp_api_v2_gis` passes (190 tests, 0 failures)
- [x] Linters pass on all changed files
- [ ] Verify geofence CRUD via API endpoints still works end-to-end
- [ ] Verify QGIS plugin can still create geofences