### PR TITLE
fix(security,vocabulary): port disability registry changes

### DIFF
--- a/spp_security/security/categories.xml
+++ b/spp_security/security/categories.xml
@@ -194,6 +194,14 @@
         <field name="sequence">150</field>
     </record>
 
+    <!-- Disability Registry Domain Category -->
+    <record id="category_spp_disability" model="ir.module.category">
+        <field name="name">Disability Registry</field>
+        <field name="description">Disability assessment and registry management</field>
+        <field name="parent_id" ref="category_spp" />
+        <field name="sequence">76</field>
+    </record>
+
     <!-- Session Tracking Domain Category -->
     <record id="category_spp_sessions" model="ir.module.category">
         <field name="name">Sessions</field>

--- a/spp_security/security/categories.xml
+++ b/spp_security/security/categories.xml
@@ -102,6 +102,14 @@
         <field name="sequence">75</field>
     </record>
 
+    <!-- Disability Registry Domain Category -->
+    <record id="category_spp_disability" model="ir.module.category">
+        <field name="name">Disability Registry</field>
+        <field name="description">Disability assessment and registry management</field>
+        <field name="parent_id" ref="category_spp" />
+        <field name="sequence">76</field>
+    </record>
+
     <!-- Health Monitoring Domain Category -->
     <record id="category_spp_health_monitoring" model="ir.module.category">
         <field name="name">Health Monitoring</field>
@@ -192,14 +200,6 @@
         <field name="description">Service provider and referral directory</field>
         <field name="parent_id" ref="category_spp" />
         <field name="sequence">150</field>
-    </record>
-
-    <!-- Disability Registry Domain Category -->
-    <record id="category_spp_disability" model="ir.module.category">
-        <field name="name">Disability Registry</field>
-        <field name="description">Disability assessment and registry management</field>
-        <field name="parent_id" ref="category_spp" />
-        <field name="sequence">76</field>
     </record>
 
     <!-- Session Tracking Domain Category -->

--- a/spp_vocabulary/__manifest__.py
+++ b/spp_vocabulary/__manifest__.py
@@ -41,6 +41,7 @@
         "data/concept_groups.xml",
         "data/vocabulary_id_type.xml",
         "data/vocabulary_cr_document_types.xml",
+        "data/vocabulary_disability.xml",
         # Temporarily disabled - references spp.relationship model from spp_registry
         # "data/relationship_types.xml",
     ],

--- a/spp_vocabulary/__manifest__.py
+++ b/spp_vocabulary/__manifest__.py
@@ -32,7 +32,6 @@
         "data/vocabulary_occupation.xml",
         "data/vocabulary_education_level.xml",
         "data/vocabulary_ethnocultural.xml",
-        "data/vocabulary_disability.xml",
         "data/vocabulary_housing.xml",
         "data/vocabulary_economic_activity.xml",
         "data/vocabulary_language.xml",


### PR DESCRIPTION
## Why is this change needed?
These changes were made in openspp-modules-v2 but not yet ported to OpenSPP2. They are needed to resolve merge conflicts in openspp-modules-v2 PR #333 (refactor/openspp2-submodule).

## How was the change implemented?
- Added `category_spp_disability` (Disability Registry) category to `spp_security/security/categories.xml` with sequence 76
- Removed `data/vocabulary_disability.xml` from `spp_vocabulary/__manifest__.py` (disability vocabulary was extracted to its own module `spp_disability_registry`)

## New unit tests

## Unit tests executed by the author

## How to test manually
- Install `spp_security` and verify the Disability Registry category appears in user settings
- Install `spp_vocabulary` and verify it loads without referencing the removed disability vocabulary file

## Related links
- openspp-modules-v2 PR: https://github.com/OpenSPP/openspp-modules-v2/pull/333