### PR TITLE
fix(modules): add missing static/description/index.html for 7 modules

### DIFF
--- a/spp_aggregation/static/description/index.html
+++ b/spp_aggregation/static/description/index.html
@@ -1,0 +1,1 @@
+<h1>spp_aggregation</h1>

--- a/spp_api_v2_simulation/static/description/index.html
+++ b/spp_api_v2_simulation/static/description/index.html
@@ -1,0 +1,1 @@
+<h1>spp_api_v2_simulation</h1>

--- a/spp_dci_demo/static/description/index.html
+++ b/spp_dci_demo/static/description/index.html
@@ -1,0 +1,1 @@
+<h1>spp_dci_demo</h1>

--- a/spp_metrics_core/static/description/index.html
+++ b/spp_metrics_core/static/description/index.html
@@ -1,0 +1,1 @@
+<h1>spp_metrics_core</h1>

--- a/spp_metrics_services/static/description/index.html
+++ b/spp_metrics_services/static/description/index.html
@@ -1,0 +1,1 @@
+<h1>spp_metrics_services</h1>

--- a/spp_statistic/static/description/index.html
+++ b/spp_statistic/static/description/index.html
@@ -1,0 +1,1 @@
+<h1>spp_statistic</h1>

--- a/spp_statistic_studio/static/description/index.html
+++ b/spp_statistic_studio/static/description/index.html
@@ -1,0 +1,1 @@
+<h1>spp_statistic_studio</h1>


### PR DESCRIPTION
## Why is this change needed?
Odoo requires `static/description/index.html` to exist for all modules in the addons path. These 7 newer modules were missing it, causing `FileNotFoundError` during module loading/installation.

## How was the change implemented?
Added minimal `static/description/index.html` files to:
- spp_aggregation
- spp_api_v2_simulation
- spp_dci_demo
- spp_metrics_core
- spp_metrics_services
- spp_statistic
- spp_statistic_studio

## How to test manually
- Install any module (e.g. `spp_base`) with all addons paths configured — should no longer get `FileNotFoundError`