### PR TITLE
fix(spp_registry): use correct field for id type in validation error

### DIFF
--- a/spp_registry/models/reg_id.py
+++ b/spp_registry/models/reg_id.py
@@ -126,7 +126,7 @@ class SPPRegistrantID(models.Model):
                     raise ValidationError(
                         _(
                             "The provided %(id_type)s ID '%(value)s' is invalid.",
-                            id_type=rec.id_type_id.name,
+                            id_type=rec.id_type_id.display,
                             value=rec.value,
                         )
                     )


### PR DESCRIPTION
## Summary                                                                                                                                                                                                 
  - Fix `AttributeError` in `spp.registry.id` validation constraint caused by accessing `.name` on `spp.vocabulary.code`, which has no `name` field (`_rec_name = "display"`)                                
  - The ID validation regex check now correctly shows a `ValidationError` with the ID type label instead of crashing                                                                                         
                                                                                                                                                                                                             
  ## Test plan
  - [ ] Create an `spp.registry.id` record with an ID type that has `id_validation` set and provide a value that doesn't match the regex — should show a clean validation error with the ID type name        
  - [ ] Verify existing flows that create registry IDs with valid values still work normally    