### PR TITLE
fix(spp_dci_demo): set development_status to Alpha

### DIFF
--- a/spp_dci_demo/__manifest__.py
+++ b/spp_dci_demo/__manifest__.py
@@ -4,6 +4,7 @@
     "version": "19.0.2.0.0",
     "category": "OpenSPP",
     "license": "LGPL-3",
+    "development_status": "Alpha",
     "website": "https://github.com/OpenSPP/OpenSPP2",
     "author": "OpenSPP.org",
     "depends": [


### PR DESCRIPTION
## Why is this change needed?
The spp_dci_demo module was missing the `development_status` key in its manifest. It should be Alpha per the release plan.

## How was the change implemented?
Added `"development_status": "Alpha"` to `__manifest__.py`.

## New unit tests

## Unit tests executed by the author

## How to test manually
Verify the module manifest includes `development_status: Alpha`.

## Related links