### PR TITLE
fix: skip field types before getattr and isolate detail prefetch

### DIFF
--- a/spp_api_v2_change_request/__manifest__.py
+++ b/spp_api_v2_change_request/__manifest__.py
@@ -1,7 +1,7 @@
 {  # pylint: disable=pointless-statement
     "name": "OpenSPP API V2 - Change Request",
     "category": "OpenSPP/Integration",
-    "version": "19.0.2.0.0",
+    "version": "19.0.2.0.1",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/OpenSPP2",

--- a/spp_api_v2_change_request/services/change_request_service.py
+++ b/spp_api_v2_change_request/services/change_request_service.py
@@ -204,8 +204,15 @@ class ChangeRequestService:
         # Get fields from the model
         model_fields = detail._fields
 
+        # Field types that are skipped entirely — check BEFORE reading the
+        # value so that computed fields of these types are never triggered.
+        _SKIP_FIELD_TYPES = {"many2many", "one2many", "binary"}
+
         for field_name, field in model_fields.items():
             if field_name.startswith("_") or field_name in DETAIL_SKIP_FIELDS:
+                continue
+
+            if field.type in _SKIP_FIELD_TYPES:
                 continue
 
             value = getattr(detail, field_name)
@@ -230,19 +237,10 @@ class ChangeRequestService:
                         }
                     else:
                         result[field_name] = value.name if hasattr(value, "name") else str(value.id)
-            elif field.type == "many2many":
-                # Skip many2many for now
-                continue
-            elif field.type == "one2many":
-                # Skip one2many for now
-                continue
             elif field.type == "date":
                 result[field_name] = value.isoformat() if value else None
             elif field.type == "datetime":
                 result[field_name] = value.isoformat() if value else None
-            elif field.type == "binary":
-                # Skip binary fields in API
-                continue
             else:
                 result[field_name] = value
 

--- a/spp_change_request_v2/__manifest__.py
+++ b/spp_change_request_v2/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "OpenSPP Change Request V2",
-    "version": "19.0.2.0.0",
+    "version": "19.0.2.0.1",
     "sequence": 50,
     "category": "OpenSPP",
     "summary": "Configuration-driven change request system with UX improvements, conflict detection and duplicate prevention",

--- a/spp_change_request_v2/models/change_request.py
+++ b/spp_change_request_v2/models/change_request.py
@@ -713,10 +713,15 @@ class SPPChangeRequest(models.Model):
     # ══════════════════════════════════════════════════════════════════════════
 
     def get_detail(self):
-        """Get the detail record for this CR."""
+        """Get the detail record for this CR.
+
+        Uses with_prefetch() to isolate from _ensure_detail's sudo()
+        prefetch set — without this, non-stored computed fields can
+        trigger record-rule checks against the wrong user.
+        """
         self.ensure_one()
         if self.detail_res_model and self.detail_res_id:
-            return self.env[self.detail_res_model].browse(self.detail_res_id)
+            return self.env[self.detail_res_model].browse(self.detail_res_id).with_prefetch()
         return None
 
     def _ensure_detail(self):


### PR DESCRIPTION
_serialize_detail called getattr() on all fields before checking if the field type should be skipped (many2many, one2many, binary). This triggered computed Many2many fields like household_member_ids, causing AccessError when the compute traverses res.partner records.

Also isolate get_detail() prefetch set via with_prefetch() to prevent sudo-contamination from _ensure_detail() causing record-rule checks against the wrong user (public user instead of authenticated user).

## **Why is this change needed?**

When creating a Change Request via the FastAPI endpoint (e.g. `add_member_4ps`), `_serialize_detail()` triggers `AccessError: Public user (id=3) doesn't have 'read' access to res.partner`. This happens because:

1. `_serialize_detail()` calls `getattr(detail, field_name)` on every field before checking if the field type (`many2many`, `one2many`, `binary`) should be skipped. For non-stored computed Many2many fields like `household_member_ids`, `getattr` triggers the compute method, which traverses `res.partner` records and fails with AccessError.

2. `get_detail()` returns a record that shares the prefetch set with `_ensure_detail()`'s `sudo()` context. This causes Odoo's prefetch mechanism to trigger record-rule checks against the public user (uid=3, the FastAPI endpoint's base user) instead of the authenticated user.

## **How was the change implemented?**

1. **`spp_api_v2_change_request/services/change_request_service.py`**: Moved the field type check (`many2many`, `one2many`, `binary`) to run **before** `getattr()`. Previously these types were checked after `getattr()` had already triggered side effects. The skip set is defined once as `_SKIP_FIELD_TYPES` and checked in the loop before any field access.

2. **`spp_change_request_v2/models/change_request.py`**: `get_detail()` now calls `.with_prefetch()` on the browsed record to isolate it from `_ensure_detail()`'s sudo prefetch set.

## **New unit tests**

None — this is a bugfix to existing behavior, not a new feature. Existing tests should continue to pass.

## **Unit tests executed by the author**

```bash
python -m odoo -c odoo-dev.conf -p 5679 --test-enable -i spp_change_request_v2,spp_api_v2_change_request --stop-after-init
```

## **How to test manually**

1. Configure FastAPI endpoint with `user_id = base.public_user` (the default)
2. Authenticate via RS256 Keycloak token as a user with `Change Requests / User` group
3. POST a Change Request submission that includes an `addMembers` section (type `add_member_4ps`)
4. **Before fix**: `AccessError` — Public user (id=3) doesn't have 'read' access to res.partner
5. **After fix**: CR created successfully, response returned with detail fields

Also verify CR creation via the Odoo web UI still works normally.

## **Related links**

N/A
