### PR TITLE
fix(spp_security,spp_hazard): rename Hazard & Emergency to avoid XML parse error

### DIFF
--- a/spp_hazard/security/compliance.yaml
+++ b/spp_hazard/security/compliance.yaml
@@ -104,7 +104,7 @@ record_rules: []
 menus:
   # Main Hazard menu - accessible to all hazard groups
   - id: hazard_main_menu_root
-    name: "Hazard & Emergency"
+    name: "Hazard and Emergency"
     groups:
       [
         spp_security.group_spp_admin,

--- a/spp_hazard/views/menu.xml
+++ b/spp_hazard/views/menu.xml
@@ -3,7 +3,7 @@
     <!-- Main Hazard Menu (Top-level application) -->
     <menuitem
         id="hazard_main_menu_root"
-        name="Hazard &amp; Emergency"
+        name="Hazard and Emergency"
         web_icon="spp_hazard,static/description/OpenSPP-Web-Menu_Hazard__Emergency_Icon.png"
         sequence="45"
     />

--- a/spp_security/security/categories.xml
+++ b/spp_security/security/categories.xml
@@ -120,9 +120,9 @@
         <field name="sequence">77</field>
     </record>
 
-    <!-- Hazard & Emergency Domain Category -->
+    <!-- Hazard and Emergency Domain Category -->
     <record id="category_spp_hazard" model="ir.module.category">
-        <field name="name">Hazard &amp; Emergency</field>
+        <field name="name">Hazard and Emergency</field>
         <field
             name="description"
         >Hazard classification, incident tracking, and impact assessment</field>


### PR DESCRIPTION
## Why is this change needed?
Odoo 19's `ResUserGroupIdsField` widget inserts category names into dynamically generated XML without escaping special characters. The `&` in "Hazard & Emergency" breaks the XML parser when opening the Access Rights tab on the User form (when `spp_mis_demo_v2` is installed).

## How was the change implemented?
- Renamed category from "Hazard & Emergency" to "Hazard and Emergency" in:
  - `spp_security/security/categories.xml`
  - `spp_hazard/views/menu.xml`
  - `spp_hazard/security/compliance.yaml`

## New unit tests

## Unit tests executed by the author

## How to test manually
1. Install `spp_mis_demo_v2`
2. Go to Settings > Users & Companies > Users
3. Select a user and click the "Access Rights" tab
4. Verify no XML parse error appears

## Related links