### PR TITLE
feat: add Nginx reverse proxy as alternative to Traefik

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,9 +98,13 @@ static/security/
 docker-compose.override.yml
 
 # Production environment files (contain secrets)
+docker/.env
 docker/.env.production
 .env.production
 .env.local
+
+# Fluentd runtime log output
+docker/fluentd/log/
 
 # act (local GitHub Actions runner)
 .act-secrets

--- a/docker/.env.production.example
+++ b/docker/.env.production.example
@@ -6,6 +6,21 @@
 # SECURITY: Never commit .env.production to version control!
 
 # =============================================================================
+# COMPOSE PROFILE - Choose deployment mode
+# =============================================================================
+# Nginx mode (choose one):
+#   https = Nginx with SSL + Certbot (production)
+#   http  = Nginx HTTP only, no SSL (dev / isolated on-premises)
+# Optional add-ons (comma-separated):
+#   clamav = ClamAV antivirus scanning (adds ~1GB RAM)
+#
+# Examples:
+#   COMPOSE_PROFILES=https            # HTTPS only
+#   COMPOSE_PROFILES=https,clamav     # HTTPS + antivirus
+#   COMPOSE_PROFILES=http             # HTTP only (dev)
+COMPOSE_PROFILES=https
+
+# =============================================================================
 # REQUIRED - You must set these values
 # =============================================================================
 
@@ -60,6 +75,12 @@ DB_SSLMODE=prefer
 # Number of Odoo workers (rule: (CPU cores * 2) + 1; ~1 worker per 6 concurrent users)
 ODOO_WORKERS=2
 
+# CPU limits (number of cores)
+ODOO_CPU_LIMIT=2
+DB_CPU_LIMIT=2
+QUEUE_CPU_LIMIT=1
+NGINX_CPU_LIMIT=1
+
 # Memory limits (Docker format: 512M, 1G, 2G, etc.)
 ODOO_MEMORY_LIMIT=4G
 ODOO_MEMORY_RESERVATION=2G
@@ -67,6 +88,8 @@ DB_MEMORY_LIMIT=4G
 DB_MEMORY_RESERVATION=2G
 QUEUE_MEMORY_LIMIT=2G
 QUEUE_MEMORY_RESERVATION=1G
+NGINX_MEMORY_LIMIT=256M
+NGINX_MEMORY_RESERVATION=64M
 
 # Per-worker memory limits (in bytes)
 # Soft: worker recycled when exceeded
@@ -108,6 +131,13 @@ ODOO_INIT_MODULES=spp_base
 # Log level: debug, info, warn, error, critical
 LOG_LEVEL=warn
 
+# Fluentd log output path (Nginx stack only)
+# Host path where Fluentd writes collected logs when using the local/file backend.
+# Can be a local directory, an NFS mount, or any writable path on the host.
+# Not needed when using cloud backends (S3, GCS, Azure, MinIO).
+# Default: ./fluentd/log (relative to docker/ directory)
+FLUENTD_LOG_PATH=./fluentd/log
+
 # =============================================================================
 # BACKUPS
 # =============================================================================
@@ -117,18 +147,11 @@ LOG_LEVEL=warn
 BACKUP_SCHEDULE=0 2 * * *
 
 # =============================================================================
-# ANTIVIRUS (Optional - enable with --profile clamav)
+# ANTIVIRUS (enable with COMPOSE_PROFILES=https,clamav)
 # =============================================================================
 
-# Enable ClamAV antivirus scanning when:
-#   - Accepting file uploads from beneficiaries
-#   - Processing documents from external sources
-#   - Compliance requirements mandate it
-#
-# To enable: docker compose -f docker/docker-compose.production.yml --profile clamav up -d
-# Then install spp_attachment_av_scan module in Odoo
-
-# Memory limits for ClamAV (needs ~1GB for virus definitions)
+# ClamAV needs ~1GB RAM for virus definitions.
+# After enabling, install spp_attachment_av_scan module in Odoo.
 CLAMAV_MEMORY_LIMIT=1536M
 CLAMAV_MEMORY_RESERVATION=512M
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -23,19 +23,44 @@ See [Production Deployment](#production-deployment) below.
 | ------------------------------- | ------------------------------------------------- |
 | `Dockerfile`                    | Multi-stage build for OpenSPP                     |
 | `docker-compose.production.yml` | Production stack (Traefik + Odoo + Queue Worker)  |
+| `docker-compose.nginx.yml`      | Production stack (Nginx + Certbot + Fluentd)      |
 | `.env.production.example`       | Production configuration template                 |
 | `entrypoint.sh`                 | Container entrypoint with database initialization |
 | `odoo.conf.template`            | Odoo configuration template                       |
+| `nginx/odoo.conf.template`      | Nginx HTTPS reverse proxy config (Odoo docs)      |
+| `nginx/odoo-http-only.conf.template` | Nginx HTTP-only reverse proxy config         |
+| `nginx/certbot-init.sh`         | Bootstrap script for initial SSL certificate      |
+| `fluentd/`                      | Fluentd log collection configs                    |
+| `backup.sh`                     | Automated PostgreSQL/PostGIS backup script        |
+| `backup-entrypoint.sh`          | Backup container entrypoint with cron scheduling  |
 | `requirements.txt`              | Python dependencies beyond module manifests       |
 | `requirements-dev.txt`          | Development-only dependencies                     |
 
 ## Production Deployment
 
-### Architecture
+Two production compose files are available:
+
+| Compose file                    | Reverse proxy | SSL            | Logging  |
+| ------------------------------- | ------------- | -------------- | -------- |
+| `docker-compose.production.yml` | Traefik       | Let's Encrypt (automatic) | Docker default |
+| `docker-compose.nginx.yml`      | Nginx         | Certbot (Let's Encrypt)   | Fluentd  |
+
+### Architecture (Traefik)
 
 ```
 Internet -> Traefik (SSL) -> Odoo (workers) -> PostgreSQL
                           -> Queue Worker
+```
+
+### Architecture (Nginx)
+
+```
+Internet -> Nginx (SSL) -> Odoo (workers) -> PostgreSQL
+                        -> Queue Worker
+         Certbot (certificate renewal)
+         Fluentd (log collection -> local/NFS, S3, GCS, Azure, MinIO)
+         ClamAV (antivirus, optional)
+         Backup (daily PostgreSQL dumps)
 ```
 
 ### Requirements
@@ -73,14 +98,100 @@ ODOO_ADMIN_PASSWD=<strong-random-password>
 3. **Start services:**
 
 ```bash
+# Traefik stack
 docker compose -f docker/docker-compose.production.yml up -d
+
+# Nginx stack (HTTPS)
+docker compose -f docker/docker-compose.nginx.yml --profile https up -d
 ```
 
 4. **View logs:**
 
 ```bash
 docker compose -f docker/docker-compose.production.yml logs -f odoo
+# or
+docker compose -f docker/docker-compose.nginx.yml logs -f odoo
 ```
+
+### Nginx Profiles
+
+The Nginx compose file uses profiles to select the deployment mode:
+
+| Profile  | Services added               | Use case                                   |
+| -------- | ---------------------------- | ------------------------------------------ |
+| `https`  | Nginx (SSL) + Certbot        | Production with HTTPS and auto-renewal     |
+| `http`   | Nginx (HTTP only)             | Dev or isolated on-premises networks       |
+| `clamav` | ClamAV antivirus              | File upload scanning (~1GB extra RAM)      |
+
+Profiles can be combined:
+
+```bash
+# HTTPS + ClamAV
+docker compose -f docker/docker-compose.nginx.yml --profile https --profile clamav up -d
+
+# Or set in .env.production (no --profile flags needed):
+COMPOSE_PROFILES=https,clamav
+```
+
+HTTP-only mode (no SSL, no Certbot):
+
+```bash
+docker compose -f docker/docker-compose.nginx.yml --profile http up -d
+```
+
+### Nginx SSL Certificate Setup
+
+1. **Obtain initial certificate** (HTTPS profile only):
+
+```bash
+docker compose -f docker/docker-compose.nginx.yml run --rm certbot \
+  certonly --webroot -w /var/www/certbot \
+  --email ${ACME_EMAIL} -d ${DOMAIN} --agree-tos --non-interactive
+
+# Reload nginx to pick up the new certificate
+docker compose -f docker/docker-compose.nginx.yml exec nginx nginx -s reload
+```
+
+2. **Schedule renewal** via system cron (certificates expire every 90 days):
+
+```bash
+# Add to system crontab (runs monthly)
+0 3 1 * * docker compose -f /path/to/docker/docker-compose.nginx.yml run --rm certbot renew && docker compose -f /path/to/docker/docker-compose.nginx.yml exec nginx nginx -s reload
+```
+
+### Nginx Security Hardening
+
+All services in the Nginx compose file include:
+
+- **Capability dropping:** `cap_drop: ALL` with minimal `cap_add` per service
+- **No privilege escalation:** `security_opt: no-new-privileges:true`
+- **Read-only filesystems:** `read_only: true` with targeted tmpfs mounts (where possible)
+- **Resource limits:** CPU and memory limits on every service
+- **Log rotation:** `json-file` driver with 5MB/3-file rotation (15MB max per service)
+- **SELinux compatibility:** `:ro,z` and `:rw,z` volume flags
+
+Nginx adds: rate limiting, security headers (HSTS, CSP, X-Frame-Options), OCSP stapling, proxy buffering, `/web/database` blocking.
+
+### Centralized Logging with Fluentd (Nginx stack)
+
+The Nginx compose file includes Fluentd for centralized log collection. It uses file tailing (not Docker's log driver), so `docker compose logs` keeps working and logs are never lost if Fluentd goes down.
+
+**Default backend:** Local filesystem / NFS (`output-file.conf`)
+
+**Available backends:**
+
+| Backend           | Config file                      | Plugins required |
+| ----------------- | -------------------------------- | ---------------- |
+| Local / NFS       | `output-file.conf` (default)     | None (built-in)  |
+| AWS S3            | `output-s3.conf.example`         | fluent-plugin-s3 |
+| Google Cloud GCS  | `output-gcs.conf.example`        | fluent-plugin-gcs|
+| Azure Blob        | `output-azure.conf.example`      | fluent-plugin-azure-storage-append-blob |
+| MinIO             | `output-minio.conf.example`      | fluent-plugin-s3 |
+
+To switch backends:
+
+1. Edit `docker/fluentd/fluent.conf` to `@include` the desired output config
+2. For cloud backends, uncomment the `build:` block in the fluentd service to install plugins
 
 ### Using External Database (RDS/Cloud SQL)
 
@@ -90,7 +201,7 @@ docker compose -f docker/docker-compose.production.yml logs -f odoo
 DATABASE_URL=postgres://user:password@hostname:5432/openspp?sslmode=require
 ```
 
-2. Comment out or remove the `db` service in `docker-compose.production.yml`
+2. Comment out or remove the `db` service in the compose file
 
 3. Update `depends_on` in `odoo` and `queue-worker` services
 
@@ -140,8 +251,11 @@ ClamAV antivirus scanning is available as an optional profile. Enable it when:
 **Enable ClamAV:**
 
 ```bash
-# Start with ClamAV profile
+# Traefik stack
 docker compose -f docker/docker-compose.production.yml --profile clamav up -d
+
+# Nginx stack
+docker compose -f docker/docker-compose.nginx.yml --profile https --profile clamav up -d
 ```
 
 **Configure Odoo:**
@@ -172,6 +286,7 @@ docker compose -f docker/docker-compose.production.yml exec clamav clamscan --ve
 
 | Variable            | Description                           |
 | ------------------- | ------------------------------------- |
+| `COMPOSE_PROFILES`  | Deployment profile (Nginx stack only) |
 | `DB_PASSWORD`       | PostgreSQL password                   |
 | `ODOO_ADMIN_PASSWD` | Odoo admin/master password            |
 | `DOMAIN`            | Domain name (production only)         |
@@ -198,6 +313,20 @@ docker compose -f docker/docker-compose.production.yml exec clamav clamscan --ve
 | `ODOO_MEMORY_HARD`  | 2684354560 | Hard memory limit per worker (bytes)  |
 | `ODOO_TIME_CPU`     | 600        | CPU time limit per request (seconds)  |
 | `ODOO_TIME_REAL`    | 1200       | Real time limit per request (seconds) |
+
+### Resource Limits (Nginx stack)
+
+| Variable                     | Default | Description                    |
+| ---------------------------- | ------- | ------------------------------ |
+| `ODOO_CPU_LIMIT`             | 2       | Odoo CPU cores                 |
+| `ODOO_MEMORY_LIMIT`         | 4G      | Odoo memory limit              |
+| `DB_CPU_LIMIT`               | 2       | PostgreSQL CPU cores           |
+| `DB_MEMORY_LIMIT`           | 4G      | PostgreSQL memory limit        |
+| `QUEUE_CPU_LIMIT`            | 1       | Queue worker CPU cores         |
+| `QUEUE_MEMORY_LIMIT`        | 2G      | Queue worker memory limit      |
+| `NGINX_CPU_LIMIT`            | 1       | Nginx CPU cores                |
+| `NGINX_MEMORY_LIMIT`        | 256M    | Nginx memory limit             |
+| `CLAMAV_MEMORY_LIMIT`       | 1536M   | ClamAV memory limit            |
 
 ### Logging
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -19,31 +19,31 @@ See [Production Deployment](#production-deployment) below.
 
 ## Files
 
-| File                            | Description                                       |
-| ------------------------------- | ------------------------------------------------- |
-| `Dockerfile`                    | Multi-stage build for OpenSPP                     |
-| `docker-compose.production.yml` | Production stack (Traefik + Odoo + Queue Worker)  |
-| `docker-compose.nginx.yml`      | Production stack (Nginx + Certbot + Fluentd)      |
-| `.env.production.example`       | Production configuration template                 |
-| `entrypoint.sh`                 | Container entrypoint with database initialization |
-| `odoo.conf.template`            | Odoo configuration template                       |
-| `nginx/odoo.conf.template`      | Nginx HTTPS reverse proxy config (Odoo docs)      |
-| `nginx/odoo-http-only.conf.template` | Nginx HTTP-only reverse proxy config         |
-| `nginx/certbot-init.sh`         | Bootstrap script for initial SSL certificate      |
-| `fluentd/`                      | Fluentd log collection configs                    |
-| `backup.sh`                     | Automated PostgreSQL/PostGIS backup script        |
-| `backup-entrypoint.sh`          | Backup container entrypoint with cron scheduling  |
-| `requirements.txt`              | Python dependencies beyond module manifests       |
-| `requirements-dev.txt`          | Development-only dependencies                     |
+| File                                 | Description                                       |
+| ------------------------------------ | ------------------------------------------------- |
+| `Dockerfile`                         | Multi-stage build for OpenSPP                     |
+| `docker-compose.production.yml`      | Production stack (Traefik + Odoo + Queue Worker)  |
+| `docker-compose.nginx.yml`           | Production stack (Nginx + Certbot + Fluentd)      |
+| `.env.production.example`            | Production configuration template                 |
+| `entrypoint.sh`                      | Container entrypoint with database initialization |
+| `odoo.conf.template`                 | Odoo configuration template                       |
+| `nginx/odoo.conf.template`           | Nginx HTTPS reverse proxy config (Odoo docs)      |
+| `nginx/odoo-http-only.conf.template` | Nginx HTTP-only reverse proxy config              |
+| `nginx/certbot-init.sh`              | Bootstrap script for initial SSL certificate      |
+| `fluentd/`                           | Fluentd log collection configs                    |
+| `backup.sh`                          | Automated PostgreSQL/PostGIS backup script        |
+| `backup-entrypoint.sh`               | Backup container entrypoint with cron scheduling  |
+| `requirements.txt`                   | Python dependencies beyond module manifests       |
+| `requirements-dev.txt`               | Development-only dependencies                     |
 
 ## Production Deployment
 
 Two production compose files are available:
 
-| Compose file                    | Reverse proxy | SSL            | Logging  |
-| ------------------------------- | ------------- | -------------- | -------- |
+| Compose file                    | Reverse proxy | SSL                       | Logging        |
+| ------------------------------- | ------------- | ------------------------- | -------------- |
 | `docker-compose.production.yml` | Traefik       | Let's Encrypt (automatic) | Docker default |
-| `docker-compose.nginx.yml`      | Nginx         | Certbot (Let's Encrypt)   | Fluentd  |
+| `docker-compose.nginx.yml`      | Nginx         | Certbot (Let's Encrypt)   | Fluentd        |
 
 ### Architecture (Traefik)
 
@@ -117,11 +117,11 @@ docker compose -f docker/docker-compose.nginx.yml logs -f odoo
 
 The Nginx compose file uses profiles to select the deployment mode:
 
-| Profile  | Services added               | Use case                                   |
-| -------- | ---------------------------- | ------------------------------------------ |
-| `https`  | Nginx (SSL) + Certbot        | Production with HTTPS and auto-renewal     |
-| `http`   | Nginx (HTTP only)             | Dev or isolated on-premises networks       |
-| `clamav` | ClamAV antivirus              | File upload scanning (~1GB extra RAM)      |
+| Profile  | Services added        | Use case                               |
+| -------- | --------------------- | -------------------------------------- |
+| `https`  | Nginx (SSL) + Certbot | Production with HTTPS and auto-renewal |
+| `http`   | Nginx (HTTP only)     | Dev or isolated on-premises networks   |
+| `clamav` | ClamAV antivirus      | File upload scanning (~1GB extra RAM)  |
 
 Profiles can be combined:
 
@@ -156,7 +156,7 @@ docker compose -f docker/docker-compose.nginx.yml exec nginx nginx -s reload
 
 ```bash
 # Add to system crontab (runs monthly)
-0 3 1 * * docker compose -f /path/to/docker/docker-compose.nginx.yml run --rm certbot renew && docker compose -f /path/to/docker/docker-compose.nginx.yml exec nginx nginx -s reload
+0 3 1 * * cd /path/to/your/project && docker compose -f docker/docker-compose.nginx.yml run --rm certbot renew && docker compose -f docker/docker-compose.nginx.yml exec nginx nginx -s reload
 ```
 
 ### Nginx Security Hardening
@@ -165,33 +165,38 @@ All services in the Nginx compose file include:
 
 - **Capability dropping:** `cap_drop: ALL` with minimal `cap_add` per service
 - **No privilege escalation:** `security_opt: no-new-privileges:true`
-- **Read-only filesystems:** `read_only: true` with targeted tmpfs mounts (where possible)
+- **Read-only filesystems:** `read_only: true` with targeted tmpfs mounts (where
+  possible)
 - **Resource limits:** CPU and memory limits on every service
 - **Log rotation:** `json-file` driver with 5MB/3-file rotation (15MB max per service)
 - **SELinux compatibility:** `:ro,z` and `:rw,z` volume flags
 
-Nginx adds: rate limiting, security headers (HSTS, CSP, X-Frame-Options), OCSP stapling, proxy buffering, `/web/database` blocking.
+Nginx adds: rate limiting, security headers (HSTS, CSP, X-Frame-Options), OCSP stapling,
+proxy buffering, `/web/database` blocking.
 
 ### Centralized Logging with Fluentd (Nginx stack)
 
-The Nginx compose file includes Fluentd for centralized log collection. It uses file tailing (not Docker's log driver), so `docker compose logs` keeps working and logs are never lost if Fluentd goes down.
+The Nginx compose file includes Fluentd for centralized log collection. It uses file
+tailing (not Docker's log driver), so `docker compose logs` keeps working and logs are
+never lost if Fluentd goes down.
 
 **Default backend:** Local filesystem / NFS (`output-file.conf`)
 
 **Available backends:**
 
-| Backend           | Config file                      | Plugins required |
-| ----------------- | -------------------------------- | ---------------- |
-| Local / NFS       | `output-file.conf` (default)     | None (built-in)  |
-| AWS S3            | `output-s3.conf.example`         | fluent-plugin-s3 |
-| Google Cloud GCS  | `output-gcs.conf.example`        | fluent-plugin-gcs|
-| Azure Blob        | `output-azure.conf.example`      | fluent-plugin-azure-storage-append-blob |
-| MinIO             | `output-minio.conf.example`      | fluent-plugin-s3 |
+| Backend          | Config file                  | Plugins required                        |
+| ---------------- | ---------------------------- | --------------------------------------- |
+| Local / NFS      | `output-file.conf` (default) | None (built-in)                         |
+| AWS S3           | `output-s3.conf.example`     | fluent-plugin-s3                        |
+| Google Cloud GCS | `output-gcs.conf.example`    | fluent-plugin-gcs                       |
+| Azure Blob       | `output-azure.conf.example`  | fluent-plugin-azure-storage-append-blob |
+| MinIO            | `output-minio.conf.example`  | fluent-plugin-s3                        |
 
 To switch backends:
 
 1. Edit `docker/fluentd/fluent.conf` to `@include` the desired output config
-2. For cloud backends, uncomment the `build:` block in the fluentd service to install plugins
+2. For cloud backends, uncomment the `build:` block in the fluentd service to install
+   plugins
 
 ### Using External Database (RDS/Cloud SQL)
 
@@ -316,17 +321,17 @@ docker compose -f docker/docker-compose.production.yml exec clamav clamscan --ve
 
 ### Resource Limits (Nginx stack)
 
-| Variable                     | Default | Description                    |
-| ---------------------------- | ------- | ------------------------------ |
-| `ODOO_CPU_LIMIT`             | 2       | Odoo CPU cores                 |
-| `ODOO_MEMORY_LIMIT`         | 4G      | Odoo memory limit              |
-| `DB_CPU_LIMIT`               | 2       | PostgreSQL CPU cores           |
-| `DB_MEMORY_LIMIT`           | 4G      | PostgreSQL memory limit        |
-| `QUEUE_CPU_LIMIT`            | 1       | Queue worker CPU cores         |
-| `QUEUE_MEMORY_LIMIT`        | 2G      | Queue worker memory limit      |
-| `NGINX_CPU_LIMIT`            | 1       | Nginx CPU cores                |
-| `NGINX_MEMORY_LIMIT`        | 256M    | Nginx memory limit             |
-| `CLAMAV_MEMORY_LIMIT`       | 1536M   | ClamAV memory limit            |
+| Variable              | Default | Description               |
+| --------------------- | ------- | ------------------------- |
+| `ODOO_CPU_LIMIT`      | 2       | Odoo CPU cores            |
+| `ODOO_MEMORY_LIMIT`   | 4G      | Odoo memory limit         |
+| `DB_CPU_LIMIT`        | 2       | PostgreSQL CPU cores      |
+| `DB_MEMORY_LIMIT`     | 4G      | PostgreSQL memory limit   |
+| `QUEUE_CPU_LIMIT`     | 1       | Queue worker CPU cores    |
+| `QUEUE_MEMORY_LIMIT`  | 2G      | Queue worker memory limit |
+| `NGINX_CPU_LIMIT`     | 1       | Nginx CPU cores           |
+| `NGINX_MEMORY_LIMIT`  | 256M    | Nginx memory limit        |
+| `CLAMAV_MEMORY_LIMIT` | 1536M   | ClamAV memory limit       |
 
 ### Logging
 

--- a/docker/docker-compose.nginx.yml
+++ b/docker/docker-compose.nginx.yml
@@ -81,16 +81,15 @@ x-nginx-common: &nginx-common
     - /tmp:size=10M
     - /var/cache/nginx:size=50M
     - /run:size=5M
-    - /etc/nginx/conf.d:size=1M  # envsubst writes generated config here at startup
+    - /etc/nginx/conf.d:size=1M # envsubst writes generated config here at startup
   logging: *default-logging
   cap_drop:
     - ALL
   cap_add:
-    - NET_BIND_SERVICE  # Bind to ports 80/443
-    - CHOWN             # Set file ownership (master process)
-    - SETGID            # Switch to nginx group (worker processes)
-    - SETUID            # Switch to nginx user (worker processes)
-    - DAC_OVERRIDE      # Read SSL certs and config owned by root
+    - NET_BIND_SERVICE # Bind to ports 80/443
+    - CHOWN # Set file ownership (master process)
+    - SETGID # Switch to nginx group (worker processes)
+    - SETUID # Switch to nginx user (worker processes)
   security_opt:
     - no-new-privileges:true
   deploy:
@@ -118,7 +117,12 @@ services:
       - certbot_certs:/etc/letsencrypt:ro,z
       - nginx_logs:/var/log/nginx:rw,z
     healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:80/.well-known/acme-challenge/ || curl -sf -k https://localhost:443/web/health"]
+      test:
+        [
+          "CMD-SHELL",
+          "curl -sf http://localhost:80/.well-known/acme-challenge/ || curl -sf -k
+          https://localhost:443/web/health",
+        ]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -171,8 +175,7 @@ services:
     cap_drop:
       - ALL
     cap_add:
-      - CHOWN             # Own certificate files
-      - DAC_OVERRIDE      # Write to /etc/letsencrypt
+      - CHOWN # Own certificate files
       - SETGID
       - SETUID
     security_opt:
@@ -218,7 +221,7 @@ services:
       - ALL
     cap_add:
       - CHOWN
-      - DAC_OVERRIDE
+      - DAC_OVERRIDE # Entrypoint needs to access /var/lib/postgresql data dirs
       - FOWNER
       - SETGID
       - SETUID
@@ -313,7 +316,6 @@ services:
       - ALL
     cap_add:
       - CHOWN
-      - DAC_OVERRIDE
       - FOWNER
       - SETGID
       - SETUID
@@ -360,7 +362,13 @@ services:
       # Logging
       LOG_LEVEL: ${LOG_LEVEL:-info}
     # Run job_worker standalone runner process
-    command: ["python", "/mnt/extra-addons/odoo-job-worker/job_worker_runner.py", "-c", "/etc/odoo/odoo.conf"]
+    command:
+      [
+        "python",
+        "/mnt/extra-addons/odoo-job-worker/job_worker_runner.py",
+        "-c",
+        "/etc/odoo/odoo.conf",
+      ]
     volumes:
       - odoo_data:/var/lib/odoo:rw,z
       - odoo_addons:/mnt/extra-addons:rw,z
@@ -377,7 +385,6 @@ services:
       - ALL
     cap_add:
       - CHOWN
-      - DAC_OVERRIDE
       - FOWNER
       - SETGID
       - SETUID
@@ -427,16 +434,16 @@ services:
     tmpfs:
       - /tmp:size=256M
       - /run:size=5M
-      - /etc/crontabs:size=1M   # backup-entrypoint.sh writes cron schedule here
-      - /etc/profile.d:size=1M  # backup-entrypoint.sh writes pg_env.sh here
-      - /var/log:size=10M       # backup log file
+      - /etc/crontabs:size=1M # backup-entrypoint.sh writes cron schedule here
+      - /etc/profile.d:size=1M # backup-entrypoint.sh writes pg_env.sh here
+      - /var/log:size=10M # backup log file
     logging: *default-logging
     # Security: backup needs file write and process management for cron
     cap_drop:
       - ALL
     cap_add:
       - CHOWN
-      - DAC_OVERRIDE
+      - DAC_OVERRIDE # Same PostGIS image as db; entrypoint needs this
       - FOWNER
       - SETGID
       - SETUID
@@ -470,15 +477,14 @@ services:
     read_only: true
     tmpfs:
       - /tmp:size=256M
-      - /run/clamav:uid=100,gid=101,size=5M  # ClamAV entrypoint expects /run/clamav writable by clamav user
+      - /run/clamav:uid=100,gid=101,size=5M # ClamAV entrypoint expects /run/clamav writable by clamav user
     logging: *default-logging
     # Security: ClamAV needs minimal capabilities
     cap_drop:
       - ALL
     cap_add:
       - CHOWN
-      - DAC_OVERRIDE
-      - FOWNER            # Set ownership on /run/clamav at startup
+      - FOWNER # Set ownership on /run/clamav at startup
       - SETGID
       - SETUID
     security_opt:
@@ -516,7 +522,7 @@ services:
   #   docker compose -f docker/docker-compose.nginx.yml build fluentd
   # Then uncomment the `build:` block below and comment out `image:`.
   fluentd:
-    image: fluentd:v1.19-1
+    image: fluent/fluentd:v1.19-2
     # Uncomment to build with cloud storage plugins (S3, GCS, Azure, MinIO):
     # build:
     #   context: ./fluentd
@@ -550,7 +556,6 @@ services:
       - ALL
     cap_add:
       - CHOWN
-      - DAC_OVERRIDE
       - SETGID
       - SETUID
     security_opt:

--- a/docker/docker-compose.nginx.yml
+++ b/docker/docker-compose.nginx.yml
@@ -1,0 +1,585 @@
+# OpenSPP Production Docker Compose — Nginx + Certbot
+#
+# Small-scale deployment for 10k-100k beneficiaries on a single VPS.
+#
+# Architecture:
+#   Nginx (reverse proxy + SSL) -> Odoo (workers) -> PostgreSQL
+#                                -> Queue Worker (background jobs)
+#   Certbot (certificate issuance and renewal)
+#
+# Usage:
+#   # Copy and configure environment
+#   cp docker/.env.production.example docker/.env.production
+#   # Edit docker/.env.production with your settings
+#
+#   # Start services with HTTPS (production)
+#   docker compose -f docker/docker-compose.nginx.yml --profile https up -d
+#   # Or set COMPOSE_PROFILES=https in .env.production, then just:
+#   docker compose -f docker/docker-compose.nginx.yml up -d
+#
+#   # Start with HTTP only (dev / isolated on-premises)
+#   docker compose -f docker/docker-compose.nginx.yml --profile http up -d
+#
+#   # View logs
+#   docker compose -f docker/docker-compose.nginx.yml logs -f
+#
+#   # Stop services
+#   docker compose -f docker/docker-compose.nginx.yml down
+#
+# Profiles:
+#   --profile https    Nginx with SSL + Certbot (production). Set
+#                      COMPOSE_PROFILES=https in .env to make this the default.
+#   --profile http     Nginx HTTP only (no SSL, no Certbot).
+#                      Use for dev or on-premises isolated networks.
+#   --profile clamav   ClamAV antivirus scanning (adds ~1GB RAM).
+#                      Install spp_attachment_av_scan module in Odoo to use.
+#
+#   Profiles can be combined: --profile https --profile clamav
+#   Or in .env: COMPOSE_PROFILES=https,clamav
+#
+# Fluentd Logging:
+#   Fluentd collects logs from the json-file log volumes and ships them to
+#   a configurable backend (local/NFS, S3, GCS, Azure, MinIO).
+#   This approach is runtime-agnostic (Docker, Podman, Kubernetes) and keeps
+#   `docker compose logs` working. Logs are never lost if Fluentd goes down.
+#
+#   To switch output backend:
+#   1. Edit docker/fluentd/fluent.conf to @include the output backend you need
+#      (see docker/fluentd/output-*.conf.example for available backends)
+#   2. For cloud backends (S3, GCS, Azure, MinIO), build the custom image:
+#      Uncomment `build:` in the fluentd service and comment out `image:`
+#
+# External Database (RDS/Cloud SQL):
+#   Set DATABASE_URL in .env.production and remove/comment the db service.
+#
+# Sizing Guide (adjust in .env.production):
+#   10k beneficiaries:  ODOO_WORKERS=2, 4GB RAM total
+#   50k beneficiaries:  ODOO_WORKERS=4, 8GB RAM total
+#   100k beneficiaries: ODOO_WORKERS=6, 16GB RAM total
+
+# Default log rotation for all services: 5MB per file, 3 files (15MB total).
+# Small enough to grep quickly, large enough to avoid excessive rotation I/O.
+x-logging: &default-logging
+  driver: json-file
+  options:
+    max-size: "5m"
+    max-file: "3"
+
+# Shared Nginx configuration (used by both https and http profiles)
+x-nginx-common: &nginx-common
+  image: nginx:stable-alpine
+  depends_on:
+    odoo:
+      condition: service_healthy
+  environment:
+    DOMAIN: ${DOMAIN:?DOMAIN is required}
+  networks:
+    - openspp-prod
+  restart: always
+  read_only: true
+  tmpfs:
+    - /tmp:size=10M
+    - /var/cache/nginx:size=50M
+    - /run:size=5M
+    - /etc/nginx/conf.d:size=1M  # envsubst writes generated config here at startup
+  logging: *default-logging
+  cap_drop:
+    - ALL
+  cap_add:
+    - NET_BIND_SERVICE  # Bind to ports 80/443
+    - CHOWN             # Set file ownership (master process)
+    - SETGID            # Switch to nginx group (worker processes)
+    - SETUID            # Switch to nginx user (worker processes)
+    - DAC_OVERRIDE      # Read SSL certs and config owned by root
+  security_opt:
+    - no-new-privileges:true
+  deploy:
+    resources:
+      limits:
+        cpus: "${NGINX_CPU_LIMIT:-1}"
+        memory: ${NGINX_MEMORY_LIMIT:-256M}
+      reservations:
+        memory: ${NGINX_MEMORY_RESERVATION:-64M}
+
+services:
+  # ==========================================================================
+  # Nginx HTTPS - Reverse proxy with SSL termination (--profile https)
+  # ==========================================================================
+  nginx:
+    <<: *nginx-common
+    profiles:
+      - https
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx/odoo.conf.template:/etc/nginx/templates/odoo.conf.template:ro,z
+      - certbot_webroot:/var/www/certbot:ro,z
+      - certbot_certs:/etc/letsencrypt:ro,z
+      - nginx_logs:/var/log/nginx:rw,z
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:80/.well-known/acme-challenge/ || curl -sf -k https://localhost:443/web/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  # ==========================================================================
+  # Nginx HTTP - Reverse proxy without SSL (--profile http)
+  # ==========================================================================
+  # Use for local development or on-premises isolated networks.
+  nginx-http:
+    <<: *nginx-common
+    profiles:
+      - http
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx/odoo-http-only.conf.template:/etc/nginx/templates/odoo.conf.template:ro,z
+      - nginx_logs:/var/log/nginx:rw,z
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:80/web/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  # ==========================================================================
+  # Certbot - SSL certificate management (Let's Encrypt)
+  # ==========================================================================
+  # Obtain initial certificate (run once):
+  #   docker compose -f docker/docker-compose.nginx.yml run --rm certbot \
+  #     certonly --webroot -w /var/www/certbot \
+  #     --email ${ACME_EMAIL} -d ${DOMAIN} --agree-tos --non-interactive
+  #
+  # Renew certificates (schedule via system cron every 3 months):
+  #   docker compose -f docker/docker-compose.nginx.yml run --rm certbot renew
+  #   docker compose -f docker/docker-compose.nginx.yml exec nginx nginx -s reload
+  certbot:
+    image: certbot/certbot
+    profiles:
+      - https
+    volumes:
+      - certbot_webroot:/var/www/certbot:rw,z
+      - certbot_certs:/etc/letsencrypt:rw,z
+      - certbot_lib:/var/lib/letsencrypt:rw,z
+    networks:
+      - openspp-prod
+    read_only: true
+    tmpfs:
+      - /tmp:size=10M
+    logging: *default-logging
+    # Security: drop all unnecessary capabilities
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN             # Own certificate files
+      - DAC_OVERRIDE      # Write to /etc/letsencrypt
+      - SETGID
+      - SETUID
+    security_opt:
+      - no-new-privileges:true
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 128M
+        reservations:
+          memory: 32M
+
+  # ==========================================================================
+  # PostgreSQL - Database (optional, can use external RDS)
+  # ==========================================================================
+  # Comment out this service if using DATABASE_URL with external database
+  db:
+    image: postgis/postgis:18-3.6-alpine
+    environment:
+      # NOTE: POSTGRES_USER is created as a superuser by the image.
+      # Option A (strict): set DB_ADMIN_USER to an admin role, set DB_USER to a non-superuser,
+      # and create DB_USER via init scripts (/docker-entrypoint-initdb.d).
+      # Option B (flexible): keep DB_ADMIN_USER=odoo and DB_USER=odoo (default).
+      POSTGRES_USER: ${DB_ADMIN_USER:-odoo}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:?DB_PASSWORD is required}
+      POSTGRES_DB: ${DB_NAME:-openspp}
+      # Performance tuning for production
+      POSTGRES_INITDB_ARGS: "--encoding=UTF8 --locale=C"
+    volumes:
+      - postgres_data:/var/lib/postgresql:rw,z
+      # Option A (strict): init scripts to create non-superuser Odoo role
+      # - ./initdb:/docker-entrypoint-initdb.d:ro,z
+    networks:
+      - openspp-prod
+    restart: unless-stopped
+    read_only: true
+    tmpfs:
+      - /tmp:size=256M
+      - /run:size=5M
+    logging: *default-logging
+    # Security: PostgreSQL needs minimal capabilities
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - DAC_OVERRIDE
+      - FOWNER
+      - SETGID
+      - SETUID
+    security_opt:
+      - no-new-privileges:true
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER:-odoo} -d ${DB_NAME:-openspp}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    # Resource limits - adjust based on VPS size
+    deploy:
+      resources:
+        limits:
+          cpus: "${DB_CPU_LIMIT:-2}"
+          memory: ${DB_MEMORY_LIMIT:-4G}
+        reservations:
+          memory: ${DB_MEMORY_RESERVATION:-2G}
+
+  # ==========================================================================
+  # Odoo - Main web application
+  # ==========================================================================
+  odoo:
+    image: ${OPENSPP_IMAGE:-ghcr.io/openspp/openspp:latest}
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      # Database - use DATABASE_URL for external DB, or individual vars for local
+      DATABASE_URL: ${DATABASE_URL:-}
+      DB_HOST: ${DB_HOST:-db}
+      DB_PORT: ${DB_PORT:-5432}
+      # Option A (strict): DB_USER must be a non-superuser created via init script.
+      DB_USER: ${DB_USER:-odoo}
+      DB_PASSWORD: ${DB_PASSWORD:?DB_PASSWORD is required}
+      DB_NAME: ${DB_NAME:-openspp}
+      DB_SSLMODE: ${DB_SSLMODE:-prefer}
+      DB_FILTER: "^${DB_NAME:-openspp}$$"
+      LIST_DB: "False"
+
+      # Admin credentials
+      ODOO_ADMIN_PASSWD: ${ODOO_ADMIN_PASSWD:?ODOO_ADMIN_PASSWD is required}
+
+      # Workers - adjust based on CPU cores (rule: (CPU cores * 2) + 1; ~1 worker per 6 concurrent users)
+      ODOO_WORKERS: ${ODOO_WORKERS:-2}
+      ODOO_CRON_THREADS: "1"
+
+      # Memory limits per worker (in bytes)
+      # Soft limit: worker recycled after this
+      # Hard limit: worker killed if exceeds
+      ODOO_MEMORY_SOFT: ${ODOO_MEMORY_SOFT:-2147483648}
+      ODOO_MEMORY_HARD: ${ODOO_MEMORY_HARD:-2684354560}
+
+      # Request timeouts (seconds)
+      ODOO_TIME_CPU: ${ODOO_TIME_CPU:-600}
+      ODOO_TIME_REAL: ${ODOO_TIME_REAL:-1200}
+
+      # Proxy mode (required behind Nginx)
+      PROXY_MODE: "True"
+
+      # Modules to initialize on first boot
+      ODOO_INIT_MODULES: ${ODOO_INIT_MODULES:-spp_base}
+
+      # Logging
+      LOG_LEVEL: ${LOG_LEVEL:-warn}
+
+      # Email (optional)
+      SMTP_SERVER: ${SMTP_SERVER:-}
+      SMTP_PORT: ${SMTP_PORT:-587}
+      SMTP_SSL: ${SMTP_SSL:-True}
+      SMTP_USER: ${SMTP_USER:-}
+      SMTP_PASSWORD: ${SMTP_PASSWORD:-}
+      EMAIL_FROM: ${EMAIL_FROM:-}
+    volumes:
+      - odoo_data:/var/lib/odoo:rw,z
+      - odoo_addons:/mnt/extra-addons:rw,z
+    networks:
+      - openspp-prod
+    restart: unless-stopped
+    # NOTE: read_only is not used here because the entrypoint generates
+    # /etc/odoo/odoo.conf from the template at startup. The other security
+    # controls (cap_drop, no-new-privileges) still apply.
+    tmpfs:
+      - /tmp:size=256M
+      - /run:size=5M
+    logging: *default-logging
+    # Security: Odoo needs network access and file operations
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - DAC_OVERRIDE
+      - FOWNER
+      - SETGID
+      - SETUID
+    security_opt:
+      - no-new-privileges:true
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8069/web/health"]
+      interval: 30s
+      timeout: 10s
+      start_period: 120s
+      retries: 5
+    deploy:
+      resources:
+        limits:
+          cpus: "${ODOO_CPU_LIMIT:-2}"
+          memory: ${ODOO_MEMORY_LIMIT:-4G}
+        reservations:
+          memory: ${ODOO_MEMORY_RESERVATION:-2G}
+
+  # ==========================================================================
+  # Queue Worker - Background job processing (job_worker)
+  # ==========================================================================
+  queue-worker:
+    image: ${OPENSPP_IMAGE:-ghcr.io/openspp/openspp:latest}
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    depends_on:
+      db:
+        condition: service_healthy
+      odoo:
+        condition: service_healthy
+    environment:
+      # Same database config as odoo
+      DATABASE_URL: ${DATABASE_URL:-}
+      DB_HOST: ${DB_HOST:-db}
+      DB_PORT: ${DB_PORT:-5432}
+      DB_USER: ${DB_USER:-odoo}
+      DB_PASSWORD: ${DB_PASSWORD:?DB_PASSWORD is required}
+      DB_NAME: ${DB_NAME:-openspp}
+      DB_SSLMODE: ${DB_SSLMODE:-prefer}
+      ODOO_ADMIN_PASSWD: ${ODOO_ADMIN_PASSWD:?ODOO_ADMIN_PASSWD is required}
+
+      # Logging
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+    # Run job_worker standalone runner process
+    command: ["python", "/mnt/extra-addons/odoo-job-worker/job_worker_runner.py", "-c", "/etc/odoo/odoo.conf"]
+    volumes:
+      - odoo_data:/var/lib/odoo:rw,z
+      - odoo_addons:/mnt/extra-addons:rw,z
+    networks:
+      - openspp-prod
+    restart: unless-stopped
+    # NOTE: read_only not used — same reason as odoo service (entrypoint writes config)
+    tmpfs:
+      - /tmp:size=256M
+      - /run:size=5M
+    logging: *default-logging
+    # Security: same as Odoo
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - DAC_OVERRIDE
+      - FOWNER
+      - SETGID
+      - SETUID
+    security_opt:
+      - no-new-privileges:true
+    deploy:
+      resources:
+        limits:
+          cpus: "${QUEUE_CPU_LIMIT:-1}"
+          memory: ${QUEUE_MEMORY_LIMIT:-2G}
+        reservations:
+          memory: ${QUEUE_MEMORY_RESERVATION:-1G}
+
+  # ==========================================================================
+  # Backup - Automated PostgreSQL/PostGIS backups
+  # ==========================================================================
+  # Uses official PostGIS image for full compatibility with spatial data.
+  # Backups run daily at 2am by default (configurable via BACKUP_SCHEDULE).
+  # Retention: 7 daily, 4 weekly, 6 monthly backups.
+  backup:
+    image: postgis/postgis:18-3.6-alpine
+    entrypoint: ["/backup-entrypoint.sh"]
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      # PostgreSQL connection (standard PG* variables)
+      PGHOST: ${DB_HOST:-db}
+      PGPORT: ${DB_PORT:-5432}
+      PGDATABASE: ${DB_NAME:-openspp}
+      PGUSER: ${DB_USER:-odoo}
+      PGPASSWORD: ${DB_PASSWORD:?DB_PASSWORD is required}
+      # Backup schedule (cron format, default: daily at 2am)
+      BACKUP_SCHEDULE: ${BACKUP_SCHEDULE:-0 2 * * *}
+      # Retention policy
+      BACKUP_KEEP_DAYS: ${BACKUP_KEEP_DAYS:-7}
+      BACKUP_KEEP_WEEKS: ${BACKUP_KEEP_WEEKS:-4}
+      BACKUP_KEEP_MONTHS: ${BACKUP_KEEP_MONTHS:-6}
+    volumes:
+      - ./backup.sh:/backup.sh:ro,z
+      - ./backup-entrypoint.sh:/backup-entrypoint.sh:ro,z
+      - backup_data:/backups:rw,z
+    networks:
+      - openspp-prod
+    restart: unless-stopped
+    read_only: true
+    tmpfs:
+      - /tmp:size=256M
+      - /run:size=5M
+      - /etc/crontabs:size=1M   # backup-entrypoint.sh writes cron schedule here
+      - /etc/profile.d:size=1M  # backup-entrypoint.sh writes pg_env.sh here
+      - /var/log:size=10M       # backup log file
+    logging: *default-logging
+    # Security: backup needs file write and process management for cron
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - DAC_OVERRIDE
+      - FOWNER
+      - SETGID
+      - SETUID
+    security_opt:
+      - no-new-privileges:true
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 512M
+        reservations:
+          memory: 128M
+
+  # ==========================================================================
+  # ClamAV - Antivirus scanning (--profile clamav)
+  # ==========================================================================
+  # Resource usage: ~500MB-1GB RAM for virus definitions
+  # Install spp_attachment_av_scan module in Odoo to use this service
+  clamav:
+    image: clamav/clamav:stable
+    profiles:
+      - clamav
+    environment:
+      # Disable milter (not needed for file scanning)
+      CLAMAV_NO_MILTERD: "true"
+    volumes:
+      - clamav_data:/var/lib/clamav:rw,z
+    networks:
+      - openspp-prod
+    restart: unless-stopped
+    read_only: true
+    tmpfs:
+      - /tmp:size=256M
+      - /run/clamav:uid=100,gid=101,size=5M  # ClamAV entrypoint expects /run/clamav writable by clamav user
+    logging: *default-logging
+    # Security: ClamAV needs minimal capabilities
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - DAC_OVERRIDE
+      - FOWNER            # Set ownership on /run/clamav at startup
+      - SETGID
+      - SETUID
+    security_opt:
+      - no-new-privileges:true
+    healthcheck:
+      test: ["CMD", "/usr/local/bin/clamdcheck.sh"]
+      interval: 60s
+      timeout: 10s
+      start_period: 120s
+      retries: 3
+    deploy:
+      resources:
+        limits:
+          cpus: "1"
+          memory: ${CLAMAV_MEMORY_LIMIT:-1536M}
+        reservations:
+          memory: ${CLAMAV_MEMORY_RESERVATION:-512M}
+
+  # ==========================================================================
+  # Fluentd - Centralized log collection
+  # ==========================================================================
+  # Collects container logs and ships them to a configurable backend:
+  #   - Local filesystem / NFS (default)
+  #   - AWS S3
+  #   - Google Cloud Storage
+  #   - Azure Blob Storage
+  #   - MinIO (S3-compatible, on-premises)
+  #
+  # To switch backends, edit docker/fluentd/fluent.conf and change the
+  # @include line to point to the desired output config file.
+  # See docker/fluentd/output-*.conf.example for available backends.
+  #
+  # For cloud backends (S3, GCS, Azure, MinIO), build the custom image
+  # with the required plugins:
+  #   docker compose -f docker/docker-compose.nginx.yml build fluentd
+  # Then uncomment the `build:` block below and comment out `image:`.
+  fluentd:
+    image: fluentd:v1.19-1
+    # Uncomment to build with cloud storage plugins (S3, GCS, Azure, MinIO):
+    # build:
+    #   context: ./fluentd
+    #   dockerfile: Dockerfile
+    # Run as root: Fluentd needs to read Docker container logs (/var/lib/docker/containers)
+    # which are owned by root, and write .pos files to the buffer volume.
+    user: "0:0"
+    volumes:
+      # Fluentd configuration (mount like Kubernetes configmaps)
+      - ./fluentd/fluent.conf:/fluentd/etc/fluent.conf:ro,z
+      - ./fluentd/input.conf:/fluentd/etc/input.conf:ro,z
+      - ./fluentd/output-file.conf:/fluentd/etc/output-file.conf:ro,z
+      # Docker container JSON logs (tailed by Fluentd)
+      - /var/lib/docker/containers:/var/log/docker/containers:ro,z
+      # Nginx access/error logs
+      - nginx_logs:/var/log/nginx:ro,z
+      # Fluentd output: bind-mount to a host path (local disk, NFS share, etc.)
+      # Set FLUENTD_LOG_PATH in .env.production. Only needed for local/file output,
+      # not for cloud backends (S3, GCS, Azure, MinIO).
+      - ${FLUENTD_LOG_PATH:-./fluentd/log}:/fluentd/log:rw,z
+      - fluentd_buffer:/fluentd/buffer:rw,z
+    networks:
+      - openspp-prod
+    restart: unless-stopped
+    read_only: true
+    tmpfs:
+      - /tmp:size=64M
+    logging: *default-logging
+    # Security: Fluentd needs minimal capabilities
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - DAC_OVERRIDE
+      - SETGID
+      - SETUID
+    security_opt:
+      - no-new-privileges:true
+    healthcheck:
+      test: ["CMD-SHELL", "pidof ruby || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 256M
+        reservations:
+          memory: 64M
+
+volumes:
+  certbot_webroot:
+  certbot_certs:
+  certbot_lib:
+  nginx_logs:
+  postgres_data:
+  odoo_data:
+  odoo_addons:
+  backup_data:
+  clamav_data:
+  fluentd_buffer:
+
+networks:
+  openspp-prod:
+    driver: bridge

--- a/docker/docker-compose.production.yml
+++ b/docker/docker-compose.production.yml
@@ -278,7 +278,7 @@ services:
       # Logging
       LOG_LEVEL: ${LOG_LEVEL:-info}
     # Run job_worker standalone runner process
-    command: ["python", "-m", "odoo.addons.job_worker.cli"]
+    command: ["python", "/mnt/extra-addons/odoo-job-worker/job_worker_runner.py", "-c", "/etc/odoo/odoo.conf"]
     volumes:
       - odoo_data:/var/lib/odoo
       - odoo_addons:/mnt/extra-addons

--- a/docker/docker-compose.production.yml
+++ b/docker/docker-compose.production.yml
@@ -278,7 +278,13 @@ services:
       # Logging
       LOG_LEVEL: ${LOG_LEVEL:-info}
     # Run job_worker standalone runner process
-    command: ["python", "/mnt/extra-addons/odoo-job-worker/job_worker_runner.py", "-c", "/etc/odoo/odoo.conf"]
+    command:
+      [
+        "python",
+        "/mnt/extra-addons/odoo-job-worker/job_worker_runner.py",
+        "-c",
+        "/etc/odoo/odoo.conf",
+      ]
     volumes:
       - odoo_data:/var/lib/odoo
       - odoo_addons:/mnt/extra-addons

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -204,9 +204,11 @@ fi
 
 if envsubst < /etc/odoo/odoo.conf.template > /etc/odoo/odoo.conf; then
     log_info "Configuration file generated successfully at /etc/odoo/odoo.conf"
-    # Debug: show generated config (comment out in production)
-    log_info "Generated config:"
-    cat /etc/odoo/odoo.conf
+    # Show generated config only in dev mode (contains sensitive values)
+    if [ "${ODOO_DEV_MODE:-}" = "true" ]; then
+        log_info "Generated config (dev mode):"
+        cat /etc/odoo/odoo.conf
+    fi
 else
     log_error "Failed to generate configuration file"
     exit 1

--- a/docker/fluentd/Dockerfile
+++ b/docker/fluentd/Dockerfile
@@ -1,0 +1,26 @@
+# Fluentd image with output plugins for S3, GCS, Azure, and MinIO.
+#
+# Only needed for cloud storage backends. For local filesystem / NFS output,
+# use the official fluentd image directly (no build required).
+#
+# Build with:
+#   docker compose -f docker/docker-compose.nginx.yml build fluentd
+#
+# The base image uses Debian with jemalloc to mitigate memory fragmentation.
+# Plugins are installed at build time so the container starts read-only.
+
+FROM fluent/fluentd:v1.19-2
+
+USER root
+
+# Install output plugins for all supported backends.
+# - fluent-plugin-s3: AWS S3 and MinIO (S3-compatible)
+# - fluent-plugin-gcs: Google Cloud Storage
+# - fluent-plugin-azure-storage-append-blob: Azure Blob Storage
+RUN gem install --no-document \
+        fluent-plugin-s3 \
+        fluent-plugin-gcs \
+        fluent-plugin-azure-storage-append-blob \
+    && gem cleanup
+
+USER fluent

--- a/docker/fluentd/fluent.conf
+++ b/docker/fluentd/fluent.conf
@@ -1,0 +1,14 @@
+# Fluentd main configuration
+#
+# This file wires together the input (Docker log driver) and the output
+# (storage backend). To switch backends, replace the @include for output
+# with the appropriate config file:
+#
+#   output-file.conf   — Local filesystem / NFS (default)
+#   output-s3.conf     — AWS S3
+#   output-gcs.conf    — Google Cloud Storage
+#   output-azure.conf  — Azure Blob Storage
+#   output-minio.conf  — MinIO (S3-compatible, on-premises)
+
+@include input.conf
+@include output-file.conf

--- a/docker/fluentd/input.conf
+++ b/docker/fluentd/input.conf
@@ -1,0 +1,60 @@
+# Fluentd input — tails Docker container json-file logs.
+#
+# Docker's default json-file driver writes logs to:
+#   /var/lib/docker/containers/<id>/<id>-json.log
+#
+# This is the same approach used by Kubernetes DaemonSets (tailing
+# /var/log/containers/). It keeps `docker compose logs` working while
+# Fluentd collects and ships logs independently.
+#
+# On Kubernetes, replace this file with a configmap pointing to
+# /var/log/containers/*.log instead.
+
+# Tail all Docker container JSON logs
+<source>
+  @type tail
+  path /var/log/docker/containers/*/*-json.log
+  pos_file /fluentd/buffer/docker-containers.pos
+  tag docker.*
+  read_from_head true
+
+  <parse>
+    @type json
+    time_key time
+    time_format %Y-%m-%dT%H:%M:%S.%NZ
+    keep_time_key true
+  </parse>
+</source>
+
+# Tail Nginx access and error logs (written to a dedicated volume)
+<source>
+  @type tail
+  path /var/log/nginx/odoo.access.log
+  pos_file /fluentd/buffer/nginx-access.pos
+  tag nginx.access
+  read_from_head true
+
+  <parse>
+    @type none
+  </parse>
+</source>
+
+<source>
+  @type tail
+  path /var/log/nginx/odoo.error.log
+  pos_file /fluentd/buffer/nginx-error.pos
+  tag nginx.error
+  read_from_head true
+
+  <parse>
+    @type none
+  </parse>
+</source>
+
+# Add hostname to all records
+<filter **>
+  @type record_transformer
+  <record>
+    hostname "#{Socket.gethostname}"
+  </record>
+</filter>

--- a/docker/fluentd/output-azure.conf.example
+++ b/docker/fluentd/output-azure.conf.example
@@ -1,0 +1,42 @@
+# Output: Azure Blob Storage
+#
+# Ships logs to Azure Storage append blobs. Buffers locally and flushes
+# every 2 minutes.
+#
+# To use:
+#   1. Copy this file to output-azure.conf
+#   2. Update fluent.conf to: @include output-azure.conf
+#   3. Set the environment variables below in your .env.production
+#
+# Required environment variables:
+#   AZURE_STORAGE_ACCOUNT    — Azure storage account name
+#   AZURE_STORAGE_ACCESS_KEY — Azure storage access key
+#   AZURE_CONTAINER          — Azure blob container name
+
+<match docker.**>
+  @type azure-storage-append-blob
+
+  azure_storage_account "#{ENV['AZURE_STORAGE_ACCOUNT']}"
+  azure_storage_access_key "#{ENV['AZURE_STORAGE_ACCESS_KEY']}"
+  azure_container "#{ENV['AZURE_CONTAINER']}"
+  auto_create_container true
+
+  path "openspp-logs/${tag}/"
+  azure_object_key_format %{path}%{time_slice}_%{index}.log
+
+  <format>
+    @type json
+  </format>
+
+  <buffer tag,time>
+    @type file
+    path /fluentd/buffer
+    timekey 120
+    timekey_wait 60
+    timekey_use_utc true
+    chunk_limit_size 10m
+    flush_at_shutdown true
+    retry_max_interval 30s
+    retry_forever true
+  </buffer>
+</match>

--- a/docker/fluentd/output-file.conf
+++ b/docker/fluentd/output-file.conf
@@ -1,0 +1,34 @@
+# Output: Local filesystem (default)
+#
+# Writes logs to /fluentd/log/ inside the container, which is bind-mounted
+# to the host path set by FLUENTD_LOG_PATH in .env.production.
+#
+# For on-premises production with NFS:
+#   Set FLUENTD_LOG_PATH to the NFS mount point on the host.
+#   Fluentd doesn't need to know about NFS — it just writes to a path.
+#
+# File rotation: daily, gzip compressed, UTC timestamps.
+
+<match docker.**>
+  @type file
+  path /fluentd/log/${tag}
+  append true
+  compress gzip
+
+  <format>
+    @type json
+  </format>
+
+  <buffer tag,time>
+    @type file
+    path /fluentd/buffer
+    timekey 1d
+    timekey_use_utc true
+    timekey_wait 10m
+    flush_mode interval
+    flush_interval 60s
+    chunk_limit_size 10m
+    retry_max_interval 30s
+    retry_forever true
+  </buffer>
+</match>

--- a/docker/fluentd/output-gcs.conf.example
+++ b/docker/fluentd/output-gcs.conf.example
@@ -1,0 +1,45 @@
+# Output: Google Cloud Storage
+#
+# Ships logs to a GCS bucket. Buffers locally and flushes hourly.
+#
+# To use:
+#   1. Copy this file to output-gcs.conf
+#   2. Update fluent.conf to: @include output-gcs.conf
+#   3. Set the environment variables below in your .env.production
+#   4. Mount your GCP service account key into the container:
+#      Add to fluentd volumes:
+#        - ./gcp-sa-key.json:/fluentd/gcp-sa-key.json:ro,z
+#
+# Required environment variables:
+#   GCS_PROJECT       — GCP project ID
+#   GCS_BUCKET        — GCS bucket name
+#
+# IAM permissions required:
+#   roles/storage.objectCreator on the bucket
+
+<match docker.**>
+  @type gcs
+
+  project "#{ENV['GCS_PROJECT']}"
+  keyfile /fluentd/gcp-sa-key.json
+  bucket "#{ENV['GCS_BUCKET']}"
+
+  path "openspp-logs/${tag}/"
+  object_key_format %{path}%{time_slice}_%{index}.%{file_extension}
+
+  <format>
+    @type json
+  </format>
+
+  <buffer tag,time>
+    @type file
+    path /fluentd/buffer
+    timekey 3600
+    timekey_wait 10m
+    timekey_use_utc true
+    chunk_limit_size 256m
+    flush_at_shutdown true
+    retry_max_interval 30s
+    retry_forever true
+  </buffer>
+</match>

--- a/docker/fluentd/output-minio.conf.example
+++ b/docker/fluentd/output-minio.conf.example
@@ -1,0 +1,47 @@
+# Output: MinIO (S3-compatible, on-premises)
+#
+# Ships logs to a MinIO instance using the S3 plugin. MinIO is fully
+# compatible with the AWS S3 API, so we use fluent-plugin-s3 with a
+# custom endpoint.
+#
+# To use:
+#   1. Copy this file to output-minio.conf
+#   2. Update fluent.conf to: @include output-minio.conf
+#   3. Set the environment variables below in your .env.production
+#
+# Required environment variables:
+#   MINIO_ENDPOINT    — MinIO server URL (e.g., http://minio:9000)
+#   MINIO_ACCESS_KEY  — MinIO access key
+#   MINIO_SECRET_KEY  — MinIO secret key
+#   MINIO_BUCKET      — MinIO bucket name
+
+<match docker.**>
+  @type s3
+
+  aws_key_id "#{ENV['MINIO_ACCESS_KEY']}"
+  aws_sec_key "#{ENV['MINIO_SECRET_KEY']}"
+  s3_bucket "#{ENV['MINIO_BUCKET']}"
+  s3_endpoint "#{ENV['MINIO_ENDPOINT']}"
+  s3_region us-east-1
+  force_path_style true
+
+  path "openspp-logs/${tag}/"
+  s3_object_key_format %{path}%{time_slice}_%{index}.%{file_extension}
+  store_as gzip
+
+  <format>
+    @type json
+  </format>
+
+  <buffer tag,time>
+    @type file
+    path /fluentd/buffer
+    timekey 3600
+    timekey_wait 10m
+    timekey_use_utc true
+    chunk_limit_size 256m
+    flush_at_shutdown true
+    retry_max_interval 30s
+    retry_forever true
+  </buffer>
+</match>

--- a/docker/fluentd/output-s3.conf.example
+++ b/docker/fluentd/output-s3.conf.example
@@ -1,0 +1,45 @@
+# Output: AWS S3
+#
+# Ships logs to an S3 bucket. Buffers locally and flushes hourly.
+#
+# To use:
+#   1. Copy this file to output-s3.conf
+#   2. Update fluent.conf to: @include output-s3.conf
+#   3. Set the environment variables below in your .env.production
+#
+# Required environment variables:
+#   AWS_KEY_ID        — AWS access key ID
+#   AWS_SEC_KEY       — AWS secret access key
+#   S3_BUCKET         — S3 bucket name
+#   S3_REGION         — AWS region (e.g., us-east-1)
+#
+# IAM permissions required on the bucket:
+#   s3:PutObject, s3:GetBucketLocation
+
+<match docker.**>
+  @type s3
+
+  aws_key_id "#{ENV['AWS_KEY_ID']}"
+  aws_sec_key "#{ENV['AWS_SEC_KEY']}"
+  s3_bucket "#{ENV['S3_BUCKET']}"
+  s3_region "#{ENV['S3_REGION']}"
+
+  path "openspp-logs/${tag}/"
+  s3_object_key_format %{path}%{time_slice}_%{index}.%{file_extension}
+
+  <format>
+    @type json
+  </format>
+
+  <buffer tag,time>
+    @type file
+    path /fluentd/buffer
+    timekey 3600
+    timekey_wait 10m
+    timekey_use_utc true
+    chunk_limit_size 256m
+    flush_at_shutdown true
+    retry_max_interval 30s
+    retry_forever true
+  </buffer>
+</match>

--- a/docker/nginx/certbot-init.sh
+++ b/docker/nginx/certbot-init.sh
@@ -45,6 +45,18 @@ docker compose -f "$COMPOSE_FILE" run --rm --entrypoint sh nginx -c "
 echo "==> Starting Nginx (temporary certificate) ..."
 docker compose -f "$COMPOSE_FILE" up -d nginx
 
+echo "==> Waiting for Nginx to become ready ..."
+for i in $(seq 1 30); do
+    if docker compose -f "$COMPOSE_FILE" exec nginx curl -sf http://localhost:80/.well-known/acme-challenge/ >/dev/null 2>&1; then
+        break
+    fi
+    if [ "$i" -eq 30 ]; then
+        echo "Error: Nginx did not become ready within 30 seconds"
+        exit 1
+    fi
+    sleep 1
+done
+
 echo "==> Requesting certificate from Let's Encrypt for $DOMAIN ..."
 docker compose -f "$COMPOSE_FILE" --profile certbot run --rm certbot \
     certonly --webroot -w /var/www/certbot \

--- a/docker/nginx/certbot-init.sh
+++ b/docker/nginx/certbot-init.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+# certbot-init.sh — Bootstrap SSL certificates for a fresh deployment
+#
+# This script:
+#   1. Starts Nginx in HTTP-only mode (self-signed temp cert)
+#   2. Runs Certbot to obtain real certificates via webroot challenge
+#   3. Reloads Nginx with the real certificates
+#
+# Usage:
+#   cd /path/to/project
+#   ./docker/nginx/certbot-init.sh
+#
+# Prerequisites:
+#   - docker/.env.production is configured (DOMAIN and ACME_EMAIL set)
+#   - Ports 80 and 443 are reachable from the internet
+#   - DNS A record for DOMAIN points to this server
+
+set -eu
+
+COMPOSE_FILE="docker/docker-compose.nginx.yml"
+ENV_FILE="docker/.env.production"
+
+if [ ! -f "$ENV_FILE" ]; then
+    echo "Error: $ENV_FILE not found. Copy from .env.production.example first."
+    exit 1
+fi
+
+# shellcheck disable=SC1090
+. "$ENV_FILE"
+
+if [ -z "${DOMAIN:-}" ] || [ -z "${ACME_EMAIL:-}" ]; then
+    echo "Error: DOMAIN and ACME_EMAIL must be set in $ENV_FILE"
+    exit 1
+fi
+
+echo "==> Creating temporary self-signed certificate for $DOMAIN ..."
+docker compose -f "$COMPOSE_FILE" run --rm --entrypoint sh nginx -c "
+    mkdir -p /etc/letsencrypt/live/$DOMAIN &&
+    openssl req -x509 -nodes -newkey rsa:2048 -days 1 \
+        -keyout /etc/letsencrypt/live/$DOMAIN/privkey.pem \
+        -out /etc/letsencrypt/live/$DOMAIN/fullchain.pem \
+        -subj '/CN=localhost'
+"
+
+echo "==> Starting Nginx (temporary certificate) ..."
+docker compose -f "$COMPOSE_FILE" up -d nginx
+
+echo "==> Requesting certificate from Let's Encrypt for $DOMAIN ..."
+docker compose -f "$COMPOSE_FILE" --profile certbot run --rm certbot \
+    certonly --webroot -w /var/www/certbot \
+    --email "$ACME_EMAIL" -d "$DOMAIN" \
+    --agree-tos --non-interactive --force-renewal
+
+echo "==> Reloading Nginx with real certificate ..."
+docker compose -f "$COMPOSE_FILE" exec nginx nginx -s reload
+
+echo "==> Done! SSL certificate obtained for $DOMAIN"
+echo ""
+echo "To start all services:"
+echo "  docker compose -f $COMPOSE_FILE up -d"
+echo ""
+echo "To renew certificates (schedule via cron every 3 months):"
+echo "  docker compose -f $COMPOSE_FILE --profile certbot run --rm certbot renew"
+echo "  docker compose -f $COMPOSE_FILE exec nginx nginx -s reload"

--- a/docker/nginx/odoo-http-only.conf.template
+++ b/docker/nginx/odoo-http-only.conf.template
@@ -69,7 +69,6 @@ server {
     # =========================================================================
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-Frame-Options "SAMEORIGIN" always;
-    add_header X-XSS-Protection "1; mode=block" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     proxy_hide_header X-Powered-By;
 

--- a/docker/nginx/odoo-http-only.conf.template
+++ b/docker/nginx/odoo-http-only.conf.template
@@ -1,0 +1,100 @@
+# Nginx reverse proxy configuration for Odoo — HTTP only (no SSL)
+#
+# Based on the official Odoo deployment documentation:
+# https://www.odoo.com/documentation/19.0/administration/on_premise/deploy.html
+#
+# Use this variant when SSL is not needed:
+#   - Local development
+#   - On-premises deployments on isolated networks
+#   - Behind an external load balancer that terminates SSL
+#
+# For public-facing deployments with SSL, use odoo.conf.template instead.
+#
+# Environment variables (substituted by envsubst at container start):
+#   DOMAIN - The server domain name (e.g., localhost)
+
+# Hide Nginx version in error pages and response headers
+server_tokens off;
+
+upstream odoo {
+    server odoo:8069;
+}
+
+upstream odoochat {
+    server odoo:8072;
+}
+
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
+# HTTP server (no SSL)
+server {
+    listen 80;
+    server_name ${DOMAIN};
+
+    # =========================================================================
+    # Timeouts (from Odoo docs)
+    # =========================================================================
+    proxy_read_timeout 720s;
+    proxy_connect_timeout 720s;
+    proxy_send_timeout 720s;
+
+    # =========================================================================
+    # Proxy buffering
+    # =========================================================================
+    proxy_buffering on;
+    proxy_buffer_size 16k;
+    proxy_buffers 16 64k;
+    proxy_busy_buffers_size 128k;
+
+    # =========================================================================
+    # Logging
+    # =========================================================================
+    access_log /var/log/nginx/odoo.access.log;
+    error_log /var/log/nginx/odoo.error.log;
+
+    # =========================================================================
+    # Gzip compression (from Odoo docs)
+    # =========================================================================
+    gzip_types text/css text/scss text/plain text/xml application/xml application/json application/javascript;
+    gzip on;
+
+    # Increase body size for file uploads
+    client_max_body_size 100m;
+
+    # =========================================================================
+    # Security headers (subset — no HSTS in dev since no HTTPS)
+    # =========================================================================
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    proxy_hide_header X-Powered-By;
+
+    # =========================================================================
+    # WebSocket routing for longpolling/live updates (from Odoo docs)
+    # =========================================================================
+    location /websocket {
+        proxy_pass http://odoochat;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_set_header X-Forwarded-Host $http_host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
+    # =========================================================================
+    # Main Odoo proxy (from Odoo docs)
+    # =========================================================================
+    location / {
+        proxy_set_header X-Forwarded-Host $http_host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_redirect off;
+        proxy_pass http://odoo;
+    }
+}

--- a/docker/nginx/odoo.conf.template
+++ b/docker/nginx/odoo.conf.template
@@ -108,8 +108,6 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     # Clickjacking protection
     add_header X-Frame-Options "SAMEORIGIN" always;
-    # XSS filter (legacy browsers)
-    add_header X-XSS-Protection "1; mode=block" always;
     # Referrer policy
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     # Disable unused browser features

--- a/docker/nginx/odoo.conf.template
+++ b/docker/nginx/odoo.conf.template
@@ -1,0 +1,197 @@
+# Nginx reverse proxy configuration for Odoo
+#
+# Based on the official Odoo deployment documentation:
+# https://www.odoo.com/documentation/19.0/administration/on_premise/deploy.html
+#
+# Environment variables (substituted by envsubst at container start):
+#   DOMAIN - The server domain name (e.g., openspp.example.org)
+
+# Hide Nginx version in error pages and response headers
+server_tokens off;
+
+upstream odoo {
+    server odoo:8069;
+}
+
+upstream odoochat {
+    server odoo:8072;
+}
+
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
+# Rate limiting zones
+# General: 10 requests/sec per IP with burst allowance
+limit_req_zone $binary_remote_addr zone=general:10m rate=10r/s;
+# Login/sensitive endpoints: stricter 2 requests/sec per IP
+limit_req_zone $binary_remote_addr zone=login:10m rate=2r/s;
+
+# HTTP -> HTTPS redirect + ACME challenge
+server {
+    listen 80;
+    server_name ${DOMAIN};
+
+    # Certbot ACME challenge
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+# HTTPS server
+server {
+    listen 443 ssl;
+    http2 on;
+    server_name ${DOMAIN};
+
+    # =========================================================================
+    # SSL configuration
+    # =========================================================================
+    ssl_certificate /etc/letsencrypt/live/${DOMAIN}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/${DOMAIN}/privkey.pem;
+    ssl_session_timeout 30m;
+    ssl_session_cache shared:SSL:10m;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+    ssl_prefer_server_ciphers off;
+
+    # OCSP stapling — Nginx fetches and caches the OCSP response so clients
+    # don't have to contact the CA, improving TLS handshake performance.
+    ssl_stapling on;
+    ssl_stapling_verify on;
+    ssl_trusted_certificate /etc/letsencrypt/live/${DOMAIN}/chain.pem;
+    resolver 1.1.1.1 8.8.8.8 valid=300s;
+    resolver_timeout 5s;
+
+    # =========================================================================
+    # Timeouts (from Odoo docs)
+    # =========================================================================
+    proxy_read_timeout 720s;
+    proxy_connect_timeout 720s;
+    proxy_send_timeout 720s;
+
+    # =========================================================================
+    # Proxy buffering — buffer responses from Odoo to free up worker processes
+    # faster and handle slow clients without tying up Odoo workers.
+    # =========================================================================
+    proxy_buffering on;
+    proxy_buffer_size 16k;
+    proxy_buffers 16 64k;
+    proxy_busy_buffers_size 128k;
+
+    # =========================================================================
+    # Logging
+    # =========================================================================
+    access_log /var/log/nginx/odoo.access.log;
+    error_log /var/log/nginx/odoo.error.log;
+
+    # =========================================================================
+    # Gzip compression (from Odoo docs)
+    # =========================================================================
+    gzip_types text/css text/scss text/plain text/xml application/xml application/json application/javascript;
+    gzip on;
+
+    # Increase body size for file uploads
+    client_max_body_size 100m;
+
+    # =========================================================================
+    # Security headers
+    # =========================================================================
+    # HSTS — force HTTPS for 1 year including subdomains
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    # Prevent MIME-type sniffing
+    add_header X-Content-Type-Options "nosniff" always;
+    # Clickjacking protection
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    # XSS filter (legacy browsers)
+    add_header X-XSS-Protection "1; mode=block" always;
+    # Referrer policy
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    # Disable unused browser features
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
+    # Content Security Policy
+    # NOTE: unsafe-inline and unsafe-eval are required by Odoo's OWL framework
+    # and legacy JS. This CSP restricts resource origins and prevents framing.
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; frame-ancestors 'self'; base-uri 'self'; form-action 'self';" always;
+    # Hide upstream server identity (X-Powered-By from Werkzeug/Python)
+    # NOTE: server_tokens off (above) hides the Nginx version from the Server
+    # header. Fully removing the Server header requires headers-more-nginx-module.
+    proxy_hide_header X-Powered-By;
+
+    # =========================================================================
+    # Block database manager access (redirect to login)
+    # =========================================================================
+    # NOTE: This is a URL rewrite, not a true block. The real controls are
+    # LIST_DB=False and a strong ODOO_ADMIN_PASSWD in the Odoo configuration.
+    location /web/database {
+        return 302 /web/login;
+    }
+
+    # =========================================================================
+    # Rate-limited sensitive endpoints
+    # =========================================================================
+    location /web/login {
+        limit_req zone=login burst=5 nodelay;
+        limit_req_status 429;
+
+        proxy_set_header X-Forwarded-Host $http_host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_redirect off;
+        proxy_pass http://odoo;
+
+        proxy_cookie_flags session_id samesite=lax secure;
+    }
+
+    location /web/session/authenticate {
+        limit_req zone=login burst=5 nodelay;
+        limit_req_status 429;
+
+        proxy_set_header X-Forwarded-Host $http_host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_redirect off;
+        proxy_pass http://odoo;
+
+        proxy_cookie_flags session_id samesite=lax secure;
+    }
+
+    # =========================================================================
+    # WebSocket routing for longpolling/live updates (from Odoo docs)
+    # =========================================================================
+    location /websocket {
+        proxy_pass http://odoochat;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_set_header X-Forwarded-Host $http_host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Real-IP $remote_addr;
+
+        proxy_cookie_flags session_id samesite=lax secure;
+    }
+
+    # =========================================================================
+    # Main Odoo proxy (from Odoo docs)
+    # =========================================================================
+    location / {
+        limit_req zone=general burst=20 nodelay;
+        limit_req_status 429;
+
+        proxy_set_header X-Forwarded-Host $http_host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_redirect off;
+        proxy_pass http://odoo;
+
+        proxy_cookie_flags session_id samesite=lax secure;
+    }
+}


### PR DESCRIPTION
## Summary

Closes #65

- Add `docker-compose.nginx.yml` with `nginx:stable-alpine` as a reverse proxy alternative to the existing Traefik stack, with Certbot for Let's Encrypt SSL certificates
- Add Fluentd for centralized log collection with modular backends (local/NFS, AWS S3, GCS, Azure Blob, MinIO)
- Add Nginx configs based on the official Odoo 19.0 deployment documentation: HTTPS variant with rate limiting, security headers (HSTS, CSP, X-Frame-Options), OCSP stapling, proxy buffering, and `/web/database` blocking; HTTP-only variant for dev and isolated on-premises networks

### Profile-based architecture

| Profile  | Services                      | Use case                               |
| -------- | ----------------------------- | -------------------------------------- |
| `https`  | Nginx (SSL) + Certbot         | Production with HTTPS and auto-renewal |
| `http`   | Nginx (HTTP only)              | Dev or isolated on-premises networks   |
| `clamav` | ClamAV antivirus (existing)    | File upload scanning                   |

Profiles are combinable: `COMPOSE_PROFILES=https,clamav`

### Security hardening (all services)

- `cap_drop: ALL` with minimal `cap_add` per service
- `security_opt: no-new-privileges:true`
- `read_only: true` with targeted tmpfs where possible
- CPU and memory resource limits
- Log rotation (json-file, 5MB / 3 files)
- SELinux-compatible volume flags (`:ro,z` / `:rw,z`)

### Other changes

- `entrypoint.sh`: gate config dump behind `ODOO_DEV_MODE` to prevent DB password leaking to logs
- `docker-compose.production.yml`: fix queue-worker command path
- `.env.production.example`: add profile, CPU limit, Nginx, and Fluentd log path variables
- `README.md`: document Nginx stack and Fluentd alongside existing Traefik stack

## Test plan

- [x] `docker compose -f docker/docker-compose.nginx.yml --profile http up -d` — verify HTTP-only mode starts and proxies to Odoo
- [x] `docker compose -f docker/docker-compose.nginx.yml --profile https up -d` — verify HTTPS mode starts with Certbot
- [x] `docker compose -f docker/docker-compose.nginx.yml --profile https --profile clamav up -d` — verify combined profiles
- [x] Verify Fluentd collects logs to `FLUENTD_LOG_PATH`
- [x] Verify `docker compose logs` still works (Fluentd uses file tailing, not Docker log driver)
- [x] Verify security headers in Nginx response (`curl -I`)
- [x] Verify rate limiting on `/web/login`

🤖 Generated with [Claude Code](https://claude.com/claude-code)