### PR TITLE
chore: update geoipupdate from 6.0.0 to 7.1.1

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -128,7 +128,9 @@ ARG TARGETARCH
 ARG WKHTMLTOPDF_VERSION=0.12.6.1
 ARG WKHTMLTOPDF_AMD64_CHECKSUM='98ba0d157b50d36f23bd0dedf4c0aa28c7b0c50fcdcdc54aa5b6bbba81a3941d'
 ARG WKHTMLTOPDF_ARM64_CHECKSUM='b6606157b27c13e044d0abbe670301f88de4e1782afca4f9c06a5817f3e03a9c'
-ARG GEOIP_UPDATER_VERSION=6.0.0
+ARG GEOIP_UPDATER_VERSION=7.1.1
+ARG GEOIP_AMD64_CHECKSUM='c4c964b0fabbeac4087636f4fc822a9f8c35204641675d242781a270f739b3e3'
+ARG GEOIP_ARM64_CHECKSUM='687e373348973fd9a9da7e7d8f23b7cac34ad786ea7db71f280c4953f532043c'
 ARG ODOO_VERSION=19.0
 ARG UID=1000
 ARG GID=1000
@@ -216,11 +218,17 @@ RUN --mount=type=cache,target=/tmp/downloads,sharing=locked \
     fi; \
     apt-get install -y --no-install-recommends "$WKHTMLTOPDF_DEB"; \
     # geoipupdate
-    GEOIP_DEB="/tmp/downloads/geoipupdate_${GEOIP_UPDATER_VERSION}_${TARGETARCH}.deb"; \
-    if [ ! -f "$GEOIP_DEB" ] || ! dpkg --info "$GEOIP_DEB" >/dev/null 2>&1; then \
+    if [ "$TARGETARCH" = "arm64" ]; then \
+        GEOIP_CHECKSUM=$GEOIP_ARM64_CHECKSUM; \
+    elif [ "$TARGETARCH" = "amd64" ]; then \
+        GEOIP_CHECKSUM=$GEOIP_AMD64_CHECKSUM; \
+    fi; \
+    GEOIP_DEB="/tmp/downloads/geoipupdate_${GEOIP_UPDATER_VERSION}_linux_${TARGETARCH}.deb"; \
+    if [ ! -f "$GEOIP_DEB" ] || ! echo "${GEOIP_CHECKSUM} ${GEOIP_DEB}" | sha256sum -c - >/dev/null 2>&1; then \
         rm -f "$GEOIP_DEB"; \
         curl -sSL -o "$GEOIP_DEB" \
             "https://github.com/maxmind/geoipupdate/releases/download/v${GEOIP_UPDATER_VERSION}/geoipupdate_${GEOIP_UPDATER_VERSION}_linux_${TARGETARCH}.deb"; \
+        echo "${GEOIP_CHECKSUM} ${GEOIP_DEB}" | sha256sum -c -; \
     fi; \
     dpkg -i "$GEOIP_DEB"
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -222,6 +222,9 @@ RUN --mount=type=cache,target=/tmp/downloads,sharing=locked \
         GEOIP_CHECKSUM=$GEOIP_ARM64_CHECKSUM; \
     elif [ "$TARGETARCH" = "amd64" ]; then \
         GEOIP_CHECKSUM=$GEOIP_AMD64_CHECKSUM; \
+    else \
+        echo "Unsupported architecture for geoipupdate: $TARGETARCH" >&2; \
+        exit 1; \
     fi; \
     GEOIP_DEB="/tmp/downloads/geoipupdate_${GEOIP_UPDATER_VERSION}_linux_${TARGETARCH}.deb"; \
     if [ ! -f "$GEOIP_DEB" ] || ! echo "${GEOIP_CHECKSUM} ${GEOIP_DEB}" | sha256sum -c - >/dev/null 2>&1; then \


### PR DESCRIPTION
## Summary
- Update `GEOIP_UPDATER_VERSION` from 6.0.0 to 7.1.1 (latest release, Jul 2025)
- Add SHA256 checksum verification for geoipupdate `.deb` downloads, matching the existing pattern used for wkhtmltopdf
- Fix download filename to include `linux_` prefix matching the actual release artifact names

Closes #135

## Test plan
- [ ] Build Docker image for amd64 and verify geoipupdate 7.1.1 is installed
- [ ] Build Docker image for arm64 and verify geoipupdate 7.1.1 is installed
- [ ] Verify checksum validation works by tampering with a checksum and confirming the build fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)