### PR TITLE
feat(spp_change_request_v2): improve Update ID Document CR type

### DIFF
--- a/spp_base_common/__manifest__.py
+++ b/spp_base_common/__manifest__.py
@@ -36,6 +36,8 @@
             "spp_base_common/static/src/scss/navbar.scss",
             "spp_base_common/static/src/js/custom_list_create.js",
             "spp_base_common/static/src/xml/custom_list_create_template.xml",
+            "spp_base_common/static/src/js/filterable_radio_field.js",
+            "spp_base_common/static/src/xml/filterable_radio_field.xml",
         ],
         "web._assets_primary_variables": [
             "spp_base_common/static/src/scss/colors.scss",

--- a/spp_base_common/static/src/js/filterable_radio_field.js
+++ b/spp_base_common/static/src/js/filterable_radio_field.js
@@ -1,0 +1,77 @@
+/** @odoo-module **/
+
+import {RadioField, radioField} from "@web/views/fields/radio/radio_field";
+import {registry} from "@web/core/registry";
+import {_t} from "@web/core/l10n/translation";
+
+/**
+ * A radio widget that supports disabling individual options based on
+ * boolean fields on the record.
+ *
+ * Usage in XML views:
+ *   <field
+ *       name="operation"
+ *       widget="filterable_radio"
+ *       options="{
+ *           'disabled_map': {
+ *               'update': 'allow_id_edit',
+ *               'remove': 'allow_id_remove'
+ *           }
+ *       }"
+ *   />
+ *
+ * The `disabled_map` option maps selection values to boolean field names.
+ * When the boolean field is falsy, the corresponding radio option is
+ * rendered as disabled (grayed out, not clickable).
+ */
+export class FilterableRadioField extends RadioField {
+    static template = "spp_base_common.FilterableRadioField";
+    static props = {
+        ...RadioField.props,
+        disabledMap: {type: Object, optional: true},
+    };
+    static defaultProps = {
+        ...RadioField.defaultProps,
+        disabledMap: {},
+    };
+
+    /**
+     * Check whether a given selection value should be disabled.
+     * @param {any} value - The selection key to check
+     * @returns {Boolean}
+     */
+    isItemDisabled(value) {
+        if (this.props.readonly) {
+            return true;
+        }
+        const map = this.props.disabledMap;
+        if (!map || !(value in map)) {
+            return false;
+        }
+        const boolField = map[value];
+        return !this.props.record.data[boolField];
+    }
+}
+
+export const filterableRadioField = {
+    ...radioField,
+    component: FilterableRadioField,
+    displayName: _t("Filterable Radio"),
+    supportedOptions: [
+        ...radioField.supportedOptions,
+        {
+            label: _t("Disabled map (value → boolean field)"),
+            name: "disabled_map",
+            type: "object",
+        },
+    ],
+    extractProps: (fieldInfo, dynamicInfo) => {
+        const baseProps = radioField.extractProps(fieldInfo, dynamicInfo);
+        return {
+            ...baseProps,
+            disabledMap: fieldInfo.options.disabled_map || {},
+        };
+    },
+};
+
+registry.category("fields").add("filterable_radio", filterableRadioField);

--- a/spp_base_common/static/src/js/filterable_radio_field.js
+++ b/spp_base_common/static/src/js/filterable_radio_field.js
@@ -5,7 +5,7 @@ import {registry} from "@web/core/registry";
 import {_t} from "@web/core/l10n/translation";
 
 /**
- * A radio widget that supports disabling individual options based on
+ * A radio widget that supports hiding individual options based on
  * boolean fields on the record.
  *
  * Usage in XML views:
@@ -22,7 +22,7 @@ import {_t} from "@web/core/l10n/translation";
  *
  * The `disabled_map` option maps selection values to boolean field names.
  * When the boolean field is falsy, the corresponding radio option is
- * rendered as disabled (grayed out, not clickable).
+ * hidden from the user.
  */
 export class FilterableRadioField extends RadioField {
     static template = "spp_base_common.FilterableRadioField";

--- a/spp_base_common/static/src/xml/filterable_radio_field.xml
+++ b/spp_base_common/static/src/xml/filterable_radio_field.xml
@@ -8,7 +8,10 @@
             t-att-aria-label="props.label"
         >
             <t t-foreach="items" t-as="item" t-key="item[0]">
-                <div class="form-check o_radio_item" aria-atomic="true">
+                <div
+                    t-attf-class="form-check o_radio_item #{isItemDisabled(item[0]) ? 'd-none' : ''}"
+                    aria-atomic="true"
+                >
                     <input
                         type="radio"
                         class="form-check-input o_radio_input"

--- a/spp_base_common/static/src/xml/filterable_radio_field.xml
+++ b/spp_base_common/static/src/xml/filterable_radio_field.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+
+    <t t-name="spp_base_common.FilterableRadioField">
+        <div
+            role="radiogroup"
+            t-attf-class="o_{{ props.orientation }}"
+            t-att-aria-label="props.label"
+        >
+            <t t-foreach="items" t-as="item" t-key="item[0]">
+                <div class="form-check o_radio_item" aria-atomic="true">
+                    <input
+                        type="radio"
+                        class="form-check-input o_radio_input"
+                        t-att-checked="item[0] === value"
+                        t-att-disabled="isItemDisabled(item[0])"
+                        t-att-name="id"
+                        t-att-data-value="item[0]"
+                        t-att-data-index="item_index"
+                        t-att-id="`${id}_${item[0]}`"
+                        t-on-change="() => this.onChange(item)"
+                    />
+                    <label
+                        t-att-for="`${id}_${item[0]}`"
+                        t-attf-class="form-check-label o_form_label #{isItemDisabled(item[0]) ? 'text-muted' : ''}"
+                        t-esc="item[1]"
+                    />
+                </div>
+            </t>
+        </div>
+    </t>
+
+</templates>

--- a/spp_change_request_v2/details/update_id.py
+++ b/spp_change_request_v2/details/update_id.py
@@ -1,4 +1,5 @@
-from odoo import api, fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
 
 
 class SPPCRDetailUpdateID(models.Model):
@@ -15,7 +16,7 @@ class SPPCRDetailUpdateID(models.Model):
     operation = fields.Selection(
         [
             ("add", "Add New ID"),
-            ("update", "Update Existing ID"),
+            ("update", "Edit ID"),
             ("remove", "Remove ID"),
         ],
         string="Operation",
@@ -30,8 +31,9 @@ class SPPCRDetailUpdateID(models.Model):
         help="Select existing ID to update or remove",
     )
     id_type_id = fields.Many2one(
-        "spp.id.type",
+        "spp.vocabulary.code",
         string="ID Type",
+        domain="[('vocabulary_id.namespace_uri', '=', 'urn:openspp:vocab:id-type')]",
         tracking=True,
     )
     id_value = fields.Char(
@@ -69,6 +71,31 @@ class SPPCRDetailUpdateID(models.Model):
         readonly=True,
     )
 
+    allow_id_add = fields.Boolean(
+        related="change_request_id.request_type_id.allow_id_add",
+        readonly=True,
+    )
+    allow_id_edit = fields.Boolean(
+        related="change_request_id.request_type_id.allow_id_edit",
+        readonly=True,
+    )
+    allow_id_remove = fields.Boolean(
+        related="change_request_id.request_type_id.allow_id_remove",
+        readonly=True,
+    )
+
+    @api.constrains("operation")
+    def _check_operation_allowed(self):
+        """Validate that the chosen operation is allowed by the CR type config."""
+        for rec in self:
+            if not rec.change_request_id or not rec.change_request_id.request_type_id:
+                continue
+            cr_type = rec.change_request_id.request_type_id
+            if rec.operation == "update" and not cr_type.allow_id_edit:
+                raise ValidationError(_("Edit ID operation is not allowed for this change request type."))
+            if rec.operation == "remove" and not cr_type.allow_id_remove:
+                raise ValidationError(_("Remove ID operation is not allowed for this change request type."))
+
     @api.onchange("existing_id_record_id")
     def _onchange_existing_id(self):
         """Pre-fill fields when updating existing ID."""
@@ -76,10 +103,34 @@ class SPPCRDetailUpdateID(models.Model):
             self.id_type_id = self.existing_id_record_id.id_type_id
             self.id_value = self.existing_id_record_id.value
             self.expiry_date = self.existing_id_record_id.expiry_date
-            self.description = self.existing_id_record_id.description
 
     @api.onchange("operation")
     def _onchange_operation(self):
-        """Clear fields when operation changes."""
+        """Clear fields when operation changes. Reset if operation not allowed."""
+        # Check if selected operation is allowed
+        warning = None
+        if self.operation == "update" and not self.allow_id_edit:
+            self.operation = "add"
+            warning = {
+                "title": _("Operation Not Allowed"),
+                "message": _("Edit ID is disabled for this change request type."),
+            }
+        elif self.operation == "remove" and not self.allow_id_remove:
+            self.operation = "add"
+            warning = {
+                "title": _("Operation Not Allowed"),
+                "message": _("Remove ID is disabled for this change request type."),
+            }
+
         if self.operation == "add":
             self.existing_id_record_id = False
+            self.id_type_id = False
+            self.id_value = False
+            self.expiry_date = False
+        elif self.operation in ("update", "remove"):
+            self.id_type_id = False
+            self.id_value = False
+            self.expiry_date = False
+
+        if warning:
+            return {"warning": warning}

--- a/spp_change_request_v2/details/update_id.py
+++ b/spp_change_request_v2/details/update_id.py
@@ -55,6 +55,15 @@ class SPPCRDetailUpdateID(models.Model):
         help="Upload scanned copies or photos of the ID document",
     )
     remarks = fields.Text(string="Remarks", tracking=True)
+    is_operation_locked = fields.Boolean(
+        string="Operation Locked",
+        default=False,
+        help="Set to True when user proceeds to Documents or Review stage, locking the operation selection.",
+    )
+    operation_display = fields.Char(
+        string="Operation",
+        compute="_compute_operation_display",
+    )
 
     # ══════════════════════════════════════════════════════════════════════════
     # COMPUTED FIELDS
@@ -83,6 +92,22 @@ class SPPCRDetailUpdateID(models.Model):
         related="change_request_id.request_type_id.allow_id_remove",
         readonly=True,
     )
+
+    @api.depends("operation")
+    def _compute_operation_display(self):
+        labels = dict(self._fields["operation"].selection)
+        for rec in self:
+            rec.operation_display = labels.get(rec.operation, "")
+
+    def action_next_documents(self):
+        """Lock operation before proceeding to documents stage."""
+        self.write({"is_operation_locked": True})
+        return super().action_next_documents()
+
+    def action_skip_to_review(self):
+        """Lock operation before proceeding to review stage."""
+        self.write({"is_operation_locked": True})
+        return super().action_skip_to_review()
 
     @api.constrains("operation")
     def _check_operation_allowed(self):
@@ -121,6 +146,9 @@ class SPPCRDetailUpdateID(models.Model):
                 "title": _("Operation Not Allowed"),
                 "message": _("Remove ID is disabled for this change request type."),
             }
+
+        # Unlock operation when changed (user came back to edit)
+        self.is_operation_locked = False
 
         if self.operation == "add":
             self.existing_id_record_id = False

--- a/spp_change_request_v2/details/update_id.py
+++ b/spp_change_request_v2/details/update_id.py
@@ -150,15 +150,12 @@ class SPPCRDetailUpdateID(models.Model):
         # Unlock operation when changed (user came back to edit)
         self.is_operation_locked = False
 
+        # Clear fields common to all operations
+        self.id_type_id = False
+        self.id_value = False
+        self.expiry_date = False
         if self.operation == "add":
             self.existing_id_record_id = False
-            self.id_type_id = False
-            self.id_value = False
-            self.expiry_date = False
-        elif self.operation in ("update", "remove"):
-            self.id_type_id = False
-            self.id_value = False
-            self.expiry_date = False
 
         if warning:
             return {"warning": warning}

--- a/spp_change_request_v2/models/change_request.py
+++ b/spp_change_request_v2/models/change_request.py
@@ -1147,17 +1147,21 @@ class SPPChangeRequest(models.Model):
             )
 
         action = changes.pop("_action", None)
+        header = changes.pop("_header", None)
 
         # Determine if this is a field-mapping type (has old/new dicts)
         has_comparison = any(isinstance(v, dict) and "old" in v and "new" in v for v in changes.values())
 
         if has_comparison:
-            return self._render_comparison_table(changes)
-        return self._render_action_summary(action, changes)
+            return self._render_comparison_table(changes, header=header)
+        return self._render_action_summary(action, changes, header=header)
 
-    def _render_comparison_table(self, changes):
+    def _render_comparison_table(self, changes, header=None):
         """Render a three-column comparison table for field-mapping CR types."""
-        html = ['<table class="table table-sm table-bordered mb-0" style="width:100%">']
+        html = []
+        if header:
+            html.append(f"<h4>{header}</h4>")
+        html.append('<table class="table table-sm table-bordered mb-0" style="width:100%">')
         html.append(
             "<thead><tr>"
             '<th class="bg-light"></th>'
@@ -1170,7 +1174,8 @@ class SPPChangeRequest(models.Model):
         for key, value in changes.items():
             if key.startswith("_"):
                 continue
-            display_key = key.replace("_", " ").title()
+            # Use key as-is if it contains spaces (human-readable), otherwise convert
+            display_key = key if " " in key else key.replace("_", " ").title()
 
             if isinstance(value, dict) and "old" in value:
                 old_val = value.get("old")
@@ -1203,9 +1208,12 @@ class SPPChangeRequest(models.Model):
         html.append("</tbody></table>")
         return "".join(html)
 
-    def _render_action_summary(self, action, changes):
+    def _render_action_summary(self, action, changes, header=None):
         """Render a summary table for action-based CR types."""
         html = []
+
+        if header:
+            html.append(f"<h4>{header}</h4>")
 
         if not changes:
             html.append('<p class="text-muted mb-0"><i class="fa fa-info-circle me-2"></i>No details to display.</p>')
@@ -1218,7 +1226,7 @@ class SPPChangeRequest(models.Model):
         for key, value in changes.items():
             if key.startswith("_"):
                 continue
-            display_key = key.replace("_", " ").title()
+            display_key = key if " " in key else key.replace("_", " ").title()
             display_value = self._format_review_value(value)
             html.append(f'<tr><td class="bg-light"><strong>{display_key}</strong></td><td>{display_value}</td></tr>')
 

--- a/spp_change_request_v2/models/change_request.py
+++ b/spp_change_request_v2/models/change_request.py
@@ -1,5 +1,7 @@
 import logging
 
+from markupsafe import escape as html_escape
+
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
 
@@ -1241,9 +1243,9 @@ class SPPChangeRequest(models.Model):
             return '<span class="badge text-bg-success">Yes</span>'
         if isinstance(value, list):
             if value:
-                return "<br/>".join(str(v) for v in value)
+                return "<br/>".join(html_escape(str(v)) for v in value)
             return '<span class="text-muted">—</span>'
-        return str(value)
+        return html_escape(str(value))
 
     def _capture_preview_snapshot(self):
         """Capture and store the preview HTML and JSON before applying changes."""

--- a/spp_change_request_v2/models/change_request_type.py
+++ b/spp_change_request_v2/models/change_request_type.py
@@ -252,6 +252,26 @@ class SPPChangeRequestType(models.Model):
     )
 
     # ══════════════════════════════════════════════════════════════════════════
+    # ID OPERATIONS CONFIGURATION (for update_id type)
+    # ══════════════════════════════════════════════════════════════════════════
+
+    allow_id_add = fields.Boolean(
+        string="Allow Add ID",
+        default=True,
+        help="Allow adding new ID documents via this CR type.",
+    )
+    allow_id_edit = fields.Boolean(
+        string="Allow Edit ID",
+        default=True,
+        help="Allow editing existing ID documents via this CR type.",
+    )
+    allow_id_remove = fields.Boolean(
+        string="Allow Remove ID",
+        default=True,
+        help="Allow removing ID documents via this CR type.",
+    )
+
+    # ══════════════════════════════════════════════════════════════════════════
     # APPLY CONFIGURATION
     # ══════════════════════════════════════════════════════════════════════════
 

--- a/spp_change_request_v2/strategies/update_id.py
+++ b/spp_change_request_v2/strategies/update_id.py
@@ -51,7 +51,8 @@ class SPPCRApplyUpdateID(models.AbstractModel):
         )
         if existing:
             raise UserError(
-                _("Registrant already has an ID of type '%s'. Use 'Update' operation instead.") % detail.id_type_id.name
+                _("Registrant already has an ID of type '%s'. Use 'Update' operation instead.")
+                % detail.id_type_id.display_name
             )
 
         # Create new ID record
@@ -68,7 +69,7 @@ class SPPCRApplyUpdateID(models.AbstractModel):
 
         _logger.info(
             "Added ID type=%s for registrant partner_id=%s via CR %s",
-            detail.id_type_id.name,
+            detail.id_type_id.display_name,
             registrant.id,
             change_request.name,
         )
@@ -119,16 +120,53 @@ class SPPCRApplyUpdateID(models.AbstractModel):
         return True
 
     def preview(self, change_request):
-        """Preview what will be changed."""
+        """Preview what will be changed, with different layouts per operation."""
         detail = change_request.get_detail()
         if not detail:
             return {}
 
-        return {
-            "_action": f"{detail.operation}_id",
-            "registrant": change_request.registrant_id.name,
-            "operation": detail.operation,
-            "id_type": detail.id_type_id.name if detail.id_type_id else None,
-            "id_value": detail.id_value,
-            "existing_value": detail.current_id_value,
-        }
+        operation = detail.operation
+
+        if operation == "update":
+            # Show old/new comparison for edit operations
+            result = {
+                "_action": "update_id",
+                "_header": "Edit Existing ID",
+            }
+            if detail.existing_id_record_id:
+                existing = detail.existing_id_record_id
+                result["ID Type"] = {
+                    "old": existing.id_type_id.display_name if existing.id_type_id else None,
+                    "new": detail.id_type_id.display_name if detail.id_type_id else None,
+                }
+                result["ID Number/Value"] = {
+                    "old": existing.value or None,
+                    "new": detail.id_value or None,
+                }
+                result["Expiry Date"] = {
+                    "old": str(existing.expiry_date) if existing.expiry_date else None,
+                    "new": str(detail.expiry_date) if detail.expiry_date else None,
+                }
+            return result
+
+        if operation == "add":
+            return {
+                "_action": "add_id",
+                "_header": "Add New ID",
+                "ID Type": detail.id_type_id.display_name if detail.id_type_id else None,
+                "ID Number/Value": detail.id_value or None,
+                "Expiry Date": str(detail.expiry_date) if detail.expiry_date else None,
+            }
+
+        if operation == "remove":
+            result = {
+                "_action": "remove_id",
+                "_header": "Remove Existing ID",
+            }
+            if detail.existing_id_record_id:
+                existing = detail.existing_id_record_id
+                result["ID Type"] = existing.id_type_id.display_name if existing.id_type_id else None
+                result["ID Number/Value"] = existing.value or None
+            return result
+
+        return {}

--- a/spp_change_request_v2/tests/test_update_id_strategy.py
+++ b/spp_change_request_v2/tests/test_update_id_strategy.py
@@ -262,4 +262,5 @@ class TestUpdateIDStrategy(TransactionCase):
 
         self.assertIn("_action", preview)
         self.assertEqual(preview["_action"], "add_id")
-        self.assertEqual(preview["operation"], "add")
+        self.assertIn("_header", preview)
+        self.assertEqual(preview["_header"], "Add New ID")

--- a/spp_change_request_v2/views/change_request_type_views.xml
+++ b/spp_change_request_v2/views/change_request_type_views.xml
@@ -113,6 +113,25 @@
                                 />
                             </group>
                         </page>
+                        <page
+                            string="ID Operations"
+                            name="id_operations"
+                            invisible="detail_model != 'spp.cr.detail.update_id'"
+                        >
+                            <group string="Allowed ID Operations">
+                                <field name="allow_id_add" readonly="1" />
+                                <field name="allow_id_edit" />
+                                <field name="allow_id_remove" />
+                            </group>
+                            <div class="alert alert-info" role="status">
+                                <p class="mb-0">
+                                    <strong>Add ID</strong> is always enabled.
+                                    Toggle <strong>Edit ID</strong> and <strong
+                                >Remove ID</strong>
+                                    to control which operations are available to users.
+                                </p>
+                            </div>
+                        </page>
                         <page string="Apply Configuration" name="apply">
                             <group>
                                 <group>

--- a/spp_change_request_v2/views/detail_update_id_views.xml
+++ b/spp_change_request_v2/views/detail_update_id_views.xml
@@ -44,41 +44,65 @@
                     />
                 </header>
                 <sheet>
+                    <div class="oe_title">
+                        <h1>Update ID Document</h1>
+                    </div>
+
                     <group>
-                        <group string="Registrant">
+                        <group>
                             <field
-                                name="registrant_name"
-                                readonly="not is_cr_manager or approval_state not in ('draft', 'revision')"
+                                name="registrant_id"
+                                readonly="1"
+                                options="{'no_open': True}"
                             />
-                        </group>
-                        <group string="Operation">
+                            <field name="change_request_id" invisible="1" />
+                            <field name="allow_id_add" invisible="1" />
+                            <field name="allow_id_edit" invisible="1" />
+                            <field name="allow_id_remove" invisible="1" />
+                            <field name="approval_state" invisible="1" />
                             <field
                                 name="operation"
-                                widget="radio"
+                                widget="filterable_radio"
+                                options="{'disabled_map': {'update': 'allow_id_edit', 'remove': 'allow_id_remove'}}"
                                 readonly="not is_cr_manager or approval_state not in ('draft', 'revision')"
                             />
                         </group>
                     </group>
-                    <group invisible="operation == 'add'">
-                        <group string="Existing ID">
+
+                    <!-- Select existing ID for Edit operation -->
+                    <group invisible="operation != 'update'">
+                        <group>
                             <field
                                 name="existing_id_record_id"
-                                options="{'no_create': True}"
-                                required="operation in ['update', 'remove']"
-                                readonly="not is_cr_manager or approval_state not in ('draft', 'revision')"
-                            />
-                            <field
-                                name="current_id_value"
-                                invisible="not existing_id_record_id"
+                                string="Select ID to Edit"
+                                options="{'no_create': True, 'no_open': True}"
+                                required="operation == 'update'"
                                 readonly="not is_cr_manager or approval_state not in ('draft', 'revision')"
                             />
                         </group>
                     </group>
-                    <group invisible="operation == 'remove'">
-                        <group string="ID Information">
+
+                    <!-- Select existing ID for Remove operation -->
+                    <group invisible="operation != 'remove'">
+                        <group>
+                            <field
+                                name="existing_id_record_id"
+                                string="Select ID to Remove"
+                                options="{'no_create': True, 'no_open': True}"
+                                required="operation == 'remove'"
+                                readonly="not is_cr_manager or approval_state not in ('draft', 'revision')"
+                            />
+                        </group>
+                    </group>
+
+                    <group
+                        invisible="operation == 'remove' or (operation == 'update' and not existing_id_record_id)"
+                        string="ID Information"
+                    >
+                        <group>
                             <field
                                 name="id_type_id"
-                                options="{'no_create': True, 'no_open': True}"
+                                options="{'no_create': True, 'no_open': True, 'limit': 0}"
                                 readonly="not is_cr_manager or approval_state not in ('draft', 'revision')"
                             />
                             <field
@@ -91,29 +115,13 @@
                                 readonly="not is_cr_manager or approval_state not in ('draft', 'revision')"
                             />
                         </group>
-                        <separator string="Description" />
-                        <field
-                            name="description"
-                            nolabel="1"
-                            class="oe_inline"
-                            readonly="not is_cr_manager or approval_state not in ('draft', 'revision')"
-                        />
                     </group>
-                    <group string="Supporting Documents">
-                        <field
-                            name="document_attachment_ids"
-                            widget="many2many_binary"
-                            readonly="not is_cr_manager or approval_state not in ('draft', 'revision')"
-                        />
-                    </group>
-                    <group string="Additional Information">
-                        <field
-                            name="remarks"
-                            placeholder="Enter any additional notes..."
-                            readonly="not is_cr_manager or approval_state not in ('draft', 'revision')"
-                        />
+
+                    <group string="Additional Information" invisible="1">
+                        <field name="remarks" />
                     </group>
                 </sheet>
+                <chatter />
             </form>
         </field>
     </record>

--- a/spp_change_request_v2/views/detail_update_id_views.xml
+++ b/spp_change_request_v2/views/detail_update_id_views.xml
@@ -60,11 +60,18 @@
                             <field name="allow_id_edit" invisible="1" />
                             <field name="allow_id_remove" invisible="1" />
                             <field name="approval_state" invisible="1" />
+                            <field name="is_operation_locked" invisible="1" />
                             <field
                                 name="operation"
                                 widget="filterable_radio"
                                 options="{'disabled_map': {'update': 'allow_id_edit', 'remove': 'allow_id_remove'}}"
                                 readonly="not is_cr_manager or approval_state not in ('draft', 'revision')"
+                                invisible="is_operation_locked"
+                            />
+                            <field
+                                name="operation_display"
+                                readonly="1"
+                                invisible="not is_operation_locked"
                             />
                         </group>
                     </group>

--- a/spp_cr_types_base/data/cr_types.xml
+++ b/spp_cr_types_base/data/cr_types.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<odoo>
+<odoo noupdate="1">
     <!-- ════════════════════════════════════════════════════════════════════════ -->
     <!-- BASE CHANGE REQUEST TYPES (Studio-Editable) -->
     <!-- These types use field_mapping strategy and can be customized via Studio -->
@@ -220,6 +220,7 @@
         <field name="apply_model">spp.cr.apply.update_id</field>
         <field name="icon">fa-id-card</field>
         <field name="sequence">80</field>
+        <!-- allow_id_add/edit/remove default to True via field definitions -->
         <!-- Editability flags - form can be customized but apply logic is Python -->
         <field name="is_studio_editable">True</field>
         <field name="is_studio_cloneable">True</field>

--- a/spp_registry/models/reg_id.py
+++ b/spp_registry/models/reg_id.py
@@ -90,17 +90,22 @@ class SPPRegistrantID(models.Model):
     def _compute_display_name(self):
         res = super()._compute_display_name()
         for rec in self:
-            name = ""
-            if rec.partner_id:
-                name = rec.partner_id.name
-            rec.display_name = name
+            id_type = rec.id_type_id.display_name or _("Unknown Type")
+            value = rec.value or ""
+            rec.display_name = f"{id_type} - {value}" if value else id_type
         return res
 
     @api.model
     def _name_search(self, name, domain=None, operator="ilike", limit=100, order=None):
         domain = domain or []
         if name:
-            domain = [("partner_id", operator, name)] + domain
+            domain = [
+                "|",
+                "|",
+                ("id_type_id.display", operator, name),
+                ("value", operator, name),
+                ("partner_id", operator, name),
+            ] + domain
         return self._search(domain, limit=limit, order=order)
 
     @api.depends("verification_method")


### PR DESCRIPTION
## Why is this change needed?
The "Update ID Document" change request type needed UI/UX improvements to match the quality of the "Edit Individual Information" CR type, plus configurable allowed operations.

## How was the change implemented?
- Redesigned detail form with title header, registrant_id field, operation below registrant, hidden remarks
- Renamed "Update Existing ID" → "Edit ID" in operation selection
- Added operation-specific review layouts: comparison table for Edit, summary for Add/Remove
- Added configurable allowed operations (`allow_id_add/edit/remove`) on CR type model with "ID Operations" tab
- Created reusable `filterable_radio` widget in `spp_base_common` supporting per-option disabling via `disabled_map`
- Fixed `id_type_id` to use `spp.vocabulary.code` (matching `spp.registry.id`)
- Fixed `spp.registry.id` display_name to show "ID Type - Value" instead of partner name
- Fixed `_name_search` to search by ID type, value, or partner name
- Hidden ID Information section in Edit mode until existing ID is selected
- Wrapped `cr_types.xml` in `noupdate="1"` to prevent upgrade overwrites

## New unit tests
Updated `test_update_id_preview` for new preview structure with `_header` key.

## Unit tests executed by the author
- `spp_cr_types_base`: 7/7 passed
- `spp_change_request_v2`: 279/279 passed (286 total with cr_types_base)

## How to test manually
1. Create an "Update ID Document" CR → verify new form layout (title, registrant field, operation radio below)
2. Test each operation (Add, Edit, Remove) → verify field behavior and visibility
3. Edit operation → select existing ID → verify ID Information appears with pre-filled fields
4. Navigate to Review page → verify different layouts per operation (comparison for Edit, summary for Add/Remove)
5. Go to CR Type config → verify "ID Operations" tab with toggle switches
6. Disable "Edit ID" → verify radio option is grayed out on the detail form

## Related links