### PR TITLE
chore: bump 14 migrated modules to 19.0.2.0.0

### DIFF
--- a/spp_attachment_av_scan/__manifest__.py
+++ b/spp_attachment_av_scan/__manifest__.py
@@ -1,7 +1,7 @@
 {  # pylint: disable=pointless-statement
     "name": "OpenSPP Attachment Antivirus Scan",
     "category": "OpenSPP",
-    "version": "19.0.1.0.0",
+    "version": "19.0.2.0.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/OpenSPP2",

--- a/spp_disability_registry/__manifest__.py
+++ b/spp_disability_registry/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "OpenSPP Disability Registry",
-    "version": "19.0.1.0.0",
+    "version": "19.0.2.0.0",
     "category": "OpenSPP",
     "summary": "Disability assessment and registry management for social protection",
     "author": "OpenSPP.org",

--- a/spp_farmer_registry/__manifest__.py
+++ b/spp_farmer_registry/__manifest__.py
@@ -3,7 +3,7 @@
     "name": "OpenSPP Farmer Registry",
     "summary": "Farmer Registry with vocabulary-based fields, CEL variables, and Logic Studio integration",
     "category": "OpenSPP",
-    "version": "19.0.1.0.0",
+    "version": "19.0.2.0.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/OpenSPP2",

--- a/spp_farmer_registry_cr/__manifest__.py
+++ b/spp_farmer_registry_cr/__manifest__.py
@@ -3,7 +3,7 @@
     "name": "OpenSPP Farmer Registry: Change Request Types",
     "summary": "Farmer-specific change request types for farm details and activities",
     "category": "OpenSPP",
-    "version": "19.0.1.0.0",
+    "version": "19.0.2.0.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/OpenSPP2",

--- a/spp_farmer_registry_dashboard/__manifest__.py
+++ b/spp_farmer_registry_dashboard/__manifest__.py
@@ -3,7 +3,7 @@
     "name": "OpenSPP Farmer Registry Dashboard",
     "summary": "Farmer registry dashboard with CEL-based metrics and trends",
     "category": "OpenSPP",
-    "version": "19.0.1.0.0",
+    "version": "19.0.2.0.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/OpenSPP2",

--- a/spp_farmer_registry_demo/__manifest__.py
+++ b/spp_farmer_registry_demo/__manifest__.py
@@ -3,7 +3,7 @@
     "name": "OpenSPP Farmer Registry Demo",
     "summary": "Demo generator for Farmer Registry with fixed stories and volume generation",
     "category": "OpenSPP",
-    "version": "19.0.1.0.0",
+    "version": "19.0.2.0.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/OpenSPP2",

--- a/spp_farmer_registry_vocabularies/__manifest__.py
+++ b/spp_farmer_registry_vocabularies/__manifest__.py
@@ -3,7 +3,7 @@
     "name": "OpenSPP Farmer Registry: Vocabularies",
     "summary": "FAO-aligned vocabularies for farmer registry (crops, livestock, aquaculture)",
     "category": "OpenSPP",
-    "version": "19.0.1.0.0",
+    "version": "19.0.2.0.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/OpenSPP2",

--- a/spp_irrigation/__manifest__.py
+++ b/spp_irrigation/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "OpenSPP Irrigation",
     "category": "OpenSPP",
-    "version": "19.0.1.3.1",
+    "version": "19.0.2.0.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/OpenSPP2",

--- a/spp_land_record/__manifest__.py
+++ b/spp_land_record/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "OpenSPP Land Record",
     "category": "OpenSPP",
-    "version": "19.0.1.3.1",
+    "version": "19.0.2.0.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/OpenSPP2",

--- a/spp_registry_group_hierarchy/__manifest__.py
+++ b/spp_registry_group_hierarchy/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "OpenSPP Registry Group Hierarchy",
     "summary": "The module introduces hierarchical relationships among OpenSPP registry groups, enabling the creation of nested structures where groups can contain both individuals and other sub-groups. It extends g2p_registry_group and g2p_registry_membership modules.",
     "category": "OpenSPP",
-    "version": "19.0.1.3.1",
+    "version": "19.0.2.0.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/OpenSPP2",

--- a/spp_scoring/__manifest__.py
+++ b/spp_scoring/__manifest__.py
@@ -1,7 +1,7 @@
 {
     "name": "OpenSPP Scoring",
     "category": "OpenSPP/Targeting",
-    "version": "19.0.1.0.0",
+    "version": "19.0.2.0.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/OpenSPP2",

--- a/spp_scoring_programs/__manifest__.py
+++ b/spp_scoring_programs/__manifest__.py
@@ -2,7 +2,7 @@
 {
     "name": "OpenSPP Scoring Programs Bridge",
     "category": "OpenSPP/Targeting",
-    "version": "19.0.1.0.0",
+    "version": "19.0.2.0.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/OpenSPP2",

--- a/spp_starter_farmer_registry/__manifest__.py
+++ b/spp_starter_farmer_registry/__manifest__.py
@@ -3,7 +3,7 @@
     "name": "OpenSPP Starter: Farmer Registry",
     "summary": "Complete Farmer Registry bundle with API, DCI, and Program support",
     "category": "OpenSPP",
-    "version": "19.0.1.0.0",
+    "version": "19.0.2.0.0",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/OpenSPP2",

--- a/spp_storage_backend/__manifest__.py
+++ b/spp_storage_backend/__manifest__.py
@@ -4,7 +4,7 @@
     "name": "OpenSPP Storage Backend",
     "summary": "Pluggable storage backend configuration for OpenSPP file storage",
     "category": "OpenSPP/Core",
-    "version": "19.0.1.0.0",
+    "version": "19.0.2.0.0",
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/OpenSPP2",
     "license": "LGPL-3",


### PR DESCRIPTION
## Why is this change needed?
The 14 modules recently migrated from the private repo still have v1 format versions (19.0.1.x.x). All public repo modules should use the OCA v2 format (19.0.2.0.0) for consistency before release.

## How was the change implemented?
Bumped `version` in `__manifest__.py` from `19.0.1.x.x` to `19.0.2.0.0` for:
- spp_attachment_av_scan
- spp_disability_registry
- spp_farmer_registry
- spp_farmer_registry_cr
- spp_farmer_registry_dashboard
- spp_farmer_registry_demo
- spp_farmer_registry_vocabularies
- spp_irrigation
- spp_land_record
- spp_registry_group_hierarchy
- spp_scoring
- spp_scoring_programs
- spp_starter_farmer_registry
- spp_storage_backend

## New unit tests

## Unit tests executed by the author

## How to test manually
Verify modules install correctly with the new version numbers.

## Related links