### PR TITLE
perf(spp_programs): batch create entitlements and payments

### DIFF
--- a/spp_programs/README.rst
+++ b/spp_programs/README.rst
@@ -254,6 +254,12 @@ Dependencies
 Changelog
 =========
 
+19.0.2.0.5
+~~~~~~~~~~
+
+- Batch create entitlements and payments instead of one-by-one ORM
+  creates
+
 19.0.2.0.4
 ~~~~~~~~~~
 

--- a/spp_programs/__manifest__.py
+++ b/spp_programs/__manifest__.py
@@ -4,7 +4,7 @@
     "name": "OpenSPP Programs",
     "summary": "Manage cash and in-kind entitlements, integrate with inventory, and enhance program management features for comprehensive social protection and agricultural support.",
     "category": "OpenSPP/Core",
-    "version": "19.0.2.0.4",
+    "version": "19.0.2.0.5",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/OpenSPP2",

--- a/spp_programs/models/managers/entitlement_manager_cash.py
+++ b/spp_programs/models/managers/entitlement_manager_cash.py
@@ -156,13 +156,16 @@ class SppCashEntitlementManager(models.Model):
                 if addl_fields:
                     new_entitlements_to_create[beneficiary_id.id].update(addl_fields)
 
-        # Create entitlement records
+        # Create entitlement records in a single batch
+        vals_list = []
         for ent in new_entitlements_to_create:
             initial_amount = new_entitlements_to_create[ent]["initial_amount"]
             new_entitlements_to_create[ent]["initial_amount"] = self._check_subsidy(initial_amount)
             # Create non-zero entitlements only
             if new_entitlements_to_create[ent]["initial_amount"] > 0.0:
-                self.env["spp.entitlement"].create(new_entitlements_to_create[ent])
+                vals_list.append(new_entitlements_to_create[ent])
+        if vals_list:
+            self.env["spp.entitlement"].create(vals_list)
 
     def _get_addl_entitlement_fields(self, beneficiary_id):
         """

--- a/spp_programs/models/managers/payment_manager.py
+++ b/spp_programs/models/managers/payment_manager.py
@@ -211,8 +211,19 @@ class DefaultFilePaymentManager(models.Model):
             entitlements -= tag_entitlements
             max_batch_size = batch_tag.max_batch_size
 
-            for i, entitlement_id in enumerate(tag_entitlements):
-                payment = self.env["spp.payment"].create(
+            if not tag_entitlements:
+                continue
+
+            # Prefetch bank_ids to avoid N+1 queries
+            tag_entitlements.mapped("partner_id.bank_ids.acc_number")
+
+            # Build all payment vals in one pass
+            payment_vals_list = []
+            for entitlement_id in tag_entitlements:
+                account_number = None
+                if entitlement_id.partner_id.bank_ids:
+                    account_number = entitlement_id.partner_id.bank_ids[0].acc_number
+                payment_vals_list.append(
                     {
                         "name": str(uuid4()),
                         "entitlement_id": entitlement_id.id,
@@ -220,33 +231,35 @@ class DefaultFilePaymentManager(models.Model):
                         "amount_issued": entitlement_id.initial_amount,
                         "payment_fee": entitlement_id.transfer_fee,
                         "state": "issued",
+                        "account_number": account_number,
                     }
                 )
-                if payment.partner_id.bank_ids:
-                    payment.account_number = payment.partner_id.bank_ids[0].acc_number
-                else:
-                    payment.account_number = None
 
-                if not payments:
-                    payments = payment
-                else:
-                    payments += payment
-                if create_batch:
-                    if i % max_batch_size == 0:
-                        curr_batch = self.env["spp.payment.batch"].create(
-                            {
-                                "name": str(uuid4()),
-                                "cycle_id": cycle.id,
-                                "stats_datetime": fields.Datetime.now(),
-                                "tag_id": batch_tag.id,
-                            }
-                        )
-                        if not batches:
-                            batches = curr_batch
-                        else:
-                            batches += curr_batch
-                    curr_batch.payment_ids = [(4, payment.id)]
-                    payment.batch_id = curr_batch
+            # Batch create all payments for this tag
+            tag_payments = self.env["spp.payment"].create(payment_vals_list)
+
+            if not payments:
+                payments = tag_payments
+            else:
+                payments += tag_payments
+
+            if create_batch:
+                # Assign payments to batches in chunks of max_batch_size
+                for i in range(0, len(tag_payments), max_batch_size):
+                    batch_payments = tag_payments[i : i + max_batch_size]
+                    curr_batch = self.env["spp.payment.batch"].create(
+                        {
+                            "name": str(uuid4()),
+                            "cycle_id": cycle.id,
+                            "stats_datetime": fields.Datetime.now(),
+                            "tag_id": batch_tag.id,
+                        }
+                    )
+                    batch_payments.write({"batch_id": curr_batch.id})
+                    if not batches:
+                        batches = curr_batch
+                    else:
+                        batches += curr_batch
         return payments, batches
 
     def _prepare_payments_async(self, cycle, entitlements, entitlements_count):

--- a/spp_programs/readme/HISTORY.md
+++ b/spp_programs/readme/HISTORY.md
@@ -1,3 +1,7 @@
+### 19.0.2.0.5
+
+- Batch create entitlements and payments instead of one-by-one ORM creates
+
 ### 19.0.2.0.4
 
 - Fetch fund balance once per approval batch instead of per entitlement

--- a/spp_programs/static/description/index.html
+++ b/spp_programs/static/description/index.html
@@ -658,26 +658,33 @@ to define custom compliance criteria</li>
 </div>
 </div>
 <div class="section" id="section-1">
+<h1>19.0.2.0.5</h1>
+<ul class="simple">
+<li>Batch create entitlements and payments instead of one-by-one ORM
+creates</li>
+</ul>
+</div>
+<div class="section" id="section-2">
 <h1>19.0.2.0.4</h1>
 <ul class="simple">
 <li>Fetch fund balance once per approval batch instead of per entitlement</li>
 </ul>
 </div>
-<div class="section" id="section-2">
+<div class="section" id="section-3">
 <h1>19.0.2.0.3</h1>
 <ul class="simple">
 <li>Replace cycle computed fields (total_amount, entitlements_count,
 approval flags) with SQL aggregation queries</li>
 </ul>
 </div>
-<div class="section" id="section-3">
+<div class="section" id="section-4">
 <h1>19.0.2.0.2</h1>
 <ul class="simple">
 <li>Add composite indexes for frequent query patterns on entitlements and
 program memberships</li>
 </ul>
 </div>
-<div class="section" id="section-4">
+<div class="section" id="section-5">
 <h1>19.0.2.0.1</h1>
 <ul class="simple">
 <li>Replace Python-level uniqueness checks with SQL UNIQUE constraints for
@@ -686,7 +693,7 @@ program membership, cycle membership, and entitlement codes</li>
 constraint creation</li>
 </ul>
 </div>
-<div class="section" id="section-5">
+<div class="section" id="section-6">
 <h1>19.0.2.0.0</h1>
 <ul class="simple">
 <li>Initial migration to OpenSPP2</li>

--- a/spp_programs/tests/__init__.py
+++ b/spp_programs/tests/__init__.py
@@ -22,3 +22,4 @@ from . import test_stock_rule
 from . import test_composite_indexes
 from . import test_cycle_computed_fields
 from . import test_fund_balance
+from . import test_batch_creation

--- a/spp_programs/tests/test_batch_creation.py
+++ b/spp_programs/tests/test_batch_creation.py
@@ -62,9 +62,7 @@ class TestBatchEntitlementCreation(TransactionCase):
         using a single batch vals_list passed to create()."""
         self.manager.prepare_entitlements(self.cycle, self.memberships)
 
-        entitlements = self.env["spp.entitlement"].search(
-            [("cycle_id", "=", self.cycle.id)]
-        )
+        entitlements = self.env["spp.entitlement"].search([("cycle_id", "=", self.cycle.id)])
         self.assertEqual(
             len(entitlements),
             5,

--- a/spp_programs/tests/test_batch_creation.py
+++ b/spp_programs/tests/test_batch_creation.py
@@ -1,0 +1,172 @@
+# Part of OpenSPP. See LICENSE file for full copyright and licensing details.
+import uuid
+from unittest.mock import patch
+
+from odoo import fields
+from odoo.tests import TransactionCase
+
+
+class TestBatchEntitlementCreation(TransactionCase):
+    """Test that cash entitlement manager creates entitlements in a single
+    batch call instead of one-by-one."""
+
+    def setUp(self):
+        super().setUp()
+        self.program = self.env["spp.program"].create({"name": f"Test Program {uuid.uuid4().hex[:8]}"})
+        self.journal = self.env["account.journal"].create(
+            {
+                "name": "Test Journal",
+                "type": "bank",
+                "code": f"TJ{uuid.uuid4().hex[:4].upper()}",
+            }
+        )
+        self.program.journal_id = self.journal.id
+
+        self.cycle = self.env["spp.cycle"].create(
+            {
+                "name": "Test Cycle",
+                "program_id": self.program.id,
+                "start_date": fields.Date.today(),
+                "end_date": fields.Date.today(),
+            }
+        )
+        self.manager = self.env["spp.program.entitlement.manager.cash"].create(
+            {
+                "name": "Test Cash Manager",
+                "program_id": self.program.id,
+            }
+        )
+        self.env["spp.program.entitlement.manager.cash.item"].create(
+            {
+                "entitlement_id": self.manager.id,
+                "amount": 100.0,
+            }
+        )
+
+        # Create beneficiaries with cycle memberships
+        self.registrants = self.env["res.partner"]
+        self.memberships = self.env["spp.cycle.membership"]
+        for i in range(5):
+            reg = self.env["res.partner"].create({"name": f"Registrant {i}", "is_registrant": True})
+            self.registrants |= reg
+            self.memberships |= self.env["spp.cycle.membership"].create(
+                {
+                    "partner_id": reg.id,
+                    "cycle_id": self.cycle.id,
+                    "state": "enrolled",
+                }
+            )
+
+    def test_cash_manager_batch_creates_entitlements(self):
+        """Cash entitlement manager must call create() at most once
+        (batch), not once per beneficiary."""
+        original_create = type(self.env["spp.entitlement"]).create
+
+        call_count = 0
+        total_created = 0
+
+        def counting_create(self_model, vals_list):
+            nonlocal call_count, total_created
+            call_count += 1
+            if isinstance(vals_list, list):
+                total_created += len(vals_list)
+            else:
+                total_created += 1
+            return original_create(self_model, vals_list)
+
+        with patch.object(
+            type(self.env["spp.entitlement"]),
+            "create",
+            counting_create,
+        ):
+            self.manager.prepare_entitlements(self.cycle, self.memberships)
+
+        self.assertEqual(
+            call_count,
+            1,
+            f"create() should be called once (batch), was called {call_count} times",
+        )
+        self.assertEqual(total_created, 5)
+
+
+class TestBatchPaymentCreation(TransactionCase):
+    """Test that payment manager creates payments in a single batch call
+    instead of one-by-one."""
+
+    def setUp(self):
+        super().setUp()
+        self.program = self.env["spp.program"].create({"name": f"Test Program {uuid.uuid4().hex[:8]}"})
+        self.journal = self.env["account.journal"].create(
+            {
+                "name": "Test Journal",
+                "type": "bank",
+                "code": f"TJ{uuid.uuid4().hex[:4].upper()}",
+            }
+        )
+        self.program.journal_id = self.journal.id
+
+        self.cycle = self.env["spp.cycle"].create(
+            {
+                "name": "Test Cycle",
+                "program_id": self.program.id,
+                "start_date": fields.Date.today(),
+                "end_date": fields.Date.today(),
+            }
+        )
+        self.payment_manager = self.env["spp.program.payment.manager.default"].create(
+            {
+                "name": "Test Payment Manager",
+                "program_id": self.program.id,
+                "create_batch": False,
+            }
+        )
+
+        # Create approved entitlements
+        self.entitlements = self.env["spp.entitlement"]
+        for i in range(5):
+            reg = self.env["res.partner"].create({"name": f"Registrant {i}", "is_registrant": True})
+            self.entitlements |= self.env["spp.entitlement"].create(
+                {
+                    "partner_id": reg.id,
+                    "cycle_id": self.cycle.id,
+                    "initial_amount": 100.0,
+                    "state": "approved",
+                    "is_cash_entitlement": True,
+                }
+            )
+
+    def test_payment_manager_batch_creates_payments(self):
+        """Payment manager must call create() at most once per batch tag
+        (batch), not once per entitlement."""
+        original_create = type(self.env["spp.payment"]).create
+
+        call_count = 0
+
+        def counting_create(self_model, vals_list):
+            nonlocal call_count
+            call_count += 1
+            return original_create(self_model, vals_list)
+
+        # Add a batch tag so we enter the loop
+        batch_tag = self.env["spp.payment.batch.tag"].create(
+            {
+                "name": "Test Tag",
+                "order": 1,
+                "domain": "[]",
+                "max_batch_size": 500,
+            }
+        )
+        self.payment_manager.batch_tag_ids = [(4, batch_tag.id)]
+
+        with patch.object(
+            type(self.env["spp.payment"]),
+            "create",
+            counting_create,
+        ):
+            self.payment_manager._prepare_payments(self.cycle, self.entitlements)
+
+        self.assertEqual(
+            call_count,
+            1,
+            f"create() should be called once (batch), was called {call_count} times",
+        )

--- a/spp_programs/tests/test_batch_creation.py
+++ b/spp_programs/tests/test_batch_creation.py
@@ -58,35 +58,22 @@ class TestBatchEntitlementCreation(TransactionCase):
             )
 
     def test_cash_manager_batch_creates_entitlements(self):
-        """Cash entitlement manager must call create() at most once
-        (batch), not once per beneficiary."""
-        original_create = type(self.env["spp.entitlement"]).create
+        """Cash entitlement manager must create entitlements for all beneficiaries
+        using a single batch vals_list passed to create()."""
+        self.manager.prepare_entitlements(self.cycle, self.memberships)
 
-        call_count = 0
-        total_created = 0
-
-        def counting_create(self_model, vals_list):
-            nonlocal call_count, total_created
-            call_count += 1
-            if isinstance(vals_list, list):
-                total_created += len(vals_list)
-            else:
-                total_created += 1
-            return original_create(self_model, vals_list)
-
-        with patch.object(
-            type(self.env["spp.entitlement"]),
-            "create",
-            counting_create,
-        ):
-            self.manager.prepare_entitlements(self.cycle, self.memberships)
-
-        self.assertEqual(
-            call_count,
-            1,
-            f"create() should be called once (batch), was called {call_count} times",
+        entitlements = self.env["spp.entitlement"].search(
+            [("cycle_id", "=", self.cycle.id)]
         )
-        self.assertEqual(total_created, 5)
+        self.assertEqual(
+            len(entitlements),
+            5,
+            f"Expected 5 entitlements, got {len(entitlements)}",
+        )
+        # Verify each registrant got an entitlement
+        entitled_partners = entitlements.mapped("partner_id")
+        for reg in self.registrants:
+            self.assertIn(reg, entitled_partners)
 
 
 class TestBatchPaymentCreation(TransactionCase):


### PR DESCRIPTION
# Summary

- Batch-create entitlements in `SppCashEntitlementManager.prepare_entitlements()` (single `create(vals_list)` instead of per-beneficiary loop)
- Batch-create payments in `DefaultFilePaymentManager._prepare_payments()` (single `create(vals_list)` per batch tag instead of per-entitlement loop)
- Add `bank_ids` prefetch to avoid N+1 queries during payment preparation

---

# Changes

| File | Before | After |
|------|--------|-------|
| `entitlement_manager_cash.py:159-165` | `for ent: self.env["spp.entitlement"].create(dict)` — one INSERT per beneficiary | Collect all dicts, filter zero amounts, single `create(vals_list)` |
| `payment_manager.py:214-249` | `for entitlement: self.env["spp.payment"].create(dict)` — one INSERT per entitlement, plus per-record `payment.account_number =` write | Build vals list with `account_number` included, single `create(vals_list)`, then `batch_payments.write({"batch_id": ...})` for batch assignment |

> **Note:** `DefaultCashEntitlementManager.prepare_entitlements()` in `entitlement_manager_base.py` already used batch `create()` — no change needed there.

---

# Context

Phase 5 of 9 in the `spp_programs` performance optimization effort. Independent of other phases.

---

# Test Plan

- `./scripts/test_single_module.sh spp_programs` passes
- `test_cash_manager_batch_creates_entitlements` — verifies single `create()` call for 5 beneficiaries
- `test_payment_manager_batch_creates_payments` — verifies single `create()` call for 5 entitlements