### PR TITLE
fix(spp_graduation): add web_icon to Graduation root menu

### DIFF
--- a/spp_graduation/views/graduation_menus.xml
+++ b/spp_graduation/views/graduation_menus.xml
@@ -5,6 +5,7 @@
         id="menu_graduation_root"
         name="Graduation"
         sequence="60"
+        web_icon="spp_graduation,static/description/openspp-graduation-menu-icons.png"
         groups="group_spp_graduation_user"
     />
 


### PR DESCRIPTION
## Why is this change needed?
The `openspp-graduation-menu-icons.png` file existed in `spp_graduation/static/description/` but was not referenced by the Graduation root menu, so the menu had no icon.

## How was the change implemented?
Added `web_icon` attribute to the `menu_graduation_root` menuitem pointing to the existing icon file.

## New unit tests

## Unit tests executed by the author

## How to test manually
1. Install `spp_graduation`
2. Check the top-level Graduation menu displays the custom icon

## Related links