### PR TITLE
perf(spp_programs): fetch fund balance once per approval batch

### DIFF
--- a/spp_programs/README.rst
+++ b/spp_programs/README.rst
@@ -254,6 +254,11 @@ Dependencies
 Changelog
 =========
 
+19.0.2.0.4
+~~~~~~~~~~
+
+- Fetch fund balance once per approval batch instead of per entitlement
+
 19.0.2.0.3
 ~~~~~~~~~~
 

--- a/spp_programs/__manifest__.py
+++ b/spp_programs/__manifest__.py
@@ -4,7 +4,7 @@
     "name": "OpenSPP Programs",
     "summary": "Manage cash and in-kind entitlements, integrate with inventory, and enhance program management features for comprehensive social protection and agricultural support.",
     "category": "OpenSPP/Core",
-    "version": "19.0.2.0.3",
+    "version": "19.0.2.0.4",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/OpenSPP2",

--- a/spp_programs/models/managers/entitlement_manager_base.py
+++ b/spp_programs/models/managers/entitlement_manager_base.py
@@ -577,10 +577,13 @@ class DefaultCashEntitlementManager(models.Model):
         entitlements.mapped("partner_id")
         entitlements.mapped("journal_id.currency_id")
 
+        # Fetch fund balance once for the whole batch instead of per entitlement
+        fund_balance = self.check_fund_balance(entitlements[0].cycle_id.program_id.id)
+
         for rec in entitlements:
             if rec.state in ("draft", "pending_validation"):
-                fund_balance = self.check_fund_balance(rec.cycle_id.program_id.id) - amt
-                if fund_balance >= rec.initial_amount:
+                remaining_balance = fund_balance - amt
+                if remaining_balance >= rec.initial_amount:
                     amt += rec.initial_amount
                     # Prepare journal entry (account.move) via account.payment
                     amount = rec.initial_amount
@@ -634,7 +637,7 @@ class DefaultCashEntitlementManager(models.Model):
                         + "is insufficient for the entitlement: %(entitlement)s"
                     ) % {
                         "program": rec.cycle_id.program_id.name,
-                        "fund": fund_balance,
+                        "fund": remaining_balance,
                         "entitlement": rec.code,
                     }
                     # Stop the process and return an error

--- a/spp_programs/models/managers/entitlement_manager_cash.py
+++ b/spp_programs/models/managers/entitlement_manager_cash.py
@@ -406,13 +406,16 @@ class SppCashEntitlementManager(models.Model):
         entitlements.mapped("partner_id.property_account_payable_id")
         entitlements.mapped("journal_id.currency_id")
 
+        # Fetch fund balance once for the whole batch instead of per entitlement
+        fund_balance = self.check_fund_balance(entitlements[0].cycle_id.program_id.id)
+
         state_err = 0
         message = ""
         sw = 0
         for rec in entitlements:
             if rec.state in ("draft", "pending_validation"):
-                fund_balance = self.check_fund_balance(rec.cycle_id.program_id.id) - amt
-                if fund_balance >= rec.initial_amount:
+                remaining_balance = fund_balance - amt
+                if remaining_balance >= rec.initial_amount:
                     amt += rec.initial_amount
                     # Prepare journal entry (account.move) via account.payment
                     amount = rec.initial_amount
@@ -459,7 +462,7 @@ class SppCashEntitlementManager(models.Model):
                         + "is insufficient for the entitlement: %(entitlement)s"
                     ) % {
                         "program": rec.cycle_id.program_id.name,
-                        "fund": fund_balance,
+                        "fund": remaining_balance,
                         "entitlement": rec.code,
                     }
                     # Stop the process and return an error

--- a/spp_programs/readme/HISTORY.md
+++ b/spp_programs/readme/HISTORY.md
@@ -1,3 +1,7 @@
+### 19.0.2.0.4
+
+- Fetch fund balance once per approval batch instead of per entitlement
+
 ### 19.0.2.0.3
 
 - Replace cycle computed fields (total_amount, entitlements_count, approval flags) with SQL aggregation queries

--- a/spp_programs/static/description/index.html
+++ b/spp_programs/static/description/index.html
@@ -658,20 +658,26 @@ to define custom compliance criteria</li>
 </div>
 </div>
 <div class="section" id="section-1">
+<h1>19.0.2.0.4</h1>
+<ul class="simple">
+<li>Fetch fund balance once per approval batch instead of per entitlement</li>
+</ul>
+</div>
+<div class="section" id="section-2">
 <h1>19.0.2.0.3</h1>
 <ul class="simple">
 <li>Replace cycle computed fields (total_amount, entitlements_count,
 approval flags) with SQL aggregation queries</li>
 </ul>
 </div>
-<div class="section" id="section-2">
+<div class="section" id="section-3">
 <h1>19.0.2.0.2</h1>
 <ul class="simple">
 <li>Add composite indexes for frequent query patterns on entitlements and
 program memberships</li>
 </ul>
 </div>
-<div class="section" id="section-3">
+<div class="section" id="section-4">
 <h1>19.0.2.0.1</h1>
 <ul class="simple">
 <li>Replace Python-level uniqueness checks with SQL UNIQUE constraints for
@@ -680,7 +686,7 @@ program membership, cycle membership, and entitlement codes</li>
 constraint creation</li>
 </ul>
 </div>
-<div class="section" id="section-4">
+<div class="section" id="section-5">
 <h1>19.0.2.0.0</h1>
 <ul class="simple">
 <li>Initial migration to OpenSPP2</li>

--- a/spp_programs/tests/__init__.py
+++ b/spp_programs/tests/__init__.py
@@ -21,3 +21,4 @@ from . import test_sql_constraints
 from . import test_stock_rule
 from . import test_composite_indexes
 from . import test_cycle_computed_fields
+from . import test_fund_balance

--- a/spp_programs/tests/test_fund_balance.py
+++ b/spp_programs/tests/test_fund_balance.py
@@ -1,0 +1,150 @@
+# Part of OpenSPP. See LICENSE file for full copyright and licensing details.
+import uuid
+from unittest.mock import patch
+
+from odoo import fields
+from odoo.tests import TransactionCase
+
+
+class TestFundBalanceOptimization(TransactionCase):
+    """Test that fund balance is fetched once per approval batch, not per entitlement.
+
+    The approve_entitlements methods previously called check_fund_balance()
+    (2 SQL queries) inside the per-entitlement loop. Now the balance is
+    fetched once and tracked via a running total in Python.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.program = self.env["spp.program"].create({"name": f"Test Program {uuid.uuid4().hex[:8]}"})
+        # Create a journal for the program
+        self.journal = self.env["account.journal"].create(
+            {
+                "name": "Test Journal",
+                "type": "bank",
+                "code": f"TJ{uuid.uuid4().hex[:4].upper()}",
+            }
+        )
+        self.program.journal_id = self.journal.id
+
+        self.cycle = self.env["spp.cycle"].create(
+            {
+                "name": "Test Cycle",
+                "program_id": self.program.id,
+                "start_date": fields.Date.today(),
+                "end_date": fields.Date.today(),
+            }
+        )
+
+        self.registrants = self.env["res.partner"]
+        for i in range(5):
+            self.registrants |= self.env["res.partner"].create({"name": f"Registrant {i}", "is_registrant": True})
+
+    def _create_default_manager(self):
+        return self.env["spp.program.entitlement.manager.default"].create(
+            {
+                "name": "Test Default Manager",
+                "program_id": self.program.id,
+                "amount_per_cycle": 100.0,
+            }
+        )
+
+    def _create_cash_manager(self):
+        manager = self.env["spp.program.entitlement.manager.cash"].create(
+            {
+                "name": "Test Cash Manager",
+                "program_id": self.program.id,
+            }
+        )
+        self.env["spp.program.entitlement.manager.cash.item"].create(
+            {
+                "entitlement_id": manager.id,
+                "amount": 100.0,
+            }
+        )
+        return manager
+
+    def _create_entitlements(self, count=5, amount=100.0):
+        """Create multiple entitlements in pending_validation state."""
+        entitlements = self.env["spp.entitlement"]
+        for i in range(count):
+            entitlements |= self.env["spp.entitlement"].create(
+                {
+                    "partner_id": self.registrants[i].id,
+                    "cycle_id": self.cycle.id,
+                    "initial_amount": amount,
+                    "state": "pending_validation",
+                    "is_cash_entitlement": True,
+                }
+            )
+        return entitlements
+
+    def test_default_manager_calls_check_fund_balance_once(self):
+        """DefaultCashEntitlementManager.approve_entitlements must call
+        check_fund_balance at most once per batch."""
+        manager = self._create_default_manager()
+        entitlements = self._create_entitlements(count=3)
+
+        with patch.object(
+            type(manager),
+            "check_fund_balance",
+            wraps=manager.check_fund_balance,
+        ) as mock_check:
+            # Set fund balance high enough to approve all
+            mock_check.return_value = 10000.0
+            manager.approve_entitlements(entitlements)
+            self.assertEqual(
+                mock_check.call_count,
+                1,
+                f"check_fund_balance should be called exactly once, was called {mock_check.call_count} times",
+            )
+
+    def test_cash_manager_calls_check_fund_balance_once(self):
+        """SppCashEntitlementManager.approve_entitlements must call
+        check_fund_balance at most once per batch."""
+        manager = self._create_cash_manager()
+        entitlements = self._create_entitlements(count=3)
+
+        with patch.object(
+            type(manager),
+            "check_fund_balance",
+            wraps=manager.check_fund_balance,
+        ) as mock_check:
+            mock_check.return_value = 10000.0
+            manager.approve_entitlements(entitlements)
+            self.assertEqual(
+                mock_check.call_count,
+                1,
+                f"check_fund_balance should be called exactly once, was called {mock_check.call_count} times",
+            )
+
+    def test_fund_balance_insufficient_stops_early(self):
+        """When fund runs out mid-batch, remaining entitlements are not approved."""
+        manager = self._create_default_manager()
+        entitlements = self._create_entitlements(count=3, amount=100.0)
+
+        with patch.object(
+            type(manager),
+            "check_fund_balance",
+            return_value=250.0,
+        ):
+            state_err, message = manager.approve_entitlements(entitlements)
+            self.assertEqual(state_err, 1)
+            self.assertIn("insufficient", message)
+
+    def test_fund_balance_running_total_correct(self):
+        """Running total must correctly track cumulative approved amounts."""
+        manager = self._create_default_manager()
+        entitlements = self._create_entitlements(count=3, amount=100.0)
+
+        with patch.object(
+            type(manager),
+            "check_fund_balance",
+            return_value=300.0,
+        ):
+            state_err, _message = manager.approve_entitlements(entitlements)
+            self.assertEqual(state_err, 0)
+            # All 3 should be approved (300 fund, 3x100 = 300)
+            for ent in entitlements:
+                ent.invalidate_recordset(["state"])
+                self.assertEqual(ent.state, "approved")


### PR DESCRIPTION
## Summary

- Fetch fund balance once per approval batch instead of per entitlement
- Track remaining balance via running total in Python during the approval loop
- Applies to both `DefaultCashEntitlementManager` and `SppCashEntitlementManager`

## Changes

| File | Change |
|------|--------|
| `managers/entitlement_manager_base.py` | Move `check_fund_balance()` call before the loop, replace `fund_balance` with `remaining_balance` computed from running total |
| `managers/entitlement_manager_cash.py` | Same optimization |
| `tests/test_fund_balance.py` | 4 tests: verify single call via mock, insufficient fund early stop, running total correctness |

## Before

```python
for rec in entitlements:  # N entitlements
    fund_balance = self.check_fund_balance(...)  # 2 SQL queries each = 2N queries
```

## After

```python
fund_balance = self.check_fund_balance(...)  # 2 SQL queries, once
for rec in entitlements:
    remaining_balance = fund_balance - amt  # Python arithmetic
```

## Context

Phase 4 of 9 in the `spp_programs` performance optimization effort. Independent of other phases.

## Test Plan

- `./scripts/test_single_module.sh spp_programs` passes
- Verify approval still stops when funds are insufficient (`test_fund_balance_insufficient_stops_early`)
- Verify all entitlements approved when funds are sufficient (`test_fund_balance_running_total_correct`)