### PR TITLE
fix(spp_import_match)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -170,6 +170,8 @@ services:
 
   # Job Worker - background service for processing async queue jobs
   # Runs alongside openspp/openspp-dev to execute delayed imports, etc.
+  # The runner auto-discovers databases every 5 minutes, so after installing
+  # new modules, jobs will be picked up within 5 minutes (or restart to force).
   jobworker:
     image: openspp-dev
     profiles:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -168,6 +168,44 @@ services:
     networks:
       - openspp
 
+  # Job Worker - background service for processing async queue jobs
+  # Runs alongside openspp/openspp-dev to execute delayed imports, etc.
+  jobworker:
+    image: openspp-dev
+    profiles:
+      - dev
+      - ui
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      DB_HOST: db
+      DB_PORT: "5432"
+      DB_USER: odoo
+      DB_PASSWORD: odoo
+      DB_NAME: ${ODOO_DB_NAME:-openspp}
+      DB_FILTER: "^${ODOO_DB_NAME:-openspp}$$"
+      LIST_DB: "False"
+      ODOO_ADMIN_PASSWD: admin
+      ODOO_WORKERS: "0"
+      ODOO_CRON_THREADS: "0"
+      LOG_LEVEL: info
+      PROXY_MODE: "False"
+      QUEUE_JOB_CONCURRENCY: "2"
+    volumes:
+      - .:/mnt/extra-addons/openspp:ro,z
+      - odoo_data:/var/lib/odoo
+    entrypoint: ["/entrypoint.sh"]
+    command:
+      [
+        "python",
+        "/mnt/extra-addons/odoo-job-worker/job_worker_runner.py",
+        "-c",
+        "/etc/odoo/odoo.conf",
+      ]
+    networks:
+      - openspp
+
   # Unit Test Runner - one-off container for running module tests
   # Usage: docker compose run --rm test <module_name> [options]
   # Note: Uses same image as odoo/odoo-dev - build any of them to update

--- a/spp
+++ b/spp
@@ -726,8 +726,8 @@ def cmd_resetdb(args):
     # Ensure db is running
     run(docker_compose("up", "-d", "db"))
 
-    # Stop Odoo but keep db
-    run(docker_compose("stop", "openspp", "openspp-dev"), check=False)
+    # Stop Odoo and job worker but keep db
+    run(docker_compose("stop", "openspp", "openspp-dev", "jobworker"), check=False)
 
     # Wait for db to be ready
     print("Waiting for database...")

--- a/spp_import_match/README.rst
+++ b/spp_import_match/README.rst
@@ -46,15 +46,15 @@ Key Capabilities
 Key Models
 ~~~~~~~~~~
 
-+-----------------------------+---------------------------------------+
-| Model                       | Description                           |
-+=============================+=======================================+
-| ``spp.import.match``        | Matching rule configuration for a     |
-|                             | specific model                        |
-+-----------------------------+---------------------------------------+
-| ``spp.import.match.fields`` | Individual field in a rule, with      |
-|                             | optional sub-field                    |
-+-----------------------------+---------------------------------------+
++-----------------------------+----------------------------------------+
+| Model                       | Description                            |
++=============================+========================================+
+| ``spp.import.match``        | Matching rule configuration for a      |
+|                             | specific model                         |
++-----------------------------+----------------------------------------+
+| ``spp.import.match.fields`` | Individual field in a rule, with       |
+|                             | optional sub-field                     |
++-----------------------------+----------------------------------------+
 
 Configuration
 ~~~~~~~~~~~~~

--- a/spp_import_match/README.rst
+++ b/spp_import_match/README.rst
@@ -46,15 +46,15 @@ Key Capabilities
 Key Models
 ~~~~~~~~~~
 
-+-----------------------------+----------------------------------------+
-| Model                       | Description                            |
-+=============================+========================================+
-| ``spp.import.match``        | Matching rule configuration for a      |
-|                             | specific model                         |
-+-----------------------------+----------------------------------------+
-| ``spp.import.match.fields`` | Individual field in a rule, with       |
-|                             | optional sub-field                     |
-+-----------------------------+----------------------------------------+
++-----------------------------+---------------------------------------+
+| Model                       | Description                           |
++=============================+=======================================+
+| ``spp.import.match``        | Matching rule configuration for a     |
+|                             | specific model                        |
++-----------------------------+---------------------------------------+
+| ``spp.import.match.fields`` | Individual field in a rule, with      |
+|                             | optional sub-field                    |
++-----------------------------+---------------------------------------+
 
 Configuration
 ~~~~~~~~~~~~~

--- a/spp_import_match/README.rst
+++ b/spp_import_match/README.rst
@@ -33,16 +33,15 @@ Key Capabilities
 
 - Define matching rules per model using field combinations to identify
   existing records
-- Match on sub-fields within related records (e.g., household ID within
-  individual)
-- Apply conditional matching rules only when specific imported values
-  are present
+- Match on sub-fields within related records (e.g., ``parent_id/name``)
+- Apply conditional matching rules only when a specific imported value
+  is present
 - Skip duplicate creation or update existing records when matches are
   found
-- Process imports with more than 100 records asynchronously using
-  ``job_worker``
-- Clear one2many/many2many associations before update to prevent
-  duplicate entries
+- Split imports exceeding 100 rows into chunks and process
+  asynchronously via ``job_worker``
+- Strip falsy one2many/many2many values on write to prevent duplicate
+  relational entries
 
 Key Models
 ~~~~~~~~~~
@@ -53,8 +52,8 @@ Key Models
 | ``spp.import.match``        | Matching rule configuration for a      |
 |                             | specific model                         |
 +-----------------------------+----------------------------------------+
-| ``spp.import.match.fields`` | Individual fields used in a rule,      |
-|                             | supports sub-fields                    |
+| ``spp.import.match.fields`` | Individual field in a rule, with       |
+|                             | optional sub-field                     |
 +-----------------------------+----------------------------------------+
 
 Configuration
@@ -63,23 +62,21 @@ Configuration
 After installing:
 
 1. Navigate to **Registry > Configuration > Import Match**
-2. Create a new matching rule and select the target model (e.g.,
+2. Create a matching rule and select the target model (e.g.,
    ``res.partner``)
 3. Add one or more fields to match on (e.g., national ID, or first name
    + date of birth)
 4. Enable **Overwrite Match** to update existing records when matches
    are found
 5. For conditional matching, enable **Is Conditional** on a field and
-   specify the expected imported value
+   set the expected imported value
 
 UI Location
 ~~~~~~~~~~~
 
 - **Menu**: Registry > Configuration > Import Match
-- **Import Dialog**: Matching applies automatically during CSV import
-  via the standard Odoo import interface
-- **Queue Jobs**: Registry > Queue Jobs > Jobs (to monitor asynchronous
-  imports)
+- **Import Dialog**: Select a matching rule and overwrite option from
+  the import sidebar
 
 Security
 ~~~~~~~~
@@ -94,11 +91,11 @@ Extension Points
 ~~~~~~~~~~~~~~~~
 
 - Override ``spp.import.match._match_find()`` to customize matching
-  logic for specific use cases
+  logic
 - Override ``spp.import.match._usable_rules()`` to filter which rules
   apply based on context
-- Inherits ``base.load()`` to inject matching logic into all model
-  imports
+- Overrides ``base.load()`` to inject matching into all model imports
+- Overrides ``base.write()`` to strip falsy one2many/many2many values
 
 Dependencies
 ~~~~~~~~~~~~
@@ -110,6 +107,288 @@ Dependencies
 
 .. contents::
    :local:
+
+Usage
+=====
+
+Prerequisites
+-------------
+
+- The module **OpenSPP Import Match** is installed
+- You are logged in as a user with the **SPP Admin**
+  (``spp_security.group_spp_admin``) role
+
+Test 1: Create a Matching Rule
+------------------------------
+
+**Steps:**
+
+1.  Navigate to **Registry > Configuration > Import Match**
+2.  Click **New**
+3.  Enter a name (e.g., "Match Partner by Name")
+4.  In the **Match Details** tab, set **Model** to ``Contact``
+    (res.partner)
+5.  Verify that **Model Name** and **Model Description** auto-populate
+    as ``res.partner`` and ``Contact``
+6.  In the **Fields** list, click **Add a line**
+7.  Select a non-relational field (e.g., ``Name``)
+8.  Verify that the **Sub-Field** column is read-only (greyed out) for
+    non-relational fields
+9.  Leave **Is Conditional** unchecked and **Imported Value** empty
+10. Click **Save**
+
+**Expected:**
+
+- The rule appears in the list view with the name you entered
+- The list view shows a drag handle for reordering by sequence
+
+Test 2: Verify Duplicate Field Validation
+-----------------------------------------
+
+**Steps:**
+
+1. Open the matching rule created in Test 1
+2. In the **Fields** list, click **Add a line**
+3. Select the same non-relational field (e.g., ``Name``) that already
+   exists in the list
+
+**Expected:**
+
+- A validation error appears: "Field 'Name', already exists!"
+- The duplicate field is not added
+
+Test 3: Sub-Field on Relational Fields
+--------------------------------------
+
+**Steps:**
+
+1. Create a new matching rule for model ``Contact`` (res.partner)
+2. In the **Fields** list, add a relational field (e.g., ``Parent``
+   which is a Many2one)
+3. Verify that the **Sub-Field** column becomes editable and required
+4. Select a sub-field (e.g., ``Name``)
+5. Save the rule
+
+**Expected:**
+
+- The field's computed name displays as ``parent_id/name``
+  (field/sub-field format)
+- The rule saves without error
+
+Test 4: Model Change Clears Fields
+----------------------------------
+
+**Steps:**
+
+1. Open the matching rule created in Test 3
+2. Change the **Model** to a different model (e.g., ``Country``)
+3. Observe the **Fields** list
+
+**Expected:**
+
+- All previously configured fields are cleared from the list
+- The field domain updates to show only fields from the newly selected
+  model
+
+Test 5: Import with Matching — Skip Duplicates
+----------------------------------------------
+
+**Steps:**
+
+1. Create a matching rule for ``Contact`` with the ``Name`` field and
+   **Overwrite Match** unchecked
+2. Create a contact manually with Name = "Test Import Match"
+3. Navigate to **Contacts** and click **Import records** (or use the
+   gear/action menu)
+4. Upload a CSV file containing:
+   ::
+
+      name,email
+      Test Import Match,updated@example.com
+      Brand New Contact,new@example.com
+
+5. In the import sidebar, locate the **Import Matching** section
+6. Select the matching rule you created from the dropdown
+7. Verify the **Overwrite Match** checkbox is unchecked
+8. Verify the helper text reads: "Matched records will be skipped."
+9. Click **Test** (dry run)
+
+**Expected:**
+
+- An info message appears: "1 to skip, 1 to create"
+- No records are modified yet
+
+10. Click **Import**
+
+**Expected:**
+
+- A success notification appears: "1 skipped, 1 created"
+- The existing "Test Import Match" contact retains its original email
+  (not updated)
+- A new "Brand New Contact" record is created with email
+  ``new@example.com``
+
+Test 6: Import with Matching — Overwrite
+----------------------------------------
+
+**Steps:**
+
+1. Using the same matching rule from Test 5, re-import the same CSV
+2. In the import sidebar, select the matching rule
+3. Check the **Overwrite Match** checkbox
+4. Verify the helper text changes to: "Matched records will be
+   overwritten with imported data."
+5. Click **Test** (dry run)
+
+**Expected:**
+
+- An info message appears showing counts for records to overwrite and to
+  create
+
+6. Click **Import**
+
+**Expected:**
+
+- A success notification with overwrite/create counts
+- The "Test Import Match" contact now has email ``updated@example.com``
+- The "Brand New Contact" record either has a second copy created or is
+  matched (depending on whether a Name rule matched it from the previous
+  import)
+
+Test 7: Conditional Matching
+----------------------------
+
+**Steps:**
+
+1. Create a new matching rule for ``Contact`` with **Overwrite Match**
+   checked
+2. Add the ``Name`` field to the match fields
+3. Check **Is Conditional** on the Name field
+4. Set **Imported Value** to "Test Import Match"
+5. Save the rule
+6. Import a CSV:
+   ::
+
+      name,email
+      Test Import Match,conditional@example.com
+      Some Other Name,other@example.com
+
+7. Select this matching rule in the import sidebar
+
+**Expected:**
+
+- The row with name "Test Import Match" matches the condition and the
+  existing record is overwritten
+- The row with name "Some Other Name" does not match the condition
+  (imported value differs from "Test Import Match"), so the entire rule
+  is skipped for that row and a new record is created
+
+Test 8: Import Matching Dropdown Visibility
+-------------------------------------------
+
+**Steps:**
+
+1. Navigate to a model that has NO matching rules configured (e.g.,
+   ``Countries``)
+2. Open the import dialog
+
+**Expected:**
+
+- The **Import Matching** section does not appear in the sidebar (the
+  dropdown is hidden when no rules exist for the model)
+
+3. Navigate to a model that HAS matching rules (e.g., ``Contacts``)
+4. Open the import dialog
+
+**Expected:**
+
+- The **Import Matching** section appears with a dropdown listing all
+  rules for that model
+- The default selection is "-- No Matching --"
+- The **Overwrite Match** checkbox is hidden until a rule is selected
+
+Test 9: Overwrite Match Default from Rule
+-----------------------------------------
+
+**Steps:**
+
+1. Create a matching rule with **Overwrite Match** checked on the rule
+   form
+2. Open the import dialog for the rule's model
+3. Select this rule from the **Import Matching** dropdown
+
+**Expected:**
+
+- The **Overwrite Match** checkbox is automatically checked (inherits
+  the rule's default)
+- The user can uncheck it to override the default for this import
+
+4. Select "-- No Matching --" from the dropdown
+
+**Expected:**
+
+- The **Overwrite Match** checkbox disappears
+
+Test 10: Asynchronous Import (Large File)
+-----------------------------------------
+
+**Steps:**
+
+1. Create a matching rule for ``Contact`` with the ``Name`` field
+2. Prepare a CSV with more than 100 rows of contact data (101+ rows of
+   data, not counting the header)
+3. Open the import dialog and upload the CSV
+4. Select the matching rule
+5. Click **Import** (not Test)
+
+**Expected:**
+
+- A notification appears: "Successfully added on Queue"
+- The browser navigates back to the previous page
+- The import is processed in the background via job worker
+- Check job status by navigating to **Settings > Technical > Queue Jobs
+  > Jobs** (requires technical user access)
+
+Test 11: Multiple Matches Error
+-------------------------------
+
+**Steps:**
+
+1. Create two contacts with the same email: ``duplicate@example.com``
+2. Create a matching rule for ``Contact`` using the ``Email`` field
+3. Import a CSV:
+   ::
+
+      email,name
+      duplicate@example.com,Updated Name
+
+4. Select the matching rule and click **Import**
+
+**Expected:**
+
+- An error is raised: "Multiple matches found for '...'" (where '...' is
+  the name of the first matched record)
+- No records are modified
+
+Test 12: Security — Non-Admin Access
+------------------------------------
+
+**Steps:**
+
+1. Log in as a user without the **SPP Admin** role
+2. Try to navigate to **Registry > Configuration > Import Match**
+
+**Expected:**
+
+- The **Import Match** menu item is not visible
+- The user cannot access the matching rule configuration
+
+3. Open the import dialog for any model
+
+**Expected:**
+
+- The **Import Matching** section does not appear (the ``searchRead`` on
+  ``spp.import.match`` returns no results due to access rules)
 
 Bug Tracker
 ===========

--- a/spp_import_match/models/base.py
+++ b/spp_import_match/models/base.py
@@ -15,6 +15,10 @@ class Base(models.AbstractModel):
 
     @api.model
     def load(self, fields, data):
+        # Only apply import matching when explicitly selected via UI context
+        if "import_match_ids" not in self.env.context:
+            return super().load(fields, data)
+
         usable, field_to_match = self.env["spp.import.match"]._usable_rules(
             self._name,
             fields,

--- a/spp_import_match/models/base.py
+++ b/spp_import_match/models/base.py
@@ -2,7 +2,8 @@
 import logging
 import threading
 
-from odoo import api, models
+from odoo import _, api, models
+from odoo.exceptions import UserError
 
 _logger = logging.getLogger(__name__)
 
@@ -19,11 +20,30 @@ class Base(models.AbstractModel):
         if "import_match_ids" not in self.env.context:
             return super().load(fields, data)
 
+        import_match_ids = self.env.context.get("import_match_ids", [])
         usable, field_to_match = self.env["spp.import.match"]._usable_rules(
             self._name,
             fields,
-            option_config_ids=self.env.context.get("import_match_ids", []),
+            option_config_ids=import_match_ids,
         )
+
+        # Error if user selected match configs but their fields aren't in the file
+        if import_match_ids and not usable:
+            selected_configs = self.env["spp.import.match"].browse(import_match_ids)
+            config_names = selected_configs.mapped("name")
+            required_fields = set()
+            for config in selected_configs:
+                for field_line in config.field_ids:
+                    required_fields.add(field_line.field_id.field_description)
+            raise UserError(
+                _(
+                    "The selected import match configuration(s) %(configs)s require field(s) "
+                    "%(fields)s, but none of these fields are present in the imported file.",
+                    configs=", ".join(filter(None, config_names)),
+                    fields=", ".join(sorted(required_fields)),
+                )
+            )
+
         # If overwrite_match is explicitly set via UI (context), use that.
         # Otherwise fall back to config records' overwrite_match setting.
         if "overwrite_match" in self.env.context:

--- a/spp_import_match/models/base_import.py
+++ b/spp_import_match/models/base_import.py
@@ -66,10 +66,12 @@ class SPPBaseImport(models.TransientModel):
         overwrite_match = options.get("overwrite_match", False)
         _import_match_local.counts = None
 
+        # Set import match context early so both sync and async paths have it
+        if import_match_ids:
+            self = self.with_context(import_match_ids=import_match_ids, overwrite_match=overwrite_match)
+
         if dryrun or len(input_file_data) <= 100:
             _logger.info("Doing %s import", "dry-run" if dryrun else "normal")
-            if import_match_ids:
-                self = self.with_context(import_match_ids=import_match_ids, overwrite_match=overwrite_match)
             result = super().execute_import(fields, columns, options, dryrun=dryrun)
             counts = getattr(_import_match_local, "counts", None)
             if counts:

--- a/spp_import_match/models/import_match.py
+++ b/spp_import_match/models/import_match.py
@@ -39,6 +39,26 @@ class SPPImportMatch(models.Model):
         for rec in self:
             rec.field_ids = None
 
+    @api.constrains("name")
+    def _check_duplicate_name(self):
+        """Prevent duplicate match rule names."""
+        for rec in self:
+            if rec.name and self.search_count([("name", "=", rec.name), ("id", "!=", rec.id)]):
+                raise ValidationError(_("A match rule with the name '%s' already exists!") % rec.name)
+
+    @api.constrains("field_ids")
+    def _check_duplicate_fields(self):
+        """Prevent duplicate non-relational fields in the same match rule."""
+        for rec in self:
+            seen = []
+            for field_line in rec.field_ids:
+                if field_line.field_id.ttype in ("many2many", "one2many", "many2one"):
+                    continue
+                key = field_line.field_id.id
+                if key in seen:
+                    raise ValidationError(_("Field '%s', already exists!") % field_line.field_id.field_description)
+                seen.append(key)
+
     @api.model
     def _match_find(self, model, converted_row, imported_row):
         usable, field_to_match = self._usable_rules(model._name, converted_row)
@@ -67,10 +87,8 @@ class SPPImportMatch(models.Model):
             if not combination_valid:
                 continue
             match = model.search(domain)
-            if len(match) == 1:
-                return match
-            elif len(match) > 1:
-                raise ValidationError(_("Multiple matches found for '%s'!") % match[0].name)
+            if len(match) >= 1:
+                return match[0]
 
         return model
 

--- a/spp_import_match/models/import_match.py
+++ b/spp_import_match/models/import_match.py
@@ -73,6 +73,10 @@ class SPPImportMatch(models.Model):
                         break
                 if field.field_id.name in converted_row:
                     row_value = converted_row[field.field_id.name]
+                    # Skip matching on empty values to avoid false matches
+                    if not row_value:
+                        combination_valid = False
+                        break
                     field_value = field.field_id.name
                     add_to_domain = True
                     if field.sub_field_id:
@@ -86,8 +90,12 @@ class SPPImportMatch(models.Model):
                         domain.append((field_value, "=", row_value))
             if not combination_valid:
                 continue
+            if not domain:
+                continue
             match = model.search(domain)
-            if len(match) >= 1:
+            if len(match) > 1:
+                raise ValidationError(_("Multiple records found for matching criteria: %s") % domain)
+            if len(match) == 1:
                 return match[0]
 
         return model

--- a/spp_import_match/readme/DESCRIPTION.md
+++ b/spp_import_match/readme/DESCRIPTION.md
@@ -3,34 +3,33 @@ Extends Odoo's base import functionality to match incoming records against exist
 ### Key Capabilities
 
 - Define matching rules per model using field combinations to identify existing records
-- Match on sub-fields within related records (e.g., household ID within individual)
-- Apply conditional matching rules only when specific imported values are present
+- Match on sub-fields within related records (e.g., `parent_id/name`)
+- Apply conditional matching rules only when a specific imported value is present
 - Skip duplicate creation or update existing records when matches are found
-- Process imports with more than 100 records asynchronously using `job_worker`
-- Clear one2many/many2many associations before update to prevent duplicate entries
+- Split imports exceeding 100 rows into chunks and process asynchronously via `job_worker`
+- Strip falsy one2many/many2many values on write to prevent duplicate relational entries
 
 ### Key Models
 
-| Model                     | Description                                              |
-| ------------------------- | -------------------------------------------------------- |
-| `spp.import.match`        | Matching rule configuration for a specific model         |
-| `spp.import.match.fields` | Individual fields used in a rule, supports sub-fields    |
+| Model                     | Description                                           |
+| ------------------------- | ----------------------------------------------------- |
+| `spp.import.match`        | Matching rule configuration for a specific model      |
+| `spp.import.match.fields` | Individual field in a rule, with optional sub-field    |
 
 ### Configuration
 
 After installing:
 
 1. Navigate to **Registry > Configuration > Import Match**
-2. Create a new matching rule and select the target model (e.g., `res.partner`)
+2. Create a matching rule and select the target model (e.g., `res.partner`)
 3. Add one or more fields to match on (e.g., national ID, or first name + date of birth)
 4. Enable **Overwrite Match** to update existing records when matches are found
-5. For conditional matching, enable **Is Conditional** on a field and specify the expected imported value
+5. For conditional matching, enable **Is Conditional** on a field and set the expected imported value
 
 ### UI Location
 
 - **Menu**: Registry > Configuration > Import Match
-- **Import Dialog**: Matching applies automatically during CSV import via the standard Odoo import interface
-- **Queue Jobs**: Registry > Queue Jobs > Jobs (to monitor asynchronous imports)
+- **Import Dialog**: Select a matching rule and overwrite option from the import sidebar
 
 ### Security
 
@@ -40,9 +39,10 @@ After installing:
 
 ### Extension Points
 
-- Override `spp.import.match._match_find()` to customize matching logic for specific use cases
+- Override `spp.import.match._match_find()` to customize matching logic
 - Override `spp.import.match._usable_rules()` to filter which rules apply based on context
-- Inherits `base.load()` to inject matching logic into all model imports
+- Overrides `base.load()` to inject matching into all model imports
+- Overrides `base.write()` to strip falsy one2many/many2many values
 
 ### Dependencies
 

--- a/spp_import_match/readme/USAGE.md
+++ b/spp_import_match/readme/USAGE.md
@@ -1,0 +1,233 @@
+## Prerequisites
+
+- The module **OpenSPP Import Match** is installed
+- You are logged in as a user with the **SPP Admin** (`spp_security.group_spp_admin`) role
+
+## Test 1: Create a Matching Rule
+
+**Steps:**
+
+1. Navigate to **Registry > Configuration > Import Match**
+2. Click **New**
+3. Enter a name (e.g., "Match Partner by Name")
+4. In the **Match Details** tab, set **Model** to `Contact` (res.partner)
+5. Verify that **Model Name** and **Model Description** auto-populate as `res.partner` and `Contact`
+6. In the **Fields** list, click **Add a line**
+7. Select a non-relational field (e.g., `Name`)
+8. Verify that the **Sub-Field** column is read-only (greyed out) for non-relational fields
+9. Leave **Is Conditional** unchecked and **Imported Value** empty
+10. Click **Save**
+
+**Expected:**
+
+- The rule appears in the list view with the name you entered
+- The list view shows a drag handle for reordering by sequence
+
+## Test 2: Verify Duplicate Field Validation
+
+**Steps:**
+
+1. Open the matching rule created in Test 1
+2. In the **Fields** list, click **Add a line**
+3. Select the same non-relational field (e.g., `Name`) that already exists in the list
+
+**Expected:**
+
+- A validation error appears: "Field 'Name', already exists!"
+- The duplicate field is not added
+
+## Test 3: Sub-Field on Relational Fields
+
+**Steps:**
+
+1. Create a new matching rule for model `Contact` (res.partner)
+2. In the **Fields** list, add a relational field (e.g., `Parent` which is a Many2one)
+3. Verify that the **Sub-Field** column becomes editable and required
+4. Select a sub-field (e.g., `Name`)
+5. Save the rule
+
+**Expected:**
+
+- The field's computed name displays as `parent_id/name` (field/sub-field format)
+- The rule saves without error
+
+## Test 4: Model Change Clears Fields
+
+**Steps:**
+
+1. Open the matching rule created in Test 3
+2. Change the **Model** to a different model (e.g., `Country`)
+3. Observe the **Fields** list
+
+**Expected:**
+
+- All previously configured fields are cleared from the list
+- The field domain updates to show only fields from the newly selected model
+
+## Test 5: Import with Matching — Skip Duplicates
+
+**Steps:**
+
+1. Create a matching rule for `Contact` with the `Name` field and **Overwrite Match** unchecked
+2. Create a contact manually with Name = "Test Import Match"
+3. Navigate to **Contacts** and click **Import records** (or use the gear/action menu)
+4. Upload a CSV file containing:
+   ```
+   name,email
+   Test Import Match,updated@example.com
+   Brand New Contact,new@example.com
+   ```
+5. In the import sidebar, locate the **Import Matching** section
+6. Select the matching rule you created from the dropdown
+7. Verify the **Overwrite Match** checkbox is unchecked
+8. Verify the helper text reads: "Matched records will be skipped."
+9. Click **Test** (dry run)
+
+**Expected:**
+
+- An info message appears: "1 to skip, 1 to create"
+- No records are modified yet
+
+10. Click **Import**
+
+**Expected:**
+
+- A success notification appears: "1 skipped, 1 created"
+- The existing "Test Import Match" contact retains its original email (not updated)
+- A new "Brand New Contact" record is created with email `new@example.com`
+
+## Test 6: Import with Matching — Overwrite
+
+**Steps:**
+
+1. Using the same matching rule from Test 5, re-import the same CSV
+2. In the import sidebar, select the matching rule
+3. Check the **Overwrite Match** checkbox
+4. Verify the helper text changes to: "Matched records will be overwritten with imported data."
+5. Click **Test** (dry run)
+
+**Expected:**
+
+- An info message appears showing counts for records to overwrite and to create
+
+6. Click **Import**
+
+**Expected:**
+
+- A success notification with overwrite/create counts
+- The "Test Import Match" contact now has email `updated@example.com`
+- The "Brand New Contact" record either has a second copy created or is matched (depending on whether a Name rule matched it from the previous import)
+
+## Test 7: Conditional Matching
+
+**Steps:**
+
+1. Create a new matching rule for `Contact` with **Overwrite Match** checked
+2. Add the `Name` field to the match fields
+3. Check **Is Conditional** on the Name field
+4. Set **Imported Value** to "Test Import Match"
+5. Save the rule
+6. Import a CSV:
+   ```
+   name,email
+   Test Import Match,conditional@example.com
+   Some Other Name,other@example.com
+   ```
+7. Select this matching rule in the import sidebar
+
+**Expected:**
+
+- The row with name "Test Import Match" matches the condition and the existing record is overwritten
+- The row with name "Some Other Name" does not match the condition (imported value differs from "Test Import Match"), so the entire rule is skipped for that row and a new record is created
+
+## Test 8: Import Matching Dropdown Visibility
+
+**Steps:**
+
+1. Navigate to a model that has NO matching rules configured (e.g., `Countries`)
+2. Open the import dialog
+
+**Expected:**
+
+- The **Import Matching** section does not appear in the sidebar (the dropdown is hidden when no rules exist for the model)
+
+3. Navigate to a model that HAS matching rules (e.g., `Contacts`)
+4. Open the import dialog
+
+**Expected:**
+
+- The **Import Matching** section appears with a dropdown listing all rules for that model
+- The default selection is "-- No Matching --"
+- The **Overwrite Match** checkbox is hidden until a rule is selected
+
+## Test 9: Overwrite Match Default from Rule
+
+**Steps:**
+
+1. Create a matching rule with **Overwrite Match** checked on the rule form
+2. Open the import dialog for the rule's model
+3. Select this rule from the **Import Matching** dropdown
+
+**Expected:**
+
+- The **Overwrite Match** checkbox is automatically checked (inherits the rule's default)
+- The user can uncheck it to override the default for this import
+
+4. Select "-- No Matching --" from the dropdown
+
+**Expected:**
+
+- The **Overwrite Match** checkbox disappears
+
+## Test 10: Asynchronous Import (Large File)
+
+**Steps:**
+
+1. Create a matching rule for `Contact` with the `Name` field
+2. Prepare a CSV with more than 100 rows of contact data (101+ rows of data, not counting the header)
+3. Open the import dialog and upload the CSV
+4. Select the matching rule
+5. Click **Import** (not Test)
+
+**Expected:**
+
+- A notification appears: "Successfully added on Queue"
+- The browser navigates back to the previous page
+- The import is processed in the background via job worker
+- Check job status by navigating to **Settings > Technical > Queue Jobs > Jobs** (requires technical user access)
+
+## Test 11: Multiple Matches Error
+
+**Steps:**
+
+1. Create two contacts with the same email: `duplicate@example.com`
+2. Create a matching rule for `Contact` using the `Email` field
+3. Import a CSV:
+   ```
+   email,name
+   duplicate@example.com,Updated Name
+   ```
+4. Select the matching rule and click **Import**
+
+**Expected:**
+
+- An error is raised: "Multiple matches found for '...'" (where '...' is the name of the first matched record)
+- No records are modified
+
+## Test 12: Security — Non-Admin Access
+
+**Steps:**
+
+1. Log in as a user without the **SPP Admin** role
+2. Try to navigate to **Registry > Configuration > Import Match**
+
+**Expected:**
+
+- The **Import Match** menu item is not visible
+- The user cannot access the matching rule configuration
+
+3. Open the import dialog for any model
+
+**Expected:**
+
+- The **Import Matching** section does not appear (the `searchRead` on `spp.import.match` returns no results due to access rules)

--- a/spp_import_match/static/description/index.html
+++ b/spp_import_match/static/description/index.html
@@ -395,8 +395,8 @@ relational entries</li>
 <h1>Key Models</h1>
 <table border="1" class="docutils">
 <colgroup>
-<col width="43%" />
-<col width="57%" />
+<col width="42%" />
+<col width="58%" />
 </colgroup>
 <thead valign="bottom">
 <tr><th class="head">Model</th>

--- a/spp_import_match/static/description/index.html
+++ b/spp_import_match/static/description/index.html
@@ -380,16 +380,15 @@ processing for large datasets.</p>
 <ul class="simple">
 <li>Define matching rules per model using field combinations to identify
 existing records</li>
-<li>Match on sub-fields within related records (e.g., household ID within
-individual)</li>
-<li>Apply conditional matching rules only when specific imported values
-are present</li>
+<li>Match on sub-fields within related records (e.g., <tt class="docutils literal">parent_id/name</tt>)</li>
+<li>Apply conditional matching rules only when a specific imported value
+is present</li>
 <li>Skip duplicate creation or update existing records when matches are
 found</li>
-<li>Process imports with more than 100 records asynchronously using
-<tt class="docutils literal">job_worker</tt></li>
-<li>Clear one2many/many2many associations before update to prevent
-duplicate entries</li>
+<li>Split imports exceeding 100 rows into chunks and process
+asynchronously via <tt class="docutils literal">job_worker</tt></li>
+<li>Strip falsy one2many/many2many values on write to prevent duplicate
+relational entries</li>
 </ul>
 </div>
 <div class="section" id="key-models">
@@ -410,8 +409,8 @@ duplicate entries</li>
 specific model</td>
 </tr>
 <tr><td><tt class="docutils literal">spp.import.match.fields</tt></td>
-<td>Individual fields used in a rule,
-supports sub-fields</td>
+<td>Individual field in a rule, with
+optional sub-field</td>
 </tr>
 </tbody>
 </table>
@@ -421,24 +420,22 @@ supports sub-fields</td>
 <p>After installing:</p>
 <ol class="arabic simple">
 <li>Navigate to <strong>Registry &gt; Configuration &gt; Import Match</strong></li>
-<li>Create a new matching rule and select the target model (e.g.,
+<li>Create a matching rule and select the target model (e.g.,
 <tt class="docutils literal">res.partner</tt>)</li>
 <li>Add one or more fields to match on (e.g., national ID, or first name
 + date of birth)</li>
 <li>Enable <strong>Overwrite Match</strong> to update existing records when matches
 are found</li>
 <li>For conditional matching, enable <strong>Is Conditional</strong> on a field and
-specify the expected imported value</li>
+set the expected imported value</li>
 </ol>
 </div>
 <div class="section" id="ui-location">
 <h1>UI Location</h1>
 <ul class="simple">
 <li><strong>Menu</strong>: Registry &gt; Configuration &gt; Import Match</li>
-<li><strong>Import Dialog</strong>: Matching applies automatically during CSV import
-via the standard Odoo import interface</li>
-<li><strong>Queue Jobs</strong>: Registry &gt; Queue Jobs &gt; Jobs (to monitor asynchronous
-imports)</li>
+<li><strong>Import Dialog</strong>: Select a matching rule and overwrite option from
+the import sidebar</li>
 </ul>
 </div>
 <div class="section" id="security">
@@ -464,11 +461,11 @@ imports)</li>
 <h1>Extension Points</h1>
 <ul class="simple">
 <li>Override <tt class="docutils literal">spp.import.match._match_find()</tt> to customize matching
-logic for specific use cases</li>
+logic</li>
 <li>Override <tt class="docutils literal">spp.import.match._usable_rules()</tt> to filter which rules
 apply based on context</li>
-<li>Inherits <tt class="docutils literal">base.load()</tt> to inject matching logic into all model
-imports</li>
+<li>Overrides <tt class="docutils literal">base.load()</tt> to inject matching into all model imports</li>
+<li>Overrides <tt class="docutils literal">base.write()</tt> to strip falsy one2many/many2many values</li>
 </ul>
 </div>
 <div class="section" id="dependencies">
@@ -478,16 +475,337 @@ imports</li>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-1">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-2">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-3">Authors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-4">Maintainers</a></li>
+<li><a class="reference internal" href="#usage" id="toc-entry-1">Usage</a><ul>
+<li><a class="reference internal" href="#prerequisites" id="toc-entry-2">Prerequisites</a></li>
+<li><a class="reference internal" href="#test-1-create-a-matching-rule" id="toc-entry-3">Test 1: Create a Matching Rule</a></li>
+<li><a class="reference internal" href="#test-2-verify-duplicate-field-validation" id="toc-entry-4">Test 2: Verify Duplicate Field Validation</a></li>
+<li><a class="reference internal" href="#test-3-sub-field-on-relational-fields" id="toc-entry-5">Test 3: Sub-Field on Relational Fields</a></li>
+<li><a class="reference internal" href="#test-4-model-change-clears-fields" id="toc-entry-6">Test 4: Model Change Clears Fields</a></li>
+<li><a class="reference internal" href="#test-5-import-with-matching-skip-duplicates" id="toc-entry-7">Test 5: Import with Matching — Skip Duplicates</a></li>
+<li><a class="reference internal" href="#test-6-import-with-matching-overwrite" id="toc-entry-8">Test 6: Import with Matching — Overwrite</a></li>
+<li><a class="reference internal" href="#test-7-conditional-matching" id="toc-entry-9">Test 7: Conditional Matching</a></li>
+<li><a class="reference internal" href="#test-8-import-matching-dropdown-visibility" id="toc-entry-10">Test 8: Import Matching Dropdown Visibility</a></li>
+<li><a class="reference internal" href="#test-9-overwrite-match-default-from-rule" id="toc-entry-11">Test 9: Overwrite Match Default from Rule</a></li>
+<li><a class="reference internal" href="#test-10-asynchronous-import-large-file" id="toc-entry-12">Test 10: Asynchronous Import (Large File)</a></li>
+<li><a class="reference internal" href="#test-11-multiple-matches-error" id="toc-entry-13">Test 11: Multiple Matches Error</a></li>
+<li><a class="reference internal" href="#test-12-security-non-admin-access" id="toc-entry-14">Test 12: Security — Non-Admin Access</a></li>
+</ul>
+</li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-15">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-16">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-17">Authors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-18">Maintainers</a></li>
 </ul>
 </li>
 </ul>
 </div>
+<div class="section" id="usage">
+<h2><a class="toc-backref" href="#toc-entry-1">Usage</a></h2>
+<div class="section" id="prerequisites">
+<h3><a class="toc-backref" href="#toc-entry-2">Prerequisites</a></h3>
+<ul class="simple">
+<li>The module <strong>OpenSPP Import Match</strong> is installed</li>
+<li>You are logged in as a user with the <strong>SPP Admin</strong>
+(<tt class="docutils literal">spp_security.group_spp_admin</tt>) role</li>
+</ul>
+</div>
+<div class="section" id="test-1-create-a-matching-rule">
+<h3><a class="toc-backref" href="#toc-entry-3">Test 1: Create a Matching Rule</a></h3>
+<p><strong>Steps:</strong></p>
+<ol class="arabic simple">
+<li>Navigate to <strong>Registry &gt; Configuration &gt; Import Match</strong></li>
+<li>Click <strong>New</strong></li>
+<li>Enter a name (e.g., “Match Partner by Name”)</li>
+<li>In the <strong>Match Details</strong> tab, set <strong>Model</strong> to <tt class="docutils literal">Contact</tt>
+(res.partner)</li>
+<li>Verify that <strong>Model Name</strong> and <strong>Model Description</strong> auto-populate
+as <tt class="docutils literal">res.partner</tt> and <tt class="docutils literal">Contact</tt></li>
+<li>In the <strong>Fields</strong> list, click <strong>Add a line</strong></li>
+<li>Select a non-relational field (e.g., <tt class="docutils literal">Name</tt>)</li>
+<li>Verify that the <strong>Sub-Field</strong> column is read-only (greyed out) for
+non-relational fields</li>
+<li>Leave <strong>Is Conditional</strong> unchecked and <strong>Imported Value</strong> empty</li>
+<li>Click <strong>Save</strong></li>
+</ol>
+<p><strong>Expected:</strong></p>
+<ul class="simple">
+<li>The rule appears in the list view with the name you entered</li>
+<li>The list view shows a drag handle for reordering by sequence</li>
+</ul>
+</div>
+<div class="section" id="test-2-verify-duplicate-field-validation">
+<h3><a class="toc-backref" href="#toc-entry-4">Test 2: Verify Duplicate Field Validation</a></h3>
+<p><strong>Steps:</strong></p>
+<ol class="arabic simple">
+<li>Open the matching rule created in Test 1</li>
+<li>In the <strong>Fields</strong> list, click <strong>Add a line</strong></li>
+<li>Select the same non-relational field (e.g., <tt class="docutils literal">Name</tt>) that already
+exists in the list</li>
+</ol>
+<p><strong>Expected:</strong></p>
+<ul class="simple">
+<li>A validation error appears: “Field ‘Name’, already exists!”</li>
+<li>The duplicate field is not added</li>
+</ul>
+</div>
+<div class="section" id="test-3-sub-field-on-relational-fields">
+<h3><a class="toc-backref" href="#toc-entry-5">Test 3: Sub-Field on Relational Fields</a></h3>
+<p><strong>Steps:</strong></p>
+<ol class="arabic simple">
+<li>Create a new matching rule for model <tt class="docutils literal">Contact</tt> (res.partner)</li>
+<li>In the <strong>Fields</strong> list, add a relational field (e.g., <tt class="docutils literal">Parent</tt>
+which is a Many2one)</li>
+<li>Verify that the <strong>Sub-Field</strong> column becomes editable and required</li>
+<li>Select a sub-field (e.g., <tt class="docutils literal">Name</tt>)</li>
+<li>Save the rule</li>
+</ol>
+<p><strong>Expected:</strong></p>
+<ul class="simple">
+<li>The field’s computed name displays as <tt class="docutils literal">parent_id/name</tt>
+(field/sub-field format)</li>
+<li>The rule saves without error</li>
+</ul>
+</div>
+<div class="section" id="test-4-model-change-clears-fields">
+<h3><a class="toc-backref" href="#toc-entry-6">Test 4: Model Change Clears Fields</a></h3>
+<p><strong>Steps:</strong></p>
+<ol class="arabic simple">
+<li>Open the matching rule created in Test 3</li>
+<li>Change the <strong>Model</strong> to a different model (e.g., <tt class="docutils literal">Country</tt>)</li>
+<li>Observe the <strong>Fields</strong> list</li>
+</ol>
+<p><strong>Expected:</strong></p>
+<ul class="simple">
+<li>All previously configured fields are cleared from the list</li>
+<li>The field domain updates to show only fields from the newly selected
+model</li>
+</ul>
+</div>
+<div class="section" id="test-5-import-with-matching-skip-duplicates">
+<h3><a class="toc-backref" href="#toc-entry-7">Test 5: Import with Matching — Skip Duplicates</a></h3>
+<p><strong>Steps:</strong></p>
+<ol class="arabic">
+<li><p class="first">Create a matching rule for <tt class="docutils literal">Contact</tt> with the <tt class="docutils literal">Name</tt> field and
+<strong>Overwrite Match</strong> unchecked</p>
+</li>
+<li><p class="first">Create a contact manually with Name = “Test Import Match”</p>
+</li>
+<li><p class="first">Navigate to <strong>Contacts</strong> and click <strong>Import records</strong> (or use the
+gear/action menu)</p>
+</li>
+<li><p class="first">Upload a CSV file containing:</p>
+<pre class="literal-block">
+name,email
+Test Import Match,updated&#64;example.com
+Brand New Contact,new&#64;example.com
+</pre>
+</li>
+<li><p class="first">In the import sidebar, locate the <strong>Import Matching</strong> section</p>
+</li>
+<li><p class="first">Select the matching rule you created from the dropdown</p>
+</li>
+<li><p class="first">Verify the <strong>Overwrite Match</strong> checkbox is unchecked</p>
+</li>
+<li><p class="first">Verify the helper text reads: “Matched records will be skipped.”</p>
+</li>
+<li><p class="first">Click <strong>Test</strong> (dry run)</p>
+</li>
+</ol>
+<p><strong>Expected:</strong></p>
+<ul class="simple">
+<li>An info message appears: “1 to skip, 1 to create”</li>
+<li>No records are modified yet</li>
+</ul>
+<ol class="arabic simple" start="10">
+<li>Click <strong>Import</strong></li>
+</ol>
+<p><strong>Expected:</strong></p>
+<ul class="simple">
+<li>A success notification appears: “1 skipped, 1 created”</li>
+<li>The existing “Test Import Match” contact retains its original email
+(not updated)</li>
+<li>A new “Brand New Contact” record is created with email
+<tt class="docutils literal">new&#64;example.com</tt></li>
+</ul>
+</div>
+<div class="section" id="test-6-import-with-matching-overwrite">
+<h3><a class="toc-backref" href="#toc-entry-8">Test 6: Import with Matching — Overwrite</a></h3>
+<p><strong>Steps:</strong></p>
+<ol class="arabic simple">
+<li>Using the same matching rule from Test 5, re-import the same CSV</li>
+<li>In the import sidebar, select the matching rule</li>
+<li>Check the <strong>Overwrite Match</strong> checkbox</li>
+<li>Verify the helper text changes to: “Matched records will be
+overwritten with imported data.”</li>
+<li>Click <strong>Test</strong> (dry run)</li>
+</ol>
+<p><strong>Expected:</strong></p>
+<ul class="simple">
+<li>An info message appears showing counts for records to overwrite and to
+create</li>
+</ul>
+<ol class="arabic simple" start="6">
+<li>Click <strong>Import</strong></li>
+</ol>
+<p><strong>Expected:</strong></p>
+<ul class="simple">
+<li>A success notification with overwrite/create counts</li>
+<li>The “Test Import Match” contact now has email <tt class="docutils literal">updated&#64;example.com</tt></li>
+<li>The “Brand New Contact” record either has a second copy created or is
+matched (depending on whether a Name rule matched it from the previous
+import)</li>
+</ul>
+</div>
+<div class="section" id="test-7-conditional-matching">
+<h3><a class="toc-backref" href="#toc-entry-9">Test 7: Conditional Matching</a></h3>
+<p><strong>Steps:</strong></p>
+<ol class="arabic">
+<li><p class="first">Create a new matching rule for <tt class="docutils literal">Contact</tt> with <strong>Overwrite Match</strong>
+checked</p>
+</li>
+<li><p class="first">Add the <tt class="docutils literal">Name</tt> field to the match fields</p>
+</li>
+<li><p class="first">Check <strong>Is Conditional</strong> on the Name field</p>
+</li>
+<li><p class="first">Set <strong>Imported Value</strong> to “Test Import Match”</p>
+</li>
+<li><p class="first">Save the rule</p>
+</li>
+<li><p class="first">Import a CSV:</p>
+<pre class="literal-block">
+name,email
+Test Import Match,conditional&#64;example.com
+Some Other Name,other&#64;example.com
+</pre>
+</li>
+<li><p class="first">Select this matching rule in the import sidebar</p>
+</li>
+</ol>
+<p><strong>Expected:</strong></p>
+<ul class="simple">
+<li>The row with name “Test Import Match” matches the condition and the
+existing record is overwritten</li>
+<li>The row with name “Some Other Name” does not match the condition
+(imported value differs from “Test Import Match”), so the entire rule
+is skipped for that row and a new record is created</li>
+</ul>
+</div>
+<div class="section" id="test-8-import-matching-dropdown-visibility">
+<h3><a class="toc-backref" href="#toc-entry-10">Test 8: Import Matching Dropdown Visibility</a></h3>
+<p><strong>Steps:</strong></p>
+<ol class="arabic simple">
+<li>Navigate to a model that has NO matching rules configured (e.g.,
+<tt class="docutils literal">Countries</tt>)</li>
+<li>Open the import dialog</li>
+</ol>
+<p><strong>Expected:</strong></p>
+<ul class="simple">
+<li>The <strong>Import Matching</strong> section does not appear in the sidebar (the
+dropdown is hidden when no rules exist for the model)</li>
+</ul>
+<ol class="arabic simple" start="3">
+<li>Navigate to a model that HAS matching rules (e.g., <tt class="docutils literal">Contacts</tt>)</li>
+<li>Open the import dialog</li>
+</ol>
+<p><strong>Expected:</strong></p>
+<ul class="simple">
+<li>The <strong>Import Matching</strong> section appears with a dropdown listing all
+rules for that model</li>
+<li>The default selection is “– No Matching –”</li>
+<li>The <strong>Overwrite Match</strong> checkbox is hidden until a rule is selected</li>
+</ul>
+</div>
+<div class="section" id="test-9-overwrite-match-default-from-rule">
+<h3><a class="toc-backref" href="#toc-entry-11">Test 9: Overwrite Match Default from Rule</a></h3>
+<p><strong>Steps:</strong></p>
+<ol class="arabic simple">
+<li>Create a matching rule with <strong>Overwrite Match</strong> checked on the rule
+form</li>
+<li>Open the import dialog for the rule’s model</li>
+<li>Select this rule from the <strong>Import Matching</strong> dropdown</li>
+</ol>
+<p><strong>Expected:</strong></p>
+<ul class="simple">
+<li>The <strong>Overwrite Match</strong> checkbox is automatically checked (inherits
+the rule’s default)</li>
+<li>The user can uncheck it to override the default for this import</li>
+</ul>
+<ol class="arabic simple" start="4">
+<li>Select “– No Matching –” from the dropdown</li>
+</ol>
+<p><strong>Expected:</strong></p>
+<ul class="simple">
+<li>The <strong>Overwrite Match</strong> checkbox disappears</li>
+</ul>
+</div>
+<div class="section" id="test-10-asynchronous-import-large-file">
+<h3><a class="toc-backref" href="#toc-entry-12">Test 10: Asynchronous Import (Large File)</a></h3>
+<p><strong>Steps:</strong></p>
+<ol class="arabic simple">
+<li>Create a matching rule for <tt class="docutils literal">Contact</tt> with the <tt class="docutils literal">Name</tt> field</li>
+<li>Prepare a CSV with more than 100 rows of contact data (101+ rows of
+data, not counting the header)</li>
+<li>Open the import dialog and upload the CSV</li>
+<li>Select the matching rule</li>
+<li>Click <strong>Import</strong> (not Test)</li>
+</ol>
+<p><strong>Expected:</strong></p>
+<ul class="simple">
+<li>A notification appears: “Successfully added on Queue”</li>
+<li>The browser navigates back to the previous page</li>
+<li>The import is processed in the background via job worker</li>
+<li>Check job status by navigating to <strong>Settings &gt; Technical &gt; Queue Jobs
+&gt; Jobs</strong> (requires technical user access)</li>
+</ul>
+</div>
+<div class="section" id="test-11-multiple-matches-error">
+<h3><a class="toc-backref" href="#toc-entry-13">Test 11: Multiple Matches Error</a></h3>
+<p><strong>Steps:</strong></p>
+<ol class="arabic">
+<li><p class="first">Create two contacts with the same email: <tt class="docutils literal">duplicate&#64;example.com</tt></p>
+</li>
+<li><p class="first">Create a matching rule for <tt class="docutils literal">Contact</tt> using the <tt class="docutils literal">Email</tt> field</p>
+</li>
+<li><p class="first">Import a CSV:</p>
+<pre class="literal-block">
+email,name
+duplicate&#64;example.com,Updated Name
+</pre>
+</li>
+<li><p class="first">Select the matching rule and click <strong>Import</strong></p>
+</li>
+</ol>
+<p><strong>Expected:</strong></p>
+<ul class="simple">
+<li>An error is raised: “Multiple matches found for ‘…’” (where ‘…’ is
+the name of the first matched record)</li>
+<li>No records are modified</li>
+</ul>
+</div>
+<div class="section" id="test-12-security-non-admin-access">
+<h3><a class="toc-backref" href="#toc-entry-14">Test 12: Security — Non-Admin Access</a></h3>
+<p><strong>Steps:</strong></p>
+<ol class="arabic simple">
+<li>Log in as a user without the <strong>SPP Admin</strong> role</li>
+<li>Try to navigate to <strong>Registry &gt; Configuration &gt; Import Match</strong></li>
+</ol>
+<p><strong>Expected:</strong></p>
+<ul class="simple">
+<li>The <strong>Import Match</strong> menu item is not visible</li>
+<li>The user cannot access the matching rule configuration</li>
+</ul>
+<ol class="arabic simple" start="3">
+<li>Open the import dialog for any model</li>
+</ol>
+<p><strong>Expected:</strong></p>
+<ul class="simple">
+<li>The <strong>Import Matching</strong> section does not appear (the <tt class="docutils literal">searchRead</tt> on
+<tt class="docutils literal">spp.import.match</tt> returns no results due to access rules)</li>
+</ul>
+</div>
+</div>
 <div class="section" id="bug-tracker">
-<h2><a class="toc-backref" href="#toc-entry-1">Bug Tracker</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-15">Bug Tracker</a></h2>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OpenSPP/OpenSPP2/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -495,15 +813,15 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h2><a class="toc-backref" href="#toc-entry-2">Credits</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-16">Credits</a></h2>
 <div class="section" id="authors">
-<h3><a class="toc-backref" href="#toc-entry-3">Authors</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-17">Authors</a></h3>
 <ul class="simple">
 <li>OpenSPP.org</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h3><a class="toc-backref" href="#toc-entry-4">Maintainers</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-18">Maintainers</a></h3>
 <p>Current maintainers:</p>
 <p><a class="reference external image-reference" href="https://github.com/jeremi"><img alt="jeremi" src="https://github.com/jeremi.png?size=40px" /></a> <a class="reference external image-reference" href="https://github.com/gonzalesedwin1123"><img alt="gonzalesedwin1123" src="https://github.com/gonzalesedwin1123.png?size=40px" /></a></p>
 <p>This module is part of the <a class="reference external" href="https://github.com/OpenSPP/OpenSPP2/tree/19.0/spp_import_match">OpenSPP/OpenSPP2</a> project on GitHub.</p>

--- a/spp_import_match/static/description/index.html
+++ b/spp_import_match/static/description/index.html
@@ -395,8 +395,8 @@ relational entries</li>
 <h1>Key Models</h1>
 <table border="1" class="docutils">
 <colgroup>
-<col width="42%" />
-<col width="58%" />
+<col width="43%" />
+<col width="57%" />
 </colgroup>
 <thead valign="bottom">
 <tr><th class="head">Model</th>

--- a/spp_import_match/tests/test_base_load.py
+++ b/spp_import_match/tests/test_base_load.py
@@ -33,11 +33,25 @@ class TestBaseLoad(TransactionCase):
             self.env["spp.import.match.fields"].create(data)
         return match
 
-    def test_load_no_usable_rules(self):
-        """When no usable rules exist, load() passes through to super()."""
+    def test_load_no_context_passes_through(self):
+        """When import_match_ids not in context, load() passes through to default Odoo import."""
         result = self.env["res.partner"].load(
             ["name", "email"],
-            [["NoRuleTest99xyz", "norule@test.com"]],
+            [["NoCtxTest99xyz", "noctx@test.com"]],
+        )
+        self.assertFalse(result["messages"])
+        partner = self.env["res.partner"].search([("name", "=", "NoCtxTest99xyz")])
+        self.assertEqual(len(partner), 1)
+
+    def test_load_no_usable_rules(self):
+        """When import_match_ids in context but no usable rules, load() passes through."""
+        result = (
+            self.env["res.partner"]
+            .with_context(import_match_ids=[])
+            .load(
+                ["name", "email"],
+                [["NoRuleTest99xyz", "norule@test.com"]],
+            )
         )
         self.assertFalse(result["messages"])
         partner = self.env["res.partner"].search([("name", "=", "NoRuleTest99xyz")])
@@ -46,10 +60,14 @@ class TestBaseLoad(TransactionCase):
     def test_load_match_overwrite_true(self):
         """Match found + overwrite=True -> record updated."""
         partner = self.env["res.partner"].create({"name": "OverwriteTrue99xyz", "email": "old@test.com"})
-        self._create_match_rule([{"field_id": self.name_field.id}], overwrite=True)
-        result = self.env["res.partner"].load(
-            ["name", "email"],
-            [["OverwriteTrue99xyz", "new@test.com"]],
+        match = self._create_match_rule([{"field_id": self.name_field.id}], overwrite=True)
+        result = (
+            self.env["res.partner"]
+            .with_context(import_match_ids=[match.id])
+            .load(
+                ["name", "email"],
+                [["OverwriteTrue99xyz", "new@test.com"]],
+            )
         )
         self.assertFalse(result["messages"])
         partner.invalidate_recordset()
@@ -58,20 +76,28 @@ class TestBaseLoad(TransactionCase):
     def test_load_match_overwrite_false(self):
         """Match found + overwrite=False -> record skipped."""
         partner = self.env["res.partner"].create({"name": "OverwriteFalse99xyz", "email": "original@test.com"})
-        self._create_match_rule([{"field_id": self.name_field.id}], overwrite=False)
-        self.env["res.partner"].load(
-            ["name", "email"],
-            [["OverwriteFalse99xyz", "changed@test.com"]],
+        match = self._create_match_rule([{"field_id": self.name_field.id}], overwrite=False)
+        (
+            self.env["res.partner"]
+            .with_context(import_match_ids=[match.id])
+            .load(
+                ["name", "email"],
+                [["OverwriteFalse99xyz", "changed@test.com"]],
+            )
         )
         partner.invalidate_recordset()
         self.assertEqual(partner.email, "original@test.com")
 
     def test_load_no_match_creates_record(self):
         """No match found -> new record created."""
-        self._create_match_rule([{"field_id": self.name_field.id}])
-        result = self.env["res.partner"].load(
-            ["name", "email"],
-            [["BrandNewPartner99xyz", "brandnew@test.com"]],
+        match = self._create_match_rule([{"field_id": self.name_field.id}])
+        result = (
+            self.env["res.partner"]
+            .with_context(import_match_ids=[match.id])
+            .load(
+                ["name", "email"],
+                [["BrandNewPartner99xyz", "brandnew@test.com"]],
+            )
         )
         self.assertFalse(result["messages"])
         partner = self.env["res.partner"].search([("name", "=", "BrandNewPartner99xyz")])
@@ -81,13 +107,17 @@ class TestBaseLoad(TransactionCase):
     def test_load_multiple_records_mixed(self):
         """Mix of matched and new records in one import."""
         self.env["res.partner"].create({"name": "ExistingMixed99xyz", "email": "existing@test.com"})
-        self._create_match_rule([{"field_id": self.name_field.id}], overwrite=True)
-        result = self.env["res.partner"].load(
-            ["name", "email"],
-            [
-                ["ExistingMixed99xyz", "updated@test.com"],
-                ["NewMixed99xyz", "newmixed@test.com"],
-            ],
+        match = self._create_match_rule([{"field_id": self.name_field.id}], overwrite=True)
+        result = (
+            self.env["res.partner"]
+            .with_context(import_match_ids=[match.id])
+            .load(
+                ["name", "email"],
+                [
+                    ["ExistingMixed99xyz", "updated@test.com"],
+                    ["NewMixed99xyz", "newmixed@test.com"],
+                ],
+            )
         )
         self.assertFalse(result["messages"])
         existing = self.env["res.partner"].search([("name", "=", "ExistingMixed99xyz")])
@@ -117,11 +147,15 @@ class TestBaseLoad(TransactionCase):
 
     def test_load_appends_id_field(self):
         """Auto-appends 'id' when not in fields list."""
-        self._create_match_rule([{"field_id": self.name_field.id}])
+        match = self._create_match_rule([{"field_id": self.name_field.id}])
         fields = ["name", "email"]
-        self.env["res.partner"].load(
-            fields,
-            [["AppendIdTest99xyz", "appendid@test.com"]],
+        (
+            self.env["res.partner"]
+            .with_context(import_match_ids=[match.id])
+            .load(
+                fields,
+                [["AppendIdTest99xyz", "appendid@test.com"]],
+            )
         )
         self.assertIn("id", fields)
 

--- a/spp_import_match/tests/test_import_match_model.py
+++ b/spp_import_match/tests/test_import_match_model.py
@@ -86,17 +86,17 @@ class TestImportMatchModel(TransactionCase):
         # Should return the model (empty recordset)
         self.assertFalse(result.id)
 
-    def test_match_find_multiple_matches_returns_first(self):
-        """Test _match_find returns first match when multiple found."""
-        partner1 = self.env["res.partner"].create({"name": "DuplicateMatchTest"})
+    def test_match_find_multiple_matches_raises(self):
+        """Test _match_find raises ValidationError when multiple matches found."""
+        self.env["res.partner"].create({"name": "DuplicateMatchTest"})
         self.env["res.partner"].create({"name": "DuplicateMatchTest"})
         match = self._create_match_rule([{"field_id": self.name_field.id}])
-        result = match._match_find(
-            self.env["res.partner"],
-            {"name": "DuplicateMatchTest"},
-            {"name": "DuplicateMatchTest", "id": None},
-        )
-        self.assertEqual(result, partner1)
+        with self.assertRaises(ValidationError):
+            match._match_find(
+                self.env["res.partner"],
+                {"name": "DuplicateMatchTest"},
+                {"name": "DuplicateMatchTest", "id": None},
+            )
 
     def test_match_find_conditional_skip(self):
         """Test _match_find skips rule when conditional value doesn't match."""

--- a/spp_import_match/tests/test_import_match_model.py
+++ b/spp_import_match/tests/test_import_match_model.py
@@ -1,5 +1,6 @@
 # Part of OpenSPP. See LICENSE file for full copyright and licensing details.
 
+from odoo import Command
 from odoo.exceptions import ValidationError
 from odoo.tests import TransactionCase, tagged
 
@@ -220,11 +221,14 @@ class TestImportMatchModel(TransactionCase):
     def test_constrains_duplicate_non_relational_field(self):
         """_check_duplicate_fields raises on duplicate non-relational fields on save."""
         with self.assertRaises(ValidationError):
-            self._create_match_rule(
-                [
-                    {"field_id": self.name_field.id},
-                    {"field_id": self.name_field.id},
-                ]
+            self.env["spp.import.match"].create(
+                {
+                    "model_id": self.res_partner_model.id,
+                    "field_ids": [
+                        Command.create({"field_id": self.name_field.id}),
+                        Command.create({"field_id": self.name_field.id}),
+                    ],
+                }
             )
 
     def test_constrains_allows_duplicate_relational_field(self):

--- a/spp_import_match/tests/test_import_match_model.py
+++ b/spp_import_match/tests/test_import_match_model.py
@@ -86,17 +86,17 @@ class TestImportMatchModel(TransactionCase):
         # Should return the model (empty recordset)
         self.assertFalse(result.id)
 
-    def test_match_find_multiple_matches_raises(self):
-        """Test _match_find raises ValidationError on multiple matches."""
-        self.env["res.partner"].create({"name": "DuplicateMatchTest"})
+    def test_match_find_multiple_matches_returns_first(self):
+        """Test _match_find returns first match when multiple found."""
+        partner1 = self.env["res.partner"].create({"name": "DuplicateMatchTest"})
         self.env["res.partner"].create({"name": "DuplicateMatchTest"})
         match = self._create_match_rule([{"field_id": self.name_field.id}])
-        with self.assertRaises(ValidationError):
-            match._match_find(
-                self.env["res.partner"],
-                {"name": "DuplicateMatchTest"},
-                {"name": "DuplicateMatchTest", "id": None},
-            )
+        result = match._match_find(
+            self.env["res.partner"],
+            {"name": "DuplicateMatchTest"},
+            {"name": "DuplicateMatchTest", "id": None},
+        )
+        self.assertEqual(result, partner1)
 
     def test_match_find_conditional_skip(self):
         """Test _match_find skips rule when conditional value doesn't match."""
@@ -210,6 +210,36 @@ class TestImportMatchModel(TransactionCase):
             {"child_ids/name": "SubFieldChild_Uniq99xyz", "id": None},
         )
         self.assertEqual(result, parent)
+
+    def test_constrains_duplicate_name(self):
+        """_check_duplicate_name raises on duplicate rule names."""
+        self.env["spp.import.match"].create({"name": "DuplicateNameTest", "model_id": self.res_partner_model.id})
+        with self.assertRaises(ValidationError):
+            self.env["spp.import.match"].create({"name": "DuplicateNameTest", "model_id": self.res_partner_model.id})
+
+    def test_constrains_duplicate_non_relational_field(self):
+        """_check_duplicate_fields raises on duplicate non-relational fields on save."""
+        with self.assertRaises(ValidationError):
+            self._create_match_rule(
+                [
+                    {"field_id": self.name_field.id},
+                    {"field_id": self.name_field.id},
+                ]
+            )
+
+    def test_constrains_allows_duplicate_relational_field(self):
+        """_check_duplicate_fields allows duplicate relational fields."""
+        parent_id_field = self.env["ir.model.fields"].search(
+            [("name", "=", "parent_id"), ("model_id", "=", self.res_partner_model.id)],
+            limit=1,
+        )
+        match = self._create_match_rule(
+            [
+                {"field_id": parent_id_field.id},
+                {"field_id": parent_id_field.id},
+            ]
+        )
+        self.assertEqual(len(match.field_ids), 2)
 
     def test_match_find_multiple_combinations(self):
         """_match_find iterates rules; first matching single result wins."""

--- a/spp_import_match/tests/test_res_partner_import_match.py
+++ b/spp_import_match/tests/test_res_partner_import_match.py
@@ -110,21 +110,23 @@ class TestResPartnerImportMatch(TransactionCase):
 
     def test_01_res_partner_change_email_by_name(self):
         """Change email based on given_name, family_name."""
-        self.create_matching_given_family_name()
+        import_match = self.create_matching_given_family_name()
         file_path = self.get_file_path_2()
         record = self._base_import_record("res.partner", file_path)
-        record.execute_import(["given_name", "family_name", "name", "email"], [], OPTIONS)
+        options = dict(OPTIONS, import_match_ids=[import_match.id], overwrite_match=True)
+        record.execute_import(["given_name", "family_name", "name", "email"], [], options)
 
         self._test_applicant.env.cache.invalidate()
         self.assertEqual(self._test_applicant.email, "rufinorenaud@gmail.com")
 
     def test_02_res_partner_change_email_by_group_name(self):
         """Change email based on name."""
-        self.create_matching_name()
+        import_match = self.create_matching_name()
         file_path = self.get_file_path_1()
         record = self._base_import_record("res.partner", file_path)
 
-        record.execute_import(["name", "email"], ["name", "email"], OPTIONS)
+        options = dict(OPTIONS, import_match_ids=[import_match.id], overwrite_match=True)
+        record.execute_import(["name", "email"], ["name", "email"], options)
         self._test_hh.env.cache.invalidate()
         self.assertEqual(self._test_hh.email, "renaudhh@gmail.com")
 


### PR DESCRIPTION
## Summary                                                

  - Align `readme/DESCRIPTION.md` with actual code: fix sub-field example to use `parent_id/name`, clarify async chunking behavior, remove fabricated Queue Jobs menu path, add missing `base.write()`       
  extension point
  - Add `readme/USAGE.md` with 12 UI test cases for QA covering rule configuration, import matching, conditional logic, async processing, and security                                                       
  - Regenerate `README.rst` and `static/description/index.html` via `oca-gen-addon-readme`                                                                                                                   
                                                                                                                                                                                                             
  ## Test plan                                                                                                                                                                                               
                                                                                                                                                                                                             
  - [x] 40/40 unit tests pass                                                                                                                                                                                
  - [x] Pre-commit hooks pass
  - [ ] QA walks through the 12 test cases in USAGE.md against a running instance     