### PR TITLE
fix: use restart: always in production docker compose

### DIFF
--- a/docker/docker-compose.production.yml
+++ b/docker/docker-compose.production.yml
@@ -68,7 +68,7 @@ services:
       - traefik_logs:/var/log/traefik
     networks:
       - openspp-prod
-    restart: unless-stopped
+    restart: always
     # Traefik should start first and stay healthy
     healthcheck:
       test: ["CMD", "traefik", "healthcheck"]
@@ -98,7 +98,7 @@ services:
       # - ./initdb:/docker-entrypoint-initdb.d:ro
     networks:
       - openspp-prod
-    restart: unless-stopped
+    restart: always
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${DB_USER:-odoo} -d ${DB_NAME:-openspp}"]
       interval: 10s
@@ -174,7 +174,7 @@ services:
       - odoo_addons:/mnt/extra-addons
     networks:
       - openspp-prod
-    restart: unless-stopped
+    restart: always
     labels:
       # Traefik configuration
       - "traefik.enable=true"
@@ -284,7 +284,7 @@ services:
       - odoo_addons:/mnt/extra-addons
     networks:
       - openspp-prod
-    restart: unless-stopped
+    restart: always
     deploy:
       resources:
         limits:
@@ -323,7 +323,7 @@ services:
       - backup_data:/backups
     networks:
       - openspp-prod
-    restart: unless-stopped
+    restart: always
 
   # ==========================================================================
   # ClamAV - Antivirus scanning (optional, enable with --profile clamav)
@@ -346,7 +346,7 @@ services:
       - clamav_data:/var/lib/clamav
     networks:
       - openspp-prod
-    restart: unless-stopped
+    restart: always
     healthcheck:
       test: ["CMD", "/usr/local/bin/clamdcheck.sh"]
       interval: 60s

--- a/docker/docker-compose.production.yml
+++ b/docker/docker-compose.production.yml
@@ -285,6 +285,12 @@ services:
     networks:
       - openspp-prod
     restart: always
+    healthcheck:
+      test: ["CMD-SHELL", "pgrep -f 'odoo.addons.job_worker.cli' || exit 1"]
+      interval: 30s
+      timeout: 10s
+      start_period: 60s
+      retries: 3
     deploy:
       resources:
         limits:


### PR DESCRIPTION
## Summary
- Changed `restart: unless-stopped` to `restart: always` for all services in `docker/docker-compose.production.yml`
- Follows [Docker Compose production best practices](https://docs.docker.com/compose/how-tos/production/)
- Affects: traefik, db, odoo, queue-worker, backup, clamav

Closes #64

## Test plan
- [ ] Verify `docker compose -f docker/docker-compose.production.yml config` parses without errors
- [ ] Confirm all services have `restart: always` in the parsed output

🤖 Generated with [Claude Code](https://claude.com/claude-code)