### PR TITLE
fix(spp_gis_indicators)

### DIFF
--- a/spp_gis_indicators/README.rst
+++ b/spp_gis_indicators/README.rst
@@ -31,27 +31,33 @@ legend generation.
 Key Capabilities
 ~~~~~~~~~~~~~~~~
 
-- Define indicator layer configurations that link CEL variables to color
-  scales and classification methods
-- Classify continuous indicator values into discrete color classes using
-  quantile, equal interval, or manual breaks
-- Apply preset ColorBrewer color scales (sequential, diverging,
-  categorical) or define custom scales
-- Compute break values automatically based on actual data distribution
+- Define indicator layer configurations linking a CEL variable to a
+  color scale and classification method
+- Classify continuous values into discrete color classes using quantile,
+  equal interval, or manual breaks
+- Compute break values automatically from actual data distribution
 - Generate HTML legends showing color-to-value mappings
 - Map area features to colors for choropleth rendering in GIS data
   layers
-- Filter indicators by period and hazard incident context
+- Filter indicators by period key and hazard incident context
+- Ship 11 preset ColorBrewer color scales (5 sequential, 4 diverging, 2
+  categorical)
 
 Key Models
 ~~~~~~~~~~
 
-- **spp.gis.indicator.layer** -- Configuration linking a CEL variable to
-  color scale and classification settings
-- **spp.gis.color.scale** -- Color scheme definition with JSON array of
-  hex colors
-- **spp.gis.data.layer** -- Extended with choropleth geo representation
-  option
++------------------------------+---------------------------------------+
+| Model                        | Description                           |
++==============================+=======================================+
+| ``spp.gis.indicator.layer``  | Configuration linking a CEL variable  |
+|                              | to color scale and class method       |
++------------------------------+---------------------------------------+
+| ``spp.gis.color.scale``      | Color scheme definition with JSON     |
+|                              | array of hex colors                   |
++------------------------------+---------------------------------------+
+| ``spp.gis.data.layer`` (ext) | Extended with ``indicator_layer_id``  |
+|                              | for choropleth rendering              |
++------------------------------+---------------------------------------+
 
 Configuration
 ~~~~~~~~~~~~~
@@ -59,37 +65,44 @@ Configuration
 After installing:
 
 1. Navigate to **Settings > GIS Configuration > Color Scales**
-2. Review preset ColorBrewer scales (Blues, Greens, Red-Yellow-Green,
-   etc.) or create custom scales
+2. Review the 11 preset ColorBrewer scales or create custom ones
 3. Navigate to **Settings > GIS Configuration > Indicator Layers**
-4. Create an indicator layer specifying the CEL variable, period key,
-   color scale, and classification method
-5. In an existing GIS data layer, set ``geo_repr`` to ``choropleth`` and
-   select the indicator layer to visualize
+4. Create an indicator layer: select the CEL variable, period key, color
+   scale, and classification method
+5. In a GIS data layer form, set ``geo_repr`` to ``choropleth`` and
+   select the indicator layer
 
 UI Location
 ~~~~~~~~~~~
 
 - **Menu**: Settings > GIS Configuration > Indicator Layers
 - **Menu**: Settings > GIS Configuration > Color Scales
+- **Access**: Menus restricted to ``base.group_system`` (Settings/System
+  admin)
+- **Indicator form tabs**: Data Source, Visualization, Legend Preview
 
 Security
 ~~~~~~~~
 
-- **spp_security.group_spp_user** -- Read
-- **spp_security.group_spp_manager** -- Read/write/create (no delete)
-- **spp_security.group_spp_admin** -- Full CRUD
+==================================== ============ ================
+Group                                Color Scales Indicator Layers
+==================================== ============ ================
+``spp_registry.group_registry_read`` Read         Read
+``spp_security.group_spp_admin``     Full CRUD    Full CRUD
+==================================== ============ ================
 
 Extension Points
 ~~~~~~~~~~~~~~~~
 
 - Override ``_compute_quantile_breaks()`` or
-  ``_compute_equal_interval_breaks()`` in ``spp.gis.indicator.layer`` to
-  add custom classification algorithms
+  ``_compute_equal_interval_breaks()`` for custom classification
+  algorithms
 - Inherit ``spp.gis.color.scale`` and override ``get_color_for_value()``
-  to implement custom color mapping logic
+  for custom color mapping
 - Extend ``spp.gis.indicator.layer._get_indicator_values()`` to support
-  additional data sources beyond ``spp.hxl.area.indicator``
+  data sources beyond ``spp.hxl.area.indicator``
+- Override ``spp.gis.data.layer._get_choropleth_config()`` to customize
+  frontend choropleth config
 
 Dependencies
 ~~~~~~~~~~~~
@@ -100,6 +113,299 @@ Dependencies
 
 .. contents::
    :local:
+
+Usage
+=====
+
+Prerequisites
+~~~~~~~~~~~~~
+
+- Log in as a user with **Settings / System admin** access
+  (``base.group_system``). The GIS Configuration menus are only visible
+  to this group.
+- The following modules must be installed: ``spp_gis``,
+  ``spp_hxl_area``, ``spp_registry``, ``spp_security``.
+- At least one ``spp.cel.variable`` record and some
+  ``spp.hxl.area.indicator`` records must exist for indicator layers to
+  display meaningful data.
+
+Color Scales — List View
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+1. Go to **Settings > GIS Configuration > Color Scales**.
+2. The list view shows columns: **Sequence** (drag handle), **Scale
+   Name**, **Scale Type**, **Description**, **Active**.
+3. Eleven preset ColorBrewer scales are installed as demo data (loaded
+   with ``noupdate="1"``, so they survive module upgrades).
+
+Color Scales — Form View
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Open any preset scale (e.g., "Blues (Sequential)"). Verify the form
+shows:
+
+- **Scale Name** — e.g., "Blues (Sequential)"
+- **Scale Type** — dropdown with three options: "Sequential (low to
+  high)", "Diverging (negative to positive)", "Categorical (distinct
+  values)"
+- **Sequence** — numeric ordering value
+- **Description** — free-text field below a "Description" separator
+- **Colors** section — a text area labeled "Colors (JSON)" containing a
+  JSON array of hex color codes
+- **Preview** section — static help text showing the expected JSON
+  format
+
+To create a custom scale: click **New**, fill in **Scale Name**
+(required), select a **Scale Type** (defaults to "Sequential"), and
+enter a JSON array of at least 2 hex colors in the **Colors (JSON)**
+field. Valid formats: ``#RGB`` (3-digit) or ``#RRGGBB`` (6-digit), e.g.,
+``["#f00", "#00ff00", "#0000ff"]``.
+
+To archive: open a scale, click **Action > Archive**. An "Archived"
+ribbon appears. Archived scales no longer appear in dropdowns on
+indicator layers.
+
+Color Scale — Validation Tests
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++----------------------------------+----------------------------------+
+| Action                           | Expected Result                  |
++==================================+==================================+
+| Enter invalid JSON (e.g.,        | ValidationError: "Invalid JSON   |
+| ``not json``)                    | in colors_json"                  |
++----------------------------------+----------------------------------+
+| Enter a non-array (e.g.,         | ValidationError: "colors_json    |
+| ``{"a": 1}``)                    | must be a JSON array"            |
++----------------------------------+----------------------------------+
+| Enter fewer than 2 colors (e.g., | ValidationError: "Color scale    |
+| ``["#fff"]``)                    | must have at least 2 colors"     |
++----------------------------------+----------------------------------+
+| Enter a non-string element       | ValidationError: "All colors     |
+| (e.g., ``[123, "#fff"]``)        | must be strings"                 |
++----------------------------------+----------------------------------+
+| Enter invalid hex (e.g.,         | ValidationError: "Invalid hex    |
+| ``["red", "#fff"]``)             | color format"                    |
++----------------------------------+----------------------------------+
+| Enter 5-digit hex (e.g.,         | ValidationError: "Invalid hex    |
+| ``["#12345"]``)                  | color format"                    |
++----------------------------------+----------------------------------+
+
+Indicator Layers — List and Search
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+1. Go to **Settings > GIS Configuration > Indicator Layers**.
+2. The list view shows: **Sequence** (drag handle), **Name**, **Variable
+   Name**, **Period Key**, **Classification Method**, **Number of
+   Classes**, **Active**.
+3. The default search filter is "Active" (only active records shown).
+4. Search bar supports filtering by **Name**, **Variable**, and **Period
+   Key**.
+5. Predefined filters: **Active**, **Archived** (under the Filters
+   menu).
+6. Group By options: **Variable**, **Period**, **Classification
+   Method**.
+
+Indicator Layer — Form: Data Source Tab
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Click **New** and fill in **Configuration Name** (required). The form
+has three tabs: **Data Source**, **Visualization**, and **Legend
+Preview**.
+
+The **Data Source** tab contains:
+
++-----------------------------+-----------------------------+----------+
+| Field                       | Description                 | Required |
++=============================+=============================+==========+
+| **Indicator Variable**      | Dropdown of                 | Yes      |
+|                             | ``spp.cel.variable``        |          |
+|                             | records (no inline          |          |
+|                             | create/open)                |          |
++-----------------------------+-----------------------------+----------+
+| **Period Key**              | Free-text, defaults to      | No       |
+|                             | "current". Examples:        |          |
+|                             | "2024-12", "current"        |          |
++-----------------------------+-----------------------------+----------+
+| **Incident/Disaster**       | Dropdown of                 | No       |
+|                             | ``spp.hazard.incident``     |          |
+|                             | records. Filters indicator  |          |
+|                             | data by incident.           |          |
++-----------------------------+-----------------------------+----------+
+
+Indicator Layer — Form: Visualization Tab
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++----------------------+-------------------------+----------------------+
+| Field                | Description             | Visibility           |
++======================+=========================+======================+
+| **Color Scale**      | Dropdown of             | Always visible       |
+|                      | ``spp.gis.color.scale`` |                      |
+|                      | records (no inline      |                      |
+|                      | create)                 |                      |
++----------------------+-------------------------+----------------------+
+| **Classification     | Dropdown: "Quantile     | Always visible       |
+| Method**             | (Equal count per        |                      |
+|                      | class)", "Equal         |                      |
+|                      | Interval (Equal range   |                      |
+|                      | per class)", "Manual    |                      |
+|                      | Breaks"                 |                      |
++----------------------+-------------------------+----------------------+
+| **Number of          | Integer (2–10).         | Hidden when method   |
+| Classes**            | Controls how many color | is "Manual Breaks"   |
+|                      | buckets to create.      |                      |
++----------------------+-------------------------+----------------------+
+| **Manual Break       | Comma-separated         | Only visible when    |
+| Points**             | numbers, e.g.,          | method is "Manual    |
+|                      | "10,50,100,500"         | Breaks"              |
++----------------------+-------------------------+----------------------+
+| **Computed Breaks**  | Shows the computed      | Always visible (in   |
+| (read-only)          | break values as a JSON  | "Computed            |
+|                      | array                   | Classification"      |
+|                      |                         | section)             |
++----------------------+-------------------------+----------------------+
+
+Classification method behavior:
+
+- **Quantile**: Breaks computed so each class contains approximately the
+  same number of areas. Requires indicator data. If no data, Computed
+  Breaks is empty.
+- **Equal Interval**: Breaks evenly spaced between minimum and maximum
+  indicator values. If all values are equal, Computed Breaks is empty.
+- **Manual Breaks**: Uses user-supplied break points directly. Does not
+  depend on indicator data.
+
+Indicator Layer — Form: Legend Preview Tab
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Displays a read-only HTML preview of the legend.
+- Each legend item shows a colored box and a label with the value range
+  (e.g., "< 10.00", "10.00 - 50.00", ">= 500.00").
+- The legend updates automatically when break values or color scale
+  changes.
+
+Indicator Layer — Validation Tests
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Number of Classes:**
+
++-----------------------------+----------------------------------------+
+| Action                      | Expected Result                        |
++=============================+========================================+
+| Set Number of Classes to 1  | ValidationError: "Number of classes    |
+|                             | must be at least 2"                    |
++-----------------------------+----------------------------------------+
+| Set Number of Classes to 11 | ValidationError: "Number of classes    |
+|                             | must not exceed 10"                    |
++-----------------------------+----------------------------------------+
+| Set Number of Classes to 5  | Saves successfully                     |
++-----------------------------+----------------------------------------+
+
+**Manual Breaks:**
+
++----------------------------------+----------------------------------+
+| Action                           | Expected Result                  |
++==================================+==================================+
+| Select "Manual Breaks" but leave | ValidationError: "Manual breaks  |
+| the field empty                  | are required when using manual   |
+|                                  | classification"                  |
++----------------------------------+----------------------------------+
+| Enter non-numeric text (e.g.,    | ValidationError: "Invalid manual |
+| "a,b,c")                         | breaks format"                   |
++----------------------------------+----------------------------------+
+| Enter descending values (e.g.,   | ValidationError: "Manual breaks  |
+| "100,50,10")                     | must be in ascending order"      |
++----------------------------------+----------------------------------+
+| Enter valid ascending values     | Saves successfully; Computed     |
+| (e.g., "10,50,100")              | Breaks shows                     |
+|                                  | ``[10.0, 50.0, 100.0]``          |
++----------------------------------+----------------------------------+
+
+GIS Data Layer — Choropleth Integration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This module extends the GIS data layer form to support indicator-based
+choropleth visualization. Data layers are configured within GIS view
+definitions, not through a standalone menu — they appear as inline
+records on the GIS view form.
+
+To set up: open a GIS data layer form, set **Geo Repr** to "Choropleth
+(Color by Value)". The "Colors" section hides and the "Choropleth
+Configuration" and "Choropleth Settings" sections appear. In the
+**Choropleth Settings** section (added by this module), select an
+**Indicator Configuration** from the dropdown.
+
+When ``geo_repr`` is set to "Choropleth", two configuration paths are
+available:
+
++----------------------+-------------------------+----------------------------+
+| Path                 | Source                  | When to Use                |
++======================+=========================+============================+
+| **Value Field**      | ``choropleth_field_id`` | Simple field-based         |
+| (base ``spp_gis``)   | — picks a numeric field | coloring                   |
+|                      | directly from the       |                            |
+|                      | layer's model           |                            |
++----------------------+-------------------------+----------------------------+
+| **Indicator          | ``indicator_layer_id``  | Area-level indicator data  |
+| Configuration**      | — uses a pre-configured | from                       |
+| (this module)        | indicator layer with    | ``spp.hxl.area.indicator`` |
+|                      | CEL variables           |                            |
++----------------------+-------------------------+----------------------------+
+
+Either one satisfies the choropleth validation. Setting both is allowed;
+when an Indicator Configuration is set, it takes priority over the Value
+Field.
+
+Data Layer — Choropleth Validation Tests
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++----------------------------------+----------------------------------+
+| Action                           | Expected Result                  |
++==================================+==================================+
+| Set Geo Repr to "Choropleth"     | ValidationError: "Choropleth     |
+| with neither Value Field nor     | layers require a Value Field or  |
+| Indicator Configuration          | Indicator Configuration."        |
++----------------------------------+----------------------------------+
+| Set Geo Repr to "Choropleth"     | Saves successfully               |
+| with only Indicator              |                                  |
+| Configuration set                |                                  |
++----------------------------------+----------------------------------+
+| Set Geo Repr to "Choropleth"     | Saves successfully               |
+| with only Value Field set        |                                  |
++----------------------------------+----------------------------------+
+| Set Geo Repr to "Basic" with no  | Saves successfully (no           |
+| choropleth config                | validation)                      |
++----------------------------------+----------------------------------+
+
+Edge Cases to Verify
+~~~~~~~~~~~~~~~~~~~~
+
++----------------------------------+----------------------------------+
+| Scenario                         | Expected Behavior                |
++==================================+==================================+
+| Indicator layer with no matching | Computed Breaks is empty; Legend |
+| indicator data                   | Preview is blank                 |
++----------------------------------+----------------------------------+
+| Indicator layer where all        | Equal Interval returns empty     |
+| indicator values are identical   | breaks; Quantile returns empty   |
+|                                  | breaks; Legend shows single      |
+|                                  | class                            |
++----------------------------------+----------------------------------+
+| Color scale with exactly 2       | Works correctly; values map to   |
+| colors                           | one of two colors                |
++----------------------------------+----------------------------------+
+| Manual breaks with a single      | Creates 2 classes: "< 50.00" and |
+| value (e.g., "50")               | ">= 50.00"                       |
++----------------------------------+----------------------------------+
+| Archiving an indicator layer     | The data layer still references  |
+| used by a data layer             | it but ``get_feature_colors()``  |
+|                                  | returns no colors for inactive   |
+|                                  | config                           |
++----------------------------------+----------------------------------+
+| Deleting a color scale used by   | Standard Odoo referential        |
+| an indicator layer               | integrity behavior (blocked or   |
+|                                  | cascaded depending on            |
+|                                  | ``ondelete``)                    |
++----------------------------------+----------------------------------+
 
 Bug Tracker
 ===========

--- a/spp_gis_indicators/readme/DESCRIPTION.md
+++ b/spp_gis_indicators/readme/DESCRIPTION.md
@@ -2,46 +2,52 @@ Choropleth visualization for area-level indicators on GIS maps. Maps indicator v
 
 ### Key Capabilities
 
-- Define indicator layer configurations that link CEL variables to color scales and classification methods
-- Classify continuous indicator values into discrete color classes using quantile, equal interval, or manual breaks
-- Apply preset ColorBrewer color scales (sequential, diverging, categorical) or define custom scales
-- Compute break values automatically based on actual data distribution
+- Define indicator layer configurations linking a CEL variable to a color scale and classification method
+- Classify continuous values into discrete color classes using quantile, equal interval, or manual breaks
+- Compute break values automatically from actual data distribution
 - Generate HTML legends showing color-to-value mappings
 - Map area features to colors for choropleth rendering in GIS data layers
-- Filter indicators by period and hazard incident context
+- Filter indicators by period key and hazard incident context
+- Ship 11 preset ColorBrewer color scales (5 sequential, 4 diverging, 2 categorical)
 
 ### Key Models
 
-- **spp.gis.indicator.layer** -- Configuration linking a CEL variable to color scale and classification settings
-- **spp.gis.color.scale** -- Color scheme definition with JSON array of hex colors
-- **spp.gis.data.layer** -- Extended with choropleth geo representation option
+| Model                      | Description                                                          |
+| -------------------------- | -------------------------------------------------------------------- |
+| `spp.gis.indicator.layer`  | Configuration linking a CEL variable to color scale and class method |
+| `spp.gis.color.scale`      | Color scheme definition with JSON array of hex colors                |
+| `spp.gis.data.layer` (ext) | Extended with `indicator_layer_id` for choropleth rendering          |
 
 ### Configuration
 
 After installing:
 
 1. Navigate to **Settings > GIS Configuration > Color Scales**
-2. Review preset ColorBrewer scales (Blues, Greens, Red-Yellow-Green, etc.) or create custom scales
+2. Review the 11 preset ColorBrewer scales or create custom ones
 3. Navigate to **Settings > GIS Configuration > Indicator Layers**
-4. Create an indicator layer specifying the CEL variable, period key, color scale, and classification method
-5. In an existing GIS data layer, set `geo_repr` to `choropleth` and select the indicator layer to visualize
+4. Create an indicator layer: select the CEL variable, period key, color scale, and classification method
+5. In a GIS data layer form, set `geo_repr` to `choropleth` and select the indicator layer
 
 ### UI Location
 
 - **Menu**: Settings > GIS Configuration > Indicator Layers
 - **Menu**: Settings > GIS Configuration > Color Scales
+- **Access**: Menus restricted to `base.group_system` (Settings/System admin)
+- **Indicator form tabs**: Data Source, Visualization, Legend Preview
 
 ### Security
 
-- **spp_security.group_spp_user** -- Read
-- **spp_security.group_spp_manager** -- Read/write/create (no delete)
-- **spp_security.group_spp_admin** -- Full CRUD
+| Group                            | Color Scales | Indicator Layers |
+| -------------------------------- | ------------ | ---------------- |
+| `spp_registry.group_registry_read` | Read         | Read             |
+| `spp_security.group_spp_admin`   | Full CRUD    | Full CRUD        |
 
 ### Extension Points
 
-- Override `_compute_quantile_breaks()` or `_compute_equal_interval_breaks()` in `spp.gis.indicator.layer` to add custom classification algorithms
-- Inherit `spp.gis.color.scale` and override `get_color_for_value()` to implement custom color mapping logic
-- Extend `spp.gis.indicator.layer._get_indicator_values()` to support additional data sources beyond `spp.hxl.area.indicator`
+- Override `_compute_quantile_breaks()` or `_compute_equal_interval_breaks()` for custom classification algorithms
+- Inherit `spp.gis.color.scale` and override `get_color_for_value()` for custom color mapping
+- Extend `spp.gis.indicator.layer._get_indicator_values()` to support data sources beyond `spp.hxl.area.indicator`
+- Override `spp.gis.data.layer._get_choropleth_config()` to customize frontend choropleth config
 
 ### Dependencies
 

--- a/spp_gis_indicators/readme/USAGE.md
+++ b/spp_gis_indicators/readme/USAGE.md
@@ -1,0 +1,134 @@
+### Prerequisites
+
+- Log in as a user with **Settings / System admin** access (`base.group_system`). The GIS Configuration menus are only visible to this group.
+- The following modules must be installed: `spp_gis`, `spp_hxl_area`, `spp_registry`, `spp_security`.
+- At least one `spp.cel.variable` record and some `spp.hxl.area.indicator` records must exist for indicator layers to display meaningful data.
+
+### Color Scales — List View
+
+1. Go to **Settings > GIS Configuration > Color Scales**.
+2. The list view shows columns: **Sequence** (drag handle), **Scale Name**, **Scale Type**, **Description**, **Active**.
+3. Eleven preset ColorBrewer scales are installed as demo data (loaded with `noupdate="1"`, so they survive module upgrades).
+
+### Color Scales — Form View
+
+Open any preset scale (e.g., "Blues (Sequential)"). Verify the form shows:
+
+- **Scale Name** — e.g., "Blues (Sequential)"
+- **Scale Type** — dropdown with three options: "Sequential (low to high)", "Diverging (negative to positive)", "Categorical (distinct values)"
+- **Sequence** — numeric ordering value
+- **Description** — free-text field below a "Description" separator
+- **Colors** section — a text area labeled "Colors (JSON)" containing a JSON array of hex color codes
+- **Preview** section — static help text showing the expected JSON format
+
+To create a custom scale: click **New**, fill in **Scale Name** (required), select a **Scale Type** (defaults to "Sequential"), and enter a JSON array of at least 2 hex colors in the **Colors (JSON)** field. Valid formats: `#RGB` (3-digit) or `#RRGGBB` (6-digit), e.g., `["#f00", "#00ff00", "#0000ff"]`.
+
+To archive: open a scale, click **Action > Archive**. An "Archived" ribbon appears. Archived scales no longer appear in dropdowns on indicator layers.
+
+### Color Scale — Validation Tests
+
+| Action | Expected Result |
+|--------|----------------|
+| Enter invalid JSON (e.g., `not json`) | ValidationError: "Invalid JSON in colors_json" |
+| Enter a non-array (e.g., `{"a": 1}`) | ValidationError: "colors_json must be a JSON array" |
+| Enter fewer than 2 colors (e.g., `["#fff"]`) | ValidationError: "Color scale must have at least 2 colors" |
+| Enter a non-string element (e.g., `[123, "#fff"]`) | ValidationError: "All colors must be strings" |
+| Enter invalid hex (e.g., `["red", "#fff"]`) | ValidationError: "Invalid hex color format" |
+| Enter 5-digit hex (e.g., `["#12345"]`) | ValidationError: "Invalid hex color format" |
+
+### Indicator Layers — List and Search
+
+1. Go to **Settings > GIS Configuration > Indicator Layers**.
+2. The list view shows: **Sequence** (drag handle), **Name**, **Variable Name**, **Period Key**, **Classification Method**, **Number of Classes**, **Active**.
+3. The default search filter is "Active" (only active records shown).
+4. Search bar supports filtering by **Name**, **Variable**, and **Period Key**.
+5. Predefined filters: **Active**, **Archived** (under the Filters menu).
+6. Group By options: **Variable**, **Period**, **Classification Method**.
+
+### Indicator Layer — Form: Data Source Tab
+
+Click **New** and fill in **Configuration Name** (required). The form has three tabs: **Data Source**, **Visualization**, and **Legend Preview**.
+
+The **Data Source** tab contains:
+
+| Field | Description | Required |
+|-------|-------------|----------|
+| **Indicator Variable** | Dropdown of `spp.cel.variable` records (no inline create/open) | Yes |
+| **Period Key** | Free-text, defaults to "current". Examples: "2024-12", "current" | No |
+| **Incident/Disaster** | Dropdown of `spp.hazard.incident` records. Filters indicator data by incident. | No |
+
+### Indicator Layer — Form: Visualization Tab
+
+| Field | Description | Visibility |
+|-------|-------------|------------|
+| **Color Scale** | Dropdown of `spp.gis.color.scale` records (no inline create) | Always visible |
+| **Classification Method** | Dropdown: "Quantile (Equal count per class)", "Equal Interval (Equal range per class)", "Manual Breaks" | Always visible |
+| **Number of Classes** | Integer (2–10). Controls how many color buckets to create. | Hidden when method is "Manual Breaks" |
+| **Manual Break Points** | Comma-separated numbers, e.g., "10,50,100,500" | Only visible when method is "Manual Breaks" |
+| **Computed Breaks** (read-only) | Shows the computed break values as a JSON array | Always visible (in "Computed Classification" section) |
+
+Classification method behavior:
+
+- **Quantile**: Breaks computed so each class contains approximately the same number of areas. Requires indicator data. If no data, Computed Breaks is empty.
+- **Equal Interval**: Breaks evenly spaced between minimum and maximum indicator values. If all values are equal, Computed Breaks is empty.
+- **Manual Breaks**: Uses user-supplied break points directly. Does not depend on indicator data.
+
+### Indicator Layer — Form: Legend Preview Tab
+
+- Displays a read-only HTML preview of the legend.
+- Each legend item shows a colored box and a label with the value range (e.g., "< 10.00", "10.00 - 50.00", ">= 500.00").
+- The legend updates automatically when break values or color scale changes.
+
+### Indicator Layer — Validation Tests
+
+**Number of Classes:**
+
+| Action | Expected Result |
+|--------|----------------|
+| Set Number of Classes to 1 | ValidationError: "Number of classes must be at least 2" |
+| Set Number of Classes to 11 | ValidationError: "Number of classes must not exceed 10" |
+| Set Number of Classes to 5 | Saves successfully |
+
+**Manual Breaks:**
+
+| Action | Expected Result |
+|--------|----------------|
+| Select "Manual Breaks" but leave the field empty | ValidationError: "Manual breaks are required when using manual classification" |
+| Enter non-numeric text (e.g., "a,b,c") | ValidationError: "Invalid manual breaks format" |
+| Enter descending values (e.g., "100,50,10") | ValidationError: "Manual breaks must be in ascending order" |
+| Enter valid ascending values (e.g., "10,50,100") | Saves successfully; Computed Breaks shows `[10.0, 50.0, 100.0]` |
+
+### GIS Data Layer — Choropleth Integration
+
+This module extends the GIS data layer form to support indicator-based choropleth visualization. Data layers are configured within GIS view definitions, not through a standalone menu — they appear as inline records on the GIS view form.
+
+To set up: open a GIS data layer form, set **Geo Repr** to "Choropleth (Color by Value)". The "Colors" section hides and the "Choropleth Configuration" and "Choropleth Settings" sections appear. In the **Choropleth Settings** section (added by this module), select an **Indicator Configuration** from the dropdown.
+
+When `geo_repr` is set to "Choropleth", two configuration paths are available:
+
+| Path | Source | When to Use |
+|------|--------|-------------|
+| **Value Field** (base `spp_gis`) | `choropleth_field_id` — picks a numeric field directly from the layer's model | Simple field-based coloring |
+| **Indicator Configuration** (this module) | `indicator_layer_id` — uses a pre-configured indicator layer with CEL variables | Area-level indicator data from `spp.hxl.area.indicator` |
+
+Either one satisfies the choropleth validation. Setting both is allowed; when an Indicator Configuration is set, it takes priority over the Value Field.
+
+### Data Layer — Choropleth Validation Tests
+
+| Action | Expected Result |
+|--------|----------------|
+| Set Geo Repr to "Choropleth" with neither Value Field nor Indicator Configuration | ValidationError: "Choropleth layers require a Value Field or Indicator Configuration." |
+| Set Geo Repr to "Choropleth" with only Indicator Configuration set | Saves successfully |
+| Set Geo Repr to "Choropleth" with only Value Field set | Saves successfully |
+| Set Geo Repr to "Basic" with no choropleth config | Saves successfully (no validation) |
+
+### Edge Cases to Verify
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| Indicator layer with no matching indicator data | Computed Breaks is empty; Legend Preview is blank |
+| Indicator layer where all indicator values are identical | Equal Interval returns empty breaks; Quantile returns empty breaks; Legend shows single class |
+| Color scale with exactly 2 colors | Works correctly; values map to one of two colors |
+| Manual breaks with a single value (e.g., "50") | Creates 2 classes: "< 50.00" and ">= 50.00" |
+| Archiving an indicator layer used by a data layer | The data layer still references it but `get_feature_colors()` returns no colors for inactive config |
+| Deleting a color scale used by an indicator layer | Standard Odoo referential integrity behavior (blocked or cascaded depending on `ondelete`) |

--- a/spp_gis_indicators/static/description/index.html
+++ b/spp_gis_indicators/static/description/index.html
@@ -378,42 +378,58 @@ legend generation.</p>
 <div class="section" id="key-capabilities">
 <h1>Key Capabilities</h1>
 <ul class="simple">
-<li>Define indicator layer configurations that link CEL variables to color
-scales and classification methods</li>
-<li>Classify continuous indicator values into discrete color classes using
-quantile, equal interval, or manual breaks</li>
-<li>Apply preset ColorBrewer color scales (sequential, diverging,
-categorical) or define custom scales</li>
-<li>Compute break values automatically based on actual data distribution</li>
+<li>Define indicator layer configurations linking a CEL variable to a
+color scale and classification method</li>
+<li>Classify continuous values into discrete color classes using quantile,
+equal interval, or manual breaks</li>
+<li>Compute break values automatically from actual data distribution</li>
 <li>Generate HTML legends showing color-to-value mappings</li>
 <li>Map area features to colors for choropleth rendering in GIS data
 layers</li>
-<li>Filter indicators by period and hazard incident context</li>
+<li>Filter indicators by period key and hazard incident context</li>
+<li>Ship 11 preset ColorBrewer color scales (5 sequential, 4 diverging, 2
+categorical)</li>
 </ul>
 </div>
 <div class="section" id="key-models">
 <h1>Key Models</h1>
-<ul class="simple">
-<li><strong>spp.gis.indicator.layer</strong> – Configuration linking a CEL variable to
-color scale and classification settings</li>
-<li><strong>spp.gis.color.scale</strong> – Color scheme definition with JSON array of
-hex colors</li>
-<li><strong>spp.gis.data.layer</strong> – Extended with choropleth geo representation
-option</li>
-</ul>
+<table border="1" class="docutils">
+<colgroup>
+<col width="43%" />
+<col width="57%" />
+</colgroup>
+<thead valign="bottom">
+<tr><th class="head">Model</th>
+<th class="head">Description</th>
+</tr>
+</thead>
+<tbody valign="top">
+<tr><td><tt class="docutils literal">spp.gis.indicator.layer</tt></td>
+<td>Configuration linking a CEL variable
+to color scale and class method</td>
+</tr>
+<tr><td><tt class="docutils literal">spp.gis.color.scale</tt></td>
+<td>Color scheme definition with JSON
+array of hex colors</td>
+</tr>
+<tr><td><tt class="docutils literal">spp.gis.data.layer</tt> (ext)</td>
+<td>Extended with <tt class="docutils literal">indicator_layer_id</tt>
+for choropleth rendering</td>
+</tr>
+</tbody>
+</table>
 </div>
 <div class="section" id="configuration">
 <h1>Configuration</h1>
 <p>After installing:</p>
 <ol class="arabic simple">
 <li>Navigate to <strong>Settings &gt; GIS Configuration &gt; Color Scales</strong></li>
-<li>Review preset ColorBrewer scales (Blues, Greens, Red-Yellow-Green,
-etc.) or create custom scales</li>
+<li>Review the 11 preset ColorBrewer scales or create custom ones</li>
 <li>Navigate to <strong>Settings &gt; GIS Configuration &gt; Indicator Layers</strong></li>
-<li>Create an indicator layer specifying the CEL variable, period key,
-color scale, and classification method</li>
-<li>In an existing GIS data layer, set <tt class="docutils literal">geo_repr</tt> to <tt class="docutils literal">choropleth</tt> and
-select the indicator layer to visualize</li>
+<li>Create an indicator layer: select the CEL variable, period key, color
+scale, and classification method</li>
+<li>In a GIS data layer form, set <tt class="docutils literal">geo_repr</tt> to <tt class="docutils literal">choropleth</tt> and
+select the indicator layer</li>
 </ol>
 </div>
 <div class="section" id="ui-location">
@@ -421,26 +437,49 @@ select the indicator layer to visualize</li>
 <ul class="simple">
 <li><strong>Menu</strong>: Settings &gt; GIS Configuration &gt; Indicator Layers</li>
 <li><strong>Menu</strong>: Settings &gt; GIS Configuration &gt; Color Scales</li>
+<li><strong>Access</strong>: Menus restricted to <tt class="docutils literal">base.group_system</tt> (Settings/System
+admin)</li>
+<li><strong>Indicator form tabs</strong>: Data Source, Visualization, Legend Preview</li>
 </ul>
 </div>
 <div class="section" id="security">
 <h1>Security</h1>
-<ul class="simple">
-<li><strong>spp_security.group_spp_user</strong> – Read</li>
-<li><strong>spp_security.group_spp_manager</strong> – Read/write/create (no delete)</li>
-<li><strong>spp_security.group_spp_admin</strong> – Full CRUD</li>
-</ul>
+<table border="1" class="docutils">
+<colgroup>
+<col width="56%" />
+<col width="19%" />
+<col width="25%" />
+</colgroup>
+<thead valign="bottom">
+<tr><th class="head">Group</th>
+<th class="head">Color Scales</th>
+<th class="head">Indicator Layers</th>
+</tr>
+</thead>
+<tbody valign="top">
+<tr><td><tt class="docutils literal">spp_registry.group_registry_read</tt></td>
+<td>Read</td>
+<td>Read</td>
+</tr>
+<tr><td><tt class="docutils literal">spp_security.group_spp_admin</tt></td>
+<td>Full CRUD</td>
+<td>Full CRUD</td>
+</tr>
+</tbody>
+</table>
 </div>
 <div class="section" id="extension-points">
 <h1>Extension Points</h1>
 <ul class="simple">
 <li>Override <tt class="docutils literal">_compute_quantile_breaks()</tt> or
-<tt class="docutils literal">_compute_equal_interval_breaks()</tt> in <tt class="docutils literal">spp.gis.indicator.layer</tt> to
-add custom classification algorithms</li>
+<tt class="docutils literal">_compute_equal_interval_breaks()</tt> for custom classification
+algorithms</li>
 <li>Inherit <tt class="docutils literal">spp.gis.color.scale</tt> and override <tt class="docutils literal">get_color_for_value()</tt>
-to implement custom color mapping logic</li>
+for custom color mapping</li>
 <li>Extend <tt class="docutils literal">spp.gis.indicator.layer._get_indicator_values()</tt> to support
-additional data sources beyond <tt class="docutils literal">spp.hxl.area.indicator</tt></li>
+data sources beyond <tt class="docutils literal">spp.hxl.area.indicator</tt></li>
+<li>Override <tt class="docutils literal">spp.gis.data.layer._get_choropleth_config()</tt> to customize
+frontend choropleth config</li>
 </ul>
 </div>
 <div class="section" id="dependencies">
@@ -449,16 +488,453 @@ additional data sources beyond <tt class="docutils literal">spp.hxl.area.indicat
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-1">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-2">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-3">Authors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-4">Maintainers</a></li>
-</ul>
-</li>
+<li><a class="reference internal" href="#usage" id="toc-entry-1">Usage</a></li>
 </ul>
 </div>
+<div class="section" id="usage">
+<h2><a class="toc-backref" href="#toc-entry-1">Usage</a></h2>
+</div>
+</div>
+<div class="section" id="prerequisites">
+<h1>Prerequisites</h1>
+<ul class="simple">
+<li>Log in as a user with <strong>Settings / System admin</strong> access
+(<tt class="docutils literal">base.group_system</tt>). The GIS Configuration menus are only visible
+to this group.</li>
+<li>The following modules must be installed: <tt class="docutils literal">spp_gis</tt>,
+<tt class="docutils literal">spp_hxl_area</tt>, <tt class="docutils literal">spp_registry</tt>, <tt class="docutils literal">spp_security</tt>.</li>
+<li>At least one <tt class="docutils literal">spp.cel.variable</tt> record and some
+<tt class="docutils literal">spp.hxl.area.indicator</tt> records must exist for indicator layers to
+display meaningful data.</li>
+</ul>
+</div>
+<div class="section" id="color-scales-list-view">
+<h1>Color Scales — List View</h1>
+<ol class="arabic simple">
+<li>Go to <strong>Settings &gt; GIS Configuration &gt; Color Scales</strong>.</li>
+<li>The list view shows columns: <strong>Sequence</strong> (drag handle), <strong>Scale
+Name</strong>, <strong>Scale Type</strong>, <strong>Description</strong>, <strong>Active</strong>.</li>
+<li>Eleven preset ColorBrewer scales are installed as demo data (loaded
+with <tt class="docutils literal"><span class="pre">noupdate=&quot;1&quot;</span></tt>, so they survive module upgrades).</li>
+</ol>
+</div>
+<div class="section" id="color-scales-form-view">
+<h1>Color Scales — Form View</h1>
+<p>Open any preset scale (e.g., “Blues (Sequential)”). Verify the form
+shows:</p>
+<ul class="simple">
+<li><strong>Scale Name</strong> — e.g., “Blues (Sequential)”</li>
+<li><strong>Scale Type</strong> — dropdown with three options: “Sequential (low to
+high)”, “Diverging (negative to positive)”, “Categorical (distinct
+values)”</li>
+<li><strong>Sequence</strong> — numeric ordering value</li>
+<li><strong>Description</strong> — free-text field below a “Description” separator</li>
+<li><strong>Colors</strong> section — a text area labeled “Colors (JSON)” containing a
+JSON array of hex color codes</li>
+<li><strong>Preview</strong> section — static help text showing the expected JSON
+format</li>
+</ul>
+<p>To create a custom scale: click <strong>New</strong>, fill in <strong>Scale Name</strong>
+(required), select a <strong>Scale Type</strong> (defaults to “Sequential”), and
+enter a JSON array of at least 2 hex colors in the <strong>Colors (JSON)</strong>
+field. Valid formats: <tt class="docutils literal">#RGB</tt> (3-digit) or <tt class="docutils literal">#RRGGBB</tt> (6-digit), e.g.,
+<tt class="docutils literal"><span class="pre">[&quot;#f00&quot;,</span> &quot;#00ff00&quot;, &quot;#0000ff&quot;]</tt>.</p>
+<p>To archive: open a scale, click <strong>Action &gt; Archive</strong>. An “Archived”
+ribbon appears. Archived scales no longer appear in dropdowns on
+indicator layers.</p>
+</div>
+<div class="section" id="color-scale-validation-tests">
+<h1>Color Scale — Validation Tests</h1>
+<table border="1" class="docutils">
+<colgroup>
+<col width="50%" />
+<col width="50%" />
+</colgroup>
+<thead valign="bottom">
+<tr><th class="head">Action</th>
+<th class="head">Expected Result</th>
+</tr>
+</thead>
+<tbody valign="top">
+<tr><td>Enter invalid JSON (e.g.,
+<tt class="docutils literal">not json</tt>)</td>
+<td>ValidationError: “Invalid JSON
+in colors_json”</td>
+</tr>
+<tr><td>Enter a non-array (e.g.,
+<tt class="docutils literal">{&quot;a&quot;: 1}</tt>)</td>
+<td>ValidationError: “colors_json
+must be a JSON array”</td>
+</tr>
+<tr><td>Enter fewer than 2 colors (e.g.,
+<tt class="docutils literal"><span class="pre">[&quot;#fff&quot;]</span></tt>)</td>
+<td>ValidationError: “Color scale
+must have at least 2 colors”</td>
+</tr>
+<tr><td>Enter a non-string element
+(e.g., <tt class="docutils literal">[123, &quot;#fff&quot;]</tt>)</td>
+<td>ValidationError: “All colors
+must be strings”</td>
+</tr>
+<tr><td>Enter invalid hex (e.g.,
+<tt class="docutils literal">[&quot;red&quot;, &quot;#fff&quot;]</tt>)</td>
+<td>ValidationError: “Invalid hex
+color format”</td>
+</tr>
+<tr><td>Enter 5-digit hex (e.g.,
+<tt class="docutils literal"><span class="pre">[&quot;#12345&quot;]</span></tt>)</td>
+<td>ValidationError: “Invalid hex
+color format”</td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="section" id="indicator-layers-list-and-search">
+<h1>Indicator Layers — List and Search</h1>
+<ol class="arabic simple">
+<li>Go to <strong>Settings &gt; GIS Configuration &gt; Indicator Layers</strong>.</li>
+<li>The list view shows: <strong>Sequence</strong> (drag handle), <strong>Name</strong>, <strong>Variable
+Name</strong>, <strong>Period Key</strong>, <strong>Classification Method</strong>, <strong>Number of
+Classes</strong>, <strong>Active</strong>.</li>
+<li>The default search filter is “Active” (only active records shown).</li>
+<li>Search bar supports filtering by <strong>Name</strong>, <strong>Variable</strong>, and <strong>Period
+Key</strong>.</li>
+<li>Predefined filters: <strong>Active</strong>, <strong>Archived</strong> (under the Filters
+menu).</li>
+<li>Group By options: <strong>Variable</strong>, <strong>Period</strong>, <strong>Classification
+Method</strong>.</li>
+</ol>
+</div>
+<div class="section" id="indicator-layer-form-data-source-tab">
+<h1>Indicator Layer — Form: Data Source Tab</h1>
+<p>Click <strong>New</strong> and fill in <strong>Configuration Name</strong> (required). The form
+has three tabs: <strong>Data Source</strong>, <strong>Visualization</strong>, and <strong>Legend
+Preview</strong>.</p>
+<p>The <strong>Data Source</strong> tab contains:</p>
+<table border="1" class="docutils">
+<colgroup>
+<col width="43%" />
+<col width="43%" />
+<col width="15%" />
+</colgroup>
+<thead valign="bottom">
+<tr><th class="head">Field</th>
+<th class="head">Description</th>
+<th class="head">Required</th>
+</tr>
+</thead>
+<tbody valign="top">
+<tr><td><strong>Indicator Variable</strong></td>
+<td>Dropdown of
+<tt class="docutils literal">spp.cel.variable</tt>
+records (no inline
+create/open)</td>
+<td>Yes</td>
+</tr>
+<tr><td><strong>Period Key</strong></td>
+<td>Free-text, defaults to
+“current”. Examples:
+“2024-12”, “current”</td>
+<td>No</td>
+</tr>
+<tr><td><strong>Incident/Disaster</strong></td>
+<td>Dropdown of
+<tt class="docutils literal">spp.hazard.incident</tt>
+records. Filters indicator
+data by incident.</td>
+<td>No</td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="section" id="indicator-layer-form-visualization-tab">
+<h1>Indicator Layer — Form: Visualization Tab</h1>
+<table border="1" class="docutils">
+<colgroup>
+<col width="32%" />
+<col width="36%" />
+<col width="32%" />
+</colgroup>
+<thead valign="bottom">
+<tr><th class="head">Field</th>
+<th class="head">Description</th>
+<th class="head">Visibility</th>
+</tr>
+</thead>
+<tbody valign="top">
+<tr><td><strong>Color Scale</strong></td>
+<td>Dropdown of
+<tt class="docutils literal">spp.gis.color.scale</tt>
+records (no inline
+create)</td>
+<td>Always visible</td>
+</tr>
+<tr><td><strong>Classification
+Method</strong></td>
+<td>Dropdown: “Quantile
+(Equal count per
+class)”, “Equal
+Interval (Equal range
+per class)”, “Manual
+Breaks”</td>
+<td>Always visible</td>
+</tr>
+<tr><td><strong>Number of
+Classes</strong></td>
+<td>Integer (2–10).
+Controls how many color
+buckets to create.</td>
+<td>Hidden when method
+is “Manual Breaks”</td>
+</tr>
+<tr><td><strong>Manual Break
+Points</strong></td>
+<td>Comma-separated
+numbers, e.g.,
+“10,50,100,500”</td>
+<td>Only visible when
+method is “Manual
+Breaks”</td>
+</tr>
+<tr><td><strong>Computed Breaks</strong>
+(read-only)</td>
+<td>Shows the computed
+break values as a JSON
+array</td>
+<td>Always visible (in
+“Computed
+Classification”
+section)</td>
+</tr>
+</tbody>
+</table>
+<p>Classification method behavior:</p>
+<ul class="simple">
+<li><strong>Quantile</strong>: Breaks computed so each class contains approximately the
+same number of areas. Requires indicator data. If no data, Computed
+Breaks is empty.</li>
+<li><strong>Equal Interval</strong>: Breaks evenly spaced between minimum and maximum
+indicator values. If all values are equal, Computed Breaks is empty.</li>
+<li><strong>Manual Breaks</strong>: Uses user-supplied break points directly. Does not
+depend on indicator data.</li>
+</ul>
+</div>
+<div class="section" id="indicator-layer-form-legend-preview-tab">
+<h1>Indicator Layer — Form: Legend Preview Tab</h1>
+<ul class="simple">
+<li>Displays a read-only HTML preview of the legend.</li>
+<li>Each legend item shows a colored box and a label with the value range
+(e.g., “&lt; 10.00”, “10.00 - 50.00”, “&gt;= 500.00”).</li>
+<li>The legend updates automatically when break values or color scale
+changes.</li>
+</ul>
+</div>
+<div class="section" id="indicator-layer-validation-tests">
+<h1>Indicator Layer — Validation Tests</h1>
+<p><strong>Number of Classes:</strong></p>
+<table border="1" class="docutils">
+<colgroup>
+<col width="42%" />
+<col width="58%" />
+</colgroup>
+<thead valign="bottom">
+<tr><th class="head">Action</th>
+<th class="head">Expected Result</th>
+</tr>
+</thead>
+<tbody valign="top">
+<tr><td>Set Number of Classes to 1</td>
+<td>ValidationError: “Number of classes
+must be at least 2”</td>
+</tr>
+<tr><td>Set Number of Classes to 11</td>
+<td>ValidationError: “Number of classes
+must not exceed 10”</td>
+</tr>
+<tr><td>Set Number of Classes to 5</td>
+<td>Saves successfully</td>
+</tr>
+</tbody>
+</table>
+<p><strong>Manual Breaks:</strong></p>
+<table border="1" class="docutils">
+<colgroup>
+<col width="50%" />
+<col width="50%" />
+</colgroup>
+<thead valign="bottom">
+<tr><th class="head">Action</th>
+<th class="head">Expected Result</th>
+</tr>
+</thead>
+<tbody valign="top">
+<tr><td>Select “Manual Breaks” but leave
+the field empty</td>
+<td>ValidationError: “Manual breaks
+are required when using manual
+classification”</td>
+</tr>
+<tr><td>Enter non-numeric text (e.g.,
+“a,b,c”)</td>
+<td>ValidationError: “Invalid manual
+breaks format”</td>
+</tr>
+<tr><td>Enter descending values (e.g.,
+“100,50,10”)</td>
+<td>ValidationError: “Manual breaks
+must be in ascending order”</td>
+</tr>
+<tr><td>Enter valid ascending values
+(e.g., “10,50,100”)</td>
+<td>Saves successfully; Computed
+Breaks shows
+<tt class="docutils literal">[10.0, 50.0, 100.0]</tt></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="section" id="gis-data-layer-choropleth-integration">
+<h1>GIS Data Layer — Choropleth Integration</h1>
+<p>This module extends the GIS data layer form to support indicator-based
+choropleth visualization. Data layers are configured within GIS view
+definitions, not through a standalone menu — they appear as inline
+records on the GIS view form.</p>
+<p>To set up: open a GIS data layer form, set <strong>Geo Repr</strong> to “Choropleth
+(Color by Value)”. The “Colors” section hides and the “Choropleth
+Configuration” and “Choropleth Settings” sections appear. In the
+<strong>Choropleth Settings</strong> section (added by this module), select an
+<strong>Indicator Configuration</strong> from the dropdown.</p>
+<p>When <tt class="docutils literal">geo_repr</tt> is set to “Choropleth”, two configuration paths are
+available:</p>
+<table border="1" class="docutils">
+<colgroup>
+<col width="29%" />
+<col width="33%" />
+<col width="37%" />
+</colgroup>
+<thead valign="bottom">
+<tr><th class="head">Path</th>
+<th class="head">Source</th>
+<th class="head">When to Use</th>
+</tr>
+</thead>
+<tbody valign="top">
+<tr><td><strong>Value Field</strong>
+(base <tt class="docutils literal">spp_gis</tt>)</td>
+<td><tt class="docutils literal">choropleth_field_id</tt>
+— picks a numeric field
+directly from the
+layer’s model</td>
+<td>Simple field-based
+coloring</td>
+</tr>
+<tr><td><strong>Indicator
+Configuration</strong>
+(this module)</td>
+<td><tt class="docutils literal">indicator_layer_id</tt>
+— uses a pre-configured
+indicator layer with
+CEL variables</td>
+<td>Area-level indicator data
+from
+<tt class="docutils literal">spp.hxl.area.indicator</tt></td>
+</tr>
+</tbody>
+</table>
+<p>Either one satisfies the choropleth validation. Setting both is allowed;
+when an Indicator Configuration is set, it takes priority over the Value
+Field.</p>
+</div>
+<div class="section" id="data-layer-choropleth-validation-tests">
+<h1>Data Layer — Choropleth Validation Tests</h1>
+<table border="1" class="docutils">
+<colgroup>
+<col width="50%" />
+<col width="50%" />
+</colgroup>
+<thead valign="bottom">
+<tr><th class="head">Action</th>
+<th class="head">Expected Result</th>
+</tr>
+</thead>
+<tbody valign="top">
+<tr><td>Set Geo Repr to “Choropleth”
+with neither Value Field nor
+Indicator Configuration</td>
+<td>ValidationError: “Choropleth
+layers require a Value Field or
+Indicator Configuration.”</td>
+</tr>
+<tr><td>Set Geo Repr to “Choropleth”
+with only Indicator
+Configuration set</td>
+<td>Saves successfully</td>
+</tr>
+<tr><td>Set Geo Repr to “Choropleth”
+with only Value Field set</td>
+<td>Saves successfully</td>
+</tr>
+<tr><td>Set Geo Repr to “Basic” with no
+choropleth config</td>
+<td>Saves successfully (no
+validation)</td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="section" id="edge-cases-to-verify">
+<h1>Edge Cases to Verify</h1>
+<table border="1" class="docutils">
+<colgroup>
+<col width="50%" />
+<col width="50%" />
+</colgroup>
+<thead valign="bottom">
+<tr><th class="head">Scenario</th>
+<th class="head">Expected Behavior</th>
+</tr>
+</thead>
+<tbody valign="top">
+<tr><td>Indicator layer with no matching
+indicator data</td>
+<td>Computed Breaks is empty; Legend
+Preview is blank</td>
+</tr>
+<tr><td>Indicator layer where all
+indicator values are identical</td>
+<td>Equal Interval returns empty
+breaks; Quantile returns empty
+breaks; Legend shows single
+class</td>
+</tr>
+<tr><td>Color scale with exactly 2
+colors</td>
+<td>Works correctly; values map to
+one of two colors</td>
+</tr>
+<tr><td>Manual breaks with a single
+value (e.g., “50”)</td>
+<td>Creates 2 classes: “&lt; 50.00” and
+“&gt;= 50.00”</td>
+</tr>
+<tr><td>Archiving an indicator layer
+used by a data layer</td>
+<td>The data layer still references
+it but <tt class="docutils literal">get_feature_colors()</tt>
+returns no colors for inactive
+config</td>
+</tr>
+<tr><td>Deleting a color scale used by
+an indicator layer</td>
+<td>Standard Odoo referential
+integrity behavior (blocked or
+cascaded depending on
+<tt class="docutils literal">ondelete</tt>)</td>
+</tr>
+</tbody>
+</table>
 <div class="section" id="bug-tracker">
-<h2><a class="toc-backref" href="#toc-entry-1">Bug Tracker</a></h2>
+<h2>Bug Tracker</h2>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OpenSPP/OpenSPP2/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -466,15 +942,15 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h2><a class="toc-backref" href="#toc-entry-2">Credits</a></h2>
+<h2>Credits</h2>
 <div class="section" id="authors">
-<h3><a class="toc-backref" href="#toc-entry-3">Authors</a></h3>
+<h3>Authors</h3>
 <ul class="simple">
 <li>OpenSPP.org</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h3><a class="toc-backref" href="#toc-entry-4">Maintainers</a></h3>
+<h3>Maintainers</h3>
 <p>This module is part of the <a class="reference external" href="https://github.com/OpenSPP/OpenSPP2/tree/19.0/spp_gis_indicators">OpenSPP/OpenSPP2</a> project on GitHub.</p>
 <p>You are welcome to contribute.</p>
 </div>


### PR DESCRIPTION
## Summary                                                                                                                                                                                                 
                                                                                                                                                                                                             
  - Fix inaccurate security groups, key models format, and menu access details in `DESCRIPTION.md`                                                                                                           
  - Add `USAGE.md` with a comprehensive UI testing guide for QAs                                                                                                                                             
                                                                
  ## Details                                                                                                                                                                                                 
                                                            
  ### DESCRIPTION.md fixes
  - Corrected security groups from fabricated `spp_security.group_spp_user` / `spp_security.group_spp_manager` to actual ACL entries: `spp_registry.group_registry_read` (Read) and                          
  `spp_security.group_spp_admin` (Full CRUD)                                                                                                                                       
  - Changed Key Models from bullet list to table format per module-descriptions template                                                                                                                     
  - Added menu access restriction note (`base.group_system`)                            
  - Added indicator form tab names (Data Source, Visualization, Legend Preview)                                                                                                                              
  - Added missing `_get_choropleth_config()` extension point                                                                                                                                                 
  - Added concrete count of preset color scales (11)                                                                                                                                                         
                                                                                                                                                                                                             
  ### USAGE.md (new)                                        
  QA-oriented UI testing guide covering:                                                                                                                                                                     
  - Color scales: list view, form fields, creating custom scales, archiving, 6 validation test cases
  - Indicator layers: list/search, all 3 form tabs, classification method behavior, validation tests for number of classes and manual breaks                                                                 
  - GIS data layer choropleth integration: two config paths (Value Field vs Indicator Configuration), priority rules, 4 validation test cases
  - Edge cases: empty data, identical values, 2-color scales, single break point, archiving/deletion                                                                                                         
                                                                                                                                                                                                             
  ## Test plan                                                                                                                                                                                               
  - [x] `./scripts/test_single_module.sh spp_gis_indicators` — 84 tests passed                                                                                                                               
  - [x] `pre-commit run` — all hooks passed                 
  - [x] No code changes — documentation only   