### PR TITLE
fix: add HTML escaping to sanitize=False computed Html fields

### DIFF
--- a/spp_audit/README.rst
+++ b/spp_audit/README.rst
@@ -154,6 +154,8 @@ Changelog
   all records, not just the first
 - refactor: use ``isinstance(value, Markup)`` instead of fragile
   ``str(type(...))`` comparison in all audit decorator methods
+- fix: add HTML escaping to computed ``data_html`` and
+  ``parent_data_html`` fields to prevent stored XSS (#50)
 
 19.0.2.0.0
 ~~~~~~~~~~

--- a/spp_audit/models/spp_audit_log.py
+++ b/spp_audit/models/spp_audit_log.py
@@ -2,6 +2,7 @@ import ast
 import logging
 
 from dateutil import tz
+from markupsafe import escape as html_escape
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
@@ -164,7 +165,7 @@ class SppAuditLog(models.Model):
             for line in rec._get_content():
                 row = ""
                 for item in line:
-                    row += f"<td>{item}</td>"
+                    row += f"<td>{html_escape(str(item))}</td>"
                 tbody += f"<tr>{row}</tr>"
             tbody = f"<tbody>{tbody}</tbody>"
             rec.data_html = f'<table class="o_list_view table table-condensed table-striped">{thead}{tbody}</table>'
@@ -206,7 +207,7 @@ class SppAuditLog(models.Model):
             for line in rec._parent_get_content():
                 row = ""
                 for item in line:
-                    row += f"<td>{item}</td>"
+                    row += f"<td>{html_escape(str(item))}</td>"
                 tbody += f"<tr>{row}</tr>"
             tbody = f"<tbody>{tbody}</tbody>"
             rec.parent_data_html = (

--- a/spp_audit/readme/HISTORY.md
+++ b/spp_audit/readme/HISTORY.md
@@ -3,6 +3,7 @@
 - fix: use @api.model_create_multi for audit_create to support Odoo 19 create overrides (#138)
 - fix: Markup sanitization in audit_write and audit_unlink now handles all records, not just the first
 - refactor: use `isinstance(value, Markup)` instead of fragile `str(type(...))` comparison in all audit decorator methods
+- fix: add HTML escaping to computed `data_html` and `parent_data_html` fields to prevent stored XSS (#50)
 
 ### 19.0.2.0.0
 

--- a/spp_audit/static/description/index.html
+++ b/spp_audit/static/description/index.html
@@ -524,6 +524,8 @@ create overrides (#138)</li>
 all records, not just the first</li>
 <li>refactor: use <tt class="docutils literal">isinstance(value, Markup)</tt> instead of fragile
 <tt class="docutils literal"><span class="pre">str(type(...))</span></tt> comparison in all audit decorator methods</li>
+<li>fix: add HTML escaping to computed <tt class="docutils literal">data_html</tt> and
+<tt class="docutils literal">parent_data_html</tt> fields to prevent stored XSS (#50)</li>
 </ul>
 </div>
 <div class="section" id="section-2">

--- a/spp_audit/tests/__init__.py
+++ b/spp_audit/tests/__init__.py
@@ -1,2 +1,3 @@
 from . import test_audit_backend
+from . import test_html_escaping
 from . import test_spp_audit_rule

--- a/spp_audit/tests/test_html_escaping.py
+++ b/spp_audit/tests/test_html_escaping.py
@@ -87,3 +87,4 @@ class TestAuditHtmlEscaping(TransactionCase):
         )
         html = log.parent_data_html
         self.assertNotIn("<script>", html)
+        self.assertIn("&lt;script&gt;", html)

--- a/spp_audit/tests/test_html_escaping.py
+++ b/spp_audit/tests/test_html_escaping.py
@@ -1,0 +1,89 @@
+from odoo.tests.common import TransactionCase
+
+
+class TestAuditHtmlEscaping(TransactionCase):
+    """Tests that audit log HTML fields properly escape dynamic values."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.model_partner = cls.env["ir.model"].search([("model", "=", "res.partner")], limit=1)
+        cls.audit_rule = cls.env["spp.audit.rule"].search([("model_id", "=", cls.model_partner.id)], limit=1)
+        if not cls.audit_rule:
+            cls.audit_rule = cls.env["spp.audit.rule"].create(
+                {
+                    "name": "Test Rule",
+                    "model_id": cls.model_partner.id,
+                    "is_log_create": True,
+                    "is_log_write": True,
+                    "is_log_unlink": False,
+                }
+            )
+
+    def _create_audit_log(self, old_vals, new_vals):
+        """Create an audit log record with given old/new values."""
+        data = repr({"old": old_vals, "new": new_vals})
+        return self.env["spp.audit.log"].create(
+            {
+                "audit_rule_id": self.audit_rule.id,
+                "user_id": self.env.uid,
+                "model_id": self.model_partner.id,
+                "res_id": 1,
+                "method": "write",
+                "data": data,
+            }
+        )
+
+    def test_data_html_escapes_script_tags(self):
+        """Verify data_html escapes <script> in field values."""
+        xss_payload = '<script>alert("xss")</script>'
+        log = self._create_audit_log(
+            old_vals={"name": "Safe Name"},
+            new_vals={"name": xss_payload},
+        )
+        html = log.data_html
+        self.assertNotIn("<script>", html)
+        self.assertIn("&lt;script&gt;", html)
+
+    def test_data_html_escapes_html_entities(self):
+        """Verify data_html escapes angle brackets and ampersands."""
+        log = self._create_audit_log(
+            old_vals={"name": "Before <b>bold</b>"},
+            new_vals={"name": "After <img src=x onerror=alert(1)>"},
+        )
+        html = log.data_html
+        self.assertNotIn("<img ", html)
+        self.assertIn("&lt;img ", html)
+        self.assertNotIn("<b>bold</b>", html)
+        self.assertIn("&lt;b&gt;bold&lt;/b&gt;", html)
+
+    def test_data_html_renders_table_structure(self):
+        """Verify data_html still produces valid table structure."""
+        log = self._create_audit_log(
+            old_vals={"name": "Old"},
+            new_vals={"name": "New"},
+        )
+        html = log.data_html
+        self.assertIn("<table", html)
+        self.assertIn("<thead>", html)
+        self.assertIn("<tbody>", html)
+        self.assertIn("<td>", html)
+
+    def test_parent_data_html_escapes_script_tags(self):
+        """Verify parent_data_html escapes <script> in field values."""
+        xss_payload = '<script>alert("xss")</script>'
+        parent_model = self.env["ir.model"].search([("model", "=", "res.partner")], limit=1)
+        log = self.env["spp.audit.log"].create(
+            {
+                "audit_rule_id": self.audit_rule.id,
+                "user_id": self.env.uid,
+                "model_id": self.model_partner.id,
+                "res_id": 1,
+                "method": "write",
+                "data": repr({"old": {"name": "Safe"}, "new": {"name": xss_payload}}),
+                "parent_model_id": parent_model.id,
+                "parent_res_ids_str": "1",
+            }
+        )
+        html = log.parent_data_html
+        self.assertNotIn("<script>", html)

--- a/spp_change_request_v2/README.rst
+++ b/spp_change_request_v2/README.rst
@@ -853,6 +853,12 @@ Before declaring a new CR type complete:
 Changelog
 =========
 
+19.0.2.0.3
+~~~~~~~~~~
+
+- fix: add HTML escaping to all computed Html fields with
+  ``sanitize=False`` to prevent stored XSS (#50)
+
 19.0.2.0.2
 ~~~~~~~~~~
 

--- a/spp_change_request_v2/__manifest__.py
+++ b/spp_change_request_v2/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "OpenSPP Change Request V2",
-    "version": "19.0.2.0.2",
+    "version": "19.0.2.0.3",
     "sequence": 50,
     "category": "OpenSPP",
     "summary": "Configuration-driven change request system with UX improvements, conflict detection and duplicate prevention",

--- a/spp_change_request_v2/models/change_request.py
+++ b/spp_change_request_v2/models/change_request.py
@@ -541,19 +541,20 @@ class SPPChangeRequest(models.Model):
                 html_parts.append('<i class="fa fa-users fa-lg text-primary me-2"></i>')
             else:
                 html_parts.append('<i class="fa fa-user fa-lg text-primary me-2"></i>')
-            html_parts.append(f"<strong>{reg.name}</strong>")
+            html_parts.append(f"<strong>{html_escape(reg.name or '')}</strong>")
             html_parts.append("</div>")
 
             # ID badge
             if hasattr(reg, "spp_id") and reg.spp_id:
-                html_parts.append(f'<div class="mb-2"><span class="badge bg-secondary">ID: {reg.spp_id}</span></div>')
+                escaped_id = html_escape(reg.spp_id)
+                html_parts.append(f'<div class="mb-2"><span class="badge bg-secondary">ID: {escaped_id}</span></div>')
 
             # Address
             address_parts = []
             if reg.street:
-                address_parts.append(reg.street)
+                address_parts.append(html_escape(reg.street))
             if reg.city:
-                address_parts.append(reg.city)
+                address_parts.append(html_escape(reg.city))
             if address_parts:
                 html_parts.append(
                     f'<div class="text-muted small mb-2">'
@@ -1073,7 +1074,7 @@ class SPPChangeRequest(models.Model):
         action_label = action_labels.get(action, action.replace("_", " ").title())
         html_parts.append(
             f'<div class="mb-3 d-flex align-items-center">'
-            f'<span class="badge bg-primary me-2">{action_label}</span>'
+            f'<span class="badge bg-primary me-2">{html_escape(action_label)}</span>'
             f"</div>"
         )
 
@@ -1085,7 +1086,7 @@ class SPPChangeRequest(models.Model):
             for key, value in changes.items():
                 if key.startswith("_"):
                     continue
-                display_key = key.replace("_", " ").title()
+                display_key = html_escape(key.replace("_", " ").title())
 
                 # Handle dict with old/new structure
                 if isinstance(value, dict) and "new" in value:
@@ -1095,16 +1096,16 @@ class SPPChangeRequest(models.Model):
                     if old_val is None or old_val is False or old_val == "":
                         old_display = '<span class="text-muted">—</span>'
                     else:
-                        old_display = str(old_val)
+                        old_display = html_escape(str(old_val))
                     # Format new value
                     if new_val is None or new_val is False or new_val == "":
                         new_display = '<span class="text-muted">—</span>'
                     else:
-                        new_display = f"<strong>{new_val}</strong>"
+                        new_display = f"<strong>{html_escape(str(new_val))}</strong>"
                     display_value = f"{old_display} → {new_display}"
                 elif isinstance(value, list):
                     if value:
-                        display_value = "<br/>".join(str(v) for v in value)
+                        display_value = "<br/>".join(html_escape(str(v)) for v in value)
                     else:
                         display_value = '<span class="text-muted">Not set</span>'
                 elif value is None or value is False or value == "":
@@ -1114,7 +1115,7 @@ class SPPChangeRequest(models.Model):
                     # Only True reaches here (False caught above)
                     display_value = '<span class="badge text-bg-success">Yes</span>'
                 else:
-                    display_value = str(value)
+                    display_value = html_escape(str(value))
 
                 html_parts.append(f"<tr><td><strong>{display_key}</strong></td><td>{display_value}</td></tr>")
 

--- a/spp_change_request_v2/models/change_request.py
+++ b/spp_change_request_v2/models/change_request.py
@@ -380,11 +380,11 @@ class SPPChangeRequest(models.Model):
     @api.depends("name", "request_type_id", "registrant_id")
     def _compute_stage_banner_html(self):
         for rec in self:
-            cr_ref = rec.name or ""
-            cr_type = rec.request_type_id.name if rec.request_type_id else ""
+            cr_ref = html_escape(rec.name or "")
+            cr_type = html_escape(rec.request_type_id.name) if rec.request_type_id else ""
             html = f'<span class="fw-bold">{cr_ref}</span><span class="text-muted mx-2">|</span><span>{cr_type}</span>'
             if rec.registrant_id:
-                registrant = rec.registrant_id.name or ""
+                registrant = html_escape(rec.registrant_id.name or "")
                 html += (
                     f'<span class="text-muted mx-2">|</span>'
                     f'<i class="fa fa-user me-1 text-muted"></i>'
@@ -422,14 +422,11 @@ class SPPChangeRequest(models.Model):
             uploaded_types = rec.document_ids.mapped("document_type_id").filtered(lambda c: c)
             items = []
             for doc_type in required:
+                escaped_name = html_escape(doc_type.display_name)
                 if doc_type in uploaded_types:
-                    items.append(
-                        f'<li class="text-success"><i class="fa fa-check-circle me-1"></i>{doc_type.display_name}</li>'
-                    )
+                    items.append(f'<li class="text-success"><i class="fa fa-check-circle me-1"></i>{escaped_name}</li>')
                 else:
-                    items.append(
-                        f'<li class="text-danger"><i class="fa fa-times-circle me-1"></i>{doc_type.display_name}</li>'
-                    )
+                    items.append(f'<li class="text-danger"><i class="fa fa-times-circle me-1"></i>{escaped_name}</li>')
 
             rec.required_documents_html = (
                 '<div class="mb-3">'
@@ -508,8 +505,8 @@ class SPPChangeRequest(models.Model):
             html.append("<tbody>")
 
             for doc in rec.document_ids:
-                doc_name = doc.name or ""
-                doc_type = doc.document_type_id.display_name if doc.document_type_id else ""
+                doc_name = html_escape(doc.name or "")
+                doc_type = html_escape(doc.document_type_id.display_name) if doc.document_type_id else ""
                 uploaded = doc.create_date.strftime("%Y-%m-%d") if doc.create_date else ""
                 html.append(
                     f"<tr>"
@@ -1168,7 +1165,7 @@ class SPPChangeRequest(models.Model):
         """Render a three-column comparison table for field-mapping CR types."""
         html = []
         if header:
-            html.append(f"<h4>{header}</h4>")
+            html.append(f"<h4>{html_escape(header)}</h4>")
         html.append('<table class="table table-sm table-bordered mb-0" style="width:100%">')
         html.append(
             "<thead><tr>"
@@ -1183,7 +1180,7 @@ class SPPChangeRequest(models.Model):
             if key.startswith("_"):
                 continue
             # Use key as-is if it contains spaces (human-readable), otherwise convert
-            display_key = key if " " in key else key.replace("_", " ").title()
+            display_key = html_escape(key if " " in key else key.replace("_", " ").title())
 
             if isinstance(value, dict) and "old" in value:
                 old_val = value.get("old")
@@ -1221,7 +1218,7 @@ class SPPChangeRequest(models.Model):
         html = []
 
         if header:
-            html.append(f"<h4>{header}</h4>")
+            html.append(f"<h4>{html_escape(header)}</h4>")
 
         if not changes:
             html.append('<p class="text-muted mb-0"><i class="fa fa-info-circle me-2"></i>No details to display.</p>')
@@ -1234,7 +1231,7 @@ class SPPChangeRequest(models.Model):
         for key, value in changes.items():
             if key.startswith("_"):
                 continue
-            display_key = key if " " in key else key.replace("_", " ").title()
+            display_key = html_escape(key if " " in key else key.replace("_", " ").title())
             display_value = self._format_review_value(value)
             html.append(f'<tr><td class="bg-light"><strong>{display_key}</strong></td><td>{display_value}</td></tr>')
 

--- a/spp_change_request_v2/readme/HISTORY.md
+++ b/spp_change_request_v2/readme/HISTORY.md
@@ -1,3 +1,7 @@
+### 19.0.2.0.3
+
+- fix: add HTML escaping to all computed Html fields with `sanitize=False` to prevent stored XSS (#50)
+
 ### 19.0.2.0.2
 
 - fix: fix batch approval wizard line deletion (#130)

--- a/spp_change_request_v2/static/description/index.html
+++ b/spp_change_request_v2/static/description/index.html
@@ -1339,19 +1339,26 @@ registrant</li>
 </div>
 </div>
 <div class="section" id="section-1">
+<h1>19.0.2.0.3</h1>
+<ul class="simple">
+<li>fix: add HTML escaping to all computed Html fields with
+<tt class="docutils literal">sanitize=False</tt> to prevent stored XSS (#50)</li>
+</ul>
+</div>
+<div class="section" id="section-2">
 <h1>19.0.2.0.2</h1>
 <ul class="simple">
 <li>fix: fix batch approval wizard line deletion (#130)</li>
 </ul>
 </div>
-<div class="section" id="section-2">
+<div class="section" id="section-3">
 <h1>19.0.2.0.1</h1>
 <ul class="simple">
 <li>fix: skip field types before getattr and isolate detail prefetch
 (#129)</li>
 </ul>
 </div>
-<div class="section" id="section-3">
+<div class="section" id="section-4">
 <h1>19.0.2.0.0</h1>
 <ul class="simple">
 <li>Initial migration to OpenSPP2</li>

--- a/spp_change_request_v2/tests/__init__.py
+++ b/spp_change_request_v2/tests/__init__.py
@@ -23,3 +23,5 @@ from . import test_stage_navigation
 from . import test_approval_hooks_and_audit
 from . import test_dynamic_approval
 from . import test_conflict_dynamic_approval
+from . import test_html_escaping
+from . import test_wizard_html_escaping

--- a/spp_change_request_v2/tests/test_html_escaping.py
+++ b/spp_change_request_v2/tests/test_html_escaping.py
@@ -1,0 +1,141 @@
+from unittest.mock import patch
+
+from odoo.tests import tagged
+
+from .test_change_request import TestChangeRequestBase
+
+
+@tagged("post_install", "-at_install")
+class TestHtmlEscaping(TestChangeRequestBase):
+    """Tests that computed HTML fields properly escape dynamic values."""
+
+    def _create_cr(self, registrant=None, cr_type=None):
+        """Helper to create a CR for testing."""
+        vals = {
+            "request_type_id": (cr_type or self.cr_type_add_member).id,
+        }
+        if registrant is not False:
+            vals["registrant_id"] = (registrant or self.group).id
+        return self.cr_model.create(vals)
+
+    def test_registrant_summary_escapes_name(self):
+        """Verify registrant_summary_html escapes XSS in registrant name."""
+        xss_name = '<script>alert("xss")</script>'
+        registrant = self.partner_model.create(
+            {
+                "name": xss_name,
+                "is_registrant": True,
+                "is_group": False,
+            }
+        )
+        cr = self._create_cr(registrant=registrant)
+        cr.invalidate_recordset()
+        html = cr.registrant_summary_html
+        self.assertNotIn("<script>", html)
+        self.assertIn("&lt;script&gt;", html)
+
+    def test_registrant_summary_escapes_address(self):
+        """Verify registrant_summary_html escapes XSS in street/city."""
+        registrant = self.partner_model.create(
+            {
+                "name": "Safe Name",
+                "is_registrant": True,
+                "is_group": False,
+                "street": '<img src=x onerror=alert(1)>',
+                "city": '<b onmouseover=alert(2)>City</b>',
+            }
+        )
+        cr = self._create_cr(registrant=registrant)
+        cr.invalidate_recordset()
+        html = cr.registrant_summary_html
+        self.assertNotIn("<img ", html)
+        self.assertNotIn("<b ", html)
+        self.assertIn("&lt;img ", html)
+        self.assertIn("&lt;b ", html)
+
+    def test_registrant_summary_escapes_spp_id(self):
+        """Verify registrant_summary_html escapes XSS in spp_id."""
+        registrant = self.partner_model.create(
+            {
+                "name": "Safe Name",
+                "is_registrant": True,
+                "is_group": False,
+            }
+        )
+        if hasattr(registrant, "spp_id"):
+            registrant.spp_id = '<script>alert("id")</script>'
+            cr = self._create_cr(registrant=registrant)
+            cr.invalidate_recordset()
+            html = cr.registrant_summary_html
+            self.assertNotIn("<script>", html)
+
+    def test_preview_html_escapes_field_values(self):
+        """Verify _generate_preview_html escapes dynamic values."""
+        cr = self._create_cr()
+        xss_changes = {
+            "_action": "update",
+            "name": {
+                "old": '<script>alert("old")</script>',
+                "new": '<img src=x onerror=alert("new")>',
+            },
+            "notes": '<script>alert("notes")</script>',
+        }
+        # Mock the strategy.preview() to return XSS payloads
+        with patch.object(type(cr.request_type_id), "get_apply_strategy") as mock_strategy:
+            mock_strategy.return_value.preview.return_value = xss_changes
+            cr.invalidate_recordset()
+            html = cr._generate_preview_html()
+
+        self.assertNotIn("<script>", html)
+        self.assertNotIn("<img ", html)
+        self.assertIn("&lt;script&gt;", html)
+        self.assertIn("&lt;img ", html)
+
+    def test_preview_html_escapes_list_values(self):
+        """Verify _generate_preview_html escapes list values."""
+        cr = self._create_cr()
+        xss_changes = {
+            "_action": "update",
+            "tags": ['<script>alert(1)</script>', "safe value"],
+        }
+        with patch.object(type(cr.request_type_id), "get_apply_strategy") as mock_strategy:
+            mock_strategy.return_value.preview.return_value = xss_changes
+            cr.invalidate_recordset()
+            html = cr._generate_preview_html()
+
+        self.assertNotIn("<script>", html)
+        self.assertIn("&lt;script&gt;", html)
+        self.assertIn("safe value", html)
+
+    def test_preview_html_escapes_action_label(self):
+        """Verify _generate_preview_html escapes unknown action labels."""
+        cr = self._create_cr()
+        xss_changes = {
+            "_action": '<img src=x onerror=alert("action")>',
+            "field": "value",
+        }
+        with patch.object(type(cr.request_type_id), "get_apply_strategy") as mock_strategy:
+            mock_strategy.return_value.preview.return_value = xss_changes
+            cr.invalidate_recordset()
+            html = cr._generate_preview_html()
+
+        # .title() changes case, so check case-insensitively
+        self.assertNotIn("<img ", html.lower())
+        self.assertIn("&lt;", html)
+
+    def test_preview_html_preserves_safe_content(self):
+        """Verify normal content renders correctly after escaping."""
+        cr = self._create_cr()
+        safe_changes = {
+            "_action": "update",
+            "full_name": {"old": "Old Name", "new": "New Name"},
+        }
+        with patch.object(type(cr.request_type_id), "get_apply_strategy") as mock_strategy:
+            mock_strategy.return_value.preview.return_value = safe_changes
+            cr.invalidate_recordset()
+            html = cr._generate_preview_html()
+
+        self.assertIn("Old Name", html)
+        self.assertIn("New Name", html)
+        self.assertIn("Full Name", html)
+        self.assertIn("<table", html)

--- a/spp_change_request_v2/tests/test_html_escaping.py
+++ b/spp_change_request_v2/tests/test_html_escaping.py
@@ -68,6 +68,7 @@ class TestHtmlEscaping(TestChangeRequestBase):
             cr.invalidate_recordset()
             html = cr.registrant_summary_html
             self.assertNotIn("<script>", html)
+            self.assertIn("&lt;script&gt;", html)
 
     def test_preview_html_escapes_field_values(self):
         """Verify _generate_preview_html escapes dynamic values."""

--- a/spp_change_request_v2/tests/test_html_escaping.py
+++ b/spp_change_request_v2/tests/test_html_escaping.py
@@ -41,8 +41,8 @@ class TestHtmlEscaping(TestChangeRequestBase):
                 "name": "Safe Name",
                 "is_registrant": True,
                 "is_group": False,
-                "street": '<img src=x onerror=alert(1)>',
-                "city": '<b onmouseover=alert(2)>City</b>',
+                "street": "<img src=x onerror=alert(1)>",
+                "city": "<b onmouseover=alert(2)>City</b>",
             }
         )
         cr = self._create_cr(registrant=registrant)
@@ -96,7 +96,7 @@ class TestHtmlEscaping(TestChangeRequestBase):
         cr = self._create_cr()
         xss_changes = {
             "_action": "update",
-            "tags": ['<script>alert(1)</script>', "safe value"],
+            "tags": ["<script>alert(1)</script>", "safe value"],
         }
         with patch.object(type(cr.request_type_id), "get_apply_strategy") as mock_strategy:
             mock_strategy.return_value.preview.return_value = xss_changes

--- a/spp_change_request_v2/tests/test_wizard_html_escaping.py
+++ b/spp_change_request_v2/tests/test_wizard_html_escaping.py
@@ -1,0 +1,107 @@
+import json
+from unittest.mock import patch
+
+from odoo.tests import tagged
+
+from .test_change_request import TestChangeRequestBase
+
+
+@tagged("post_install", "-at_install")
+class TestWizardHtmlEscaping(TestChangeRequestBase):
+    """Tests that the preview wizard properly escapes HTML in dynamic values."""
+
+    def _create_cr(self, registrant=None, cr_type=None):
+        """Helper to create a CR for testing."""
+        vals = {
+            "request_type_id": (cr_type or self.cr_type_add_member).id,
+        }
+        if registrant is not False:
+            vals["registrant_id"] = (registrant or self.group).id
+        return self.cr_model.create(vals)
+
+    def _create_wizard(self, cr):
+        """Create a preview wizard for the given CR."""
+        return self.env["spp.cr.preview.wizard"].create(
+            {"change_request_id": cr.id}
+        )
+
+    def test_wizard_preview_escapes_action(self):
+        """Verify wizard preview_html escapes XSS in action value."""
+        cr = self._create_cr()
+        wizard = self._create_wizard(cr)
+        xss_changes = {
+            "_action": '<script>alert("action")</script>',
+            "field": "value",
+        }
+        with patch.object(type(cr.request_type_id), "get_apply_strategy") as mock_strategy:
+            mock_strategy.return_value.preview.return_value = xss_changes
+            wizard.invalidate_recordset()
+            html = wizard.preview_html
+
+        self.assertNotIn("<script>", html)
+        self.assertIn("&lt;script&gt;", html)
+
+    def test_wizard_preview_escapes_field_values(self):
+        """Verify wizard preview_html escapes XSS in field keys and values."""
+        cr = self._create_cr()
+        wizard = self._create_wizard(cr)
+        xss_changes = {
+            "_action": "update",
+            "safe_field": '<img src=x onerror=alert(1)>',
+        }
+        with patch.object(type(cr.request_type_id), "get_apply_strategy") as mock_strategy:
+            mock_strategy.return_value.preview.return_value = xss_changes
+            wizard.invalidate_recordset()
+            html = wizard.preview_html
+
+        self.assertNotIn("<img ", html)
+        self.assertIn("&lt;img ", html)
+
+    def test_wizard_preview_escapes_list_values(self):
+        """Verify wizard preview_html escapes list items."""
+        cr = self._create_cr()
+        wizard = self._create_wizard(cr)
+        xss_changes = {
+            "_action": "update",
+            "tags": ['<script>alert(1)</script>', "safe"],
+        }
+        with patch.object(type(cr.request_type_id), "get_apply_strategy") as mock_strategy:
+            mock_strategy.return_value.preview.return_value = xss_changes
+            wizard.invalidate_recordset()
+            html = wizard.preview_html
+
+        self.assertNotIn("<script>", html)
+        self.assertIn("&lt;script&gt;", html)
+        self.assertIn("safe", html)
+
+    def test_wizard_preview_from_snapshot_escapes(self):
+        """Verify wizard escapes values from stored JSON snapshots."""
+        cr = self._create_cr()
+        xss_snapshot = json.dumps({
+            "_action": "update",
+            "name": '<script>alert("snapshot")</script>',
+        })
+        cr.write({"is_applied": True, "preview_json_snapshot": xss_snapshot})
+        wizard = self._create_wizard(cr)
+        wizard.invalidate_recordset()
+        html = wizard.preview_html
+
+        self.assertNotIn("<script>", html)
+        self.assertIn("&lt;script&gt;", html)
+
+    def test_wizard_preview_preserves_safe_content(self):
+        """Verify safe content renders correctly in wizard preview."""
+        cr = self._create_cr()
+        wizard = self._create_wizard(cr)
+        safe_changes = {
+            "_action": "create",
+            "full_name": "John Doe",
+        }
+        with patch.object(type(cr.request_type_id), "get_apply_strategy") as mock_strategy:
+            mock_strategy.return_value.preview.return_value = safe_changes
+            wizard.invalidate_recordset()
+            html = wizard.preview_html
+
+        self.assertIn("John Doe", html)
+        self.assertIn("Full Name", html)
+        self.assertIn("create", html)

--- a/spp_change_request_v2/tests/test_wizard_html_escaping.py
+++ b/spp_change_request_v2/tests/test_wizard_html_escaping.py
@@ -21,9 +21,7 @@ class TestWizardHtmlEscaping(TestChangeRequestBase):
 
     def _create_wizard(self, cr):
         """Create a preview wizard for the given CR."""
-        return self.env["spp.cr.preview.wizard"].create(
-            {"change_request_id": cr.id}
-        )
+        return self.env["spp.cr.preview.wizard"].create({"change_request_id": cr.id})
 
     def test_wizard_preview_escapes_action(self):
         """Verify wizard preview_html escapes XSS in action value."""
@@ -47,7 +45,7 @@ class TestWizardHtmlEscaping(TestChangeRequestBase):
         wizard = self._create_wizard(cr)
         xss_changes = {
             "_action": "update",
-            "safe_field": '<img src=x onerror=alert(1)>',
+            "safe_field": "<img src=x onerror=alert(1)>",
         }
         with patch.object(type(cr.request_type_id), "get_apply_strategy") as mock_strategy:
             mock_strategy.return_value.preview.return_value = xss_changes
@@ -63,7 +61,7 @@ class TestWizardHtmlEscaping(TestChangeRequestBase):
         wizard = self._create_wizard(cr)
         xss_changes = {
             "_action": "update",
-            "tags": ['<script>alert(1)</script>', "safe"],
+            "tags": ["<script>alert(1)</script>", "safe"],
         }
         with patch.object(type(cr.request_type_id), "get_apply_strategy") as mock_strategy:
             mock_strategy.return_value.preview.return_value = xss_changes
@@ -77,10 +75,12 @@ class TestWizardHtmlEscaping(TestChangeRequestBase):
     def test_wizard_preview_from_snapshot_escapes(self):
         """Verify wizard escapes values from stored JSON snapshots."""
         cr = self._create_cr()
-        xss_snapshot = json.dumps({
-            "_action": "update",
-            "name": '<script>alert("snapshot")</script>',
-        })
+        xss_snapshot = json.dumps(
+            {
+                "_action": "update",
+                "name": '<script>alert("snapshot")</script>',
+            }
+        )
         cr.write({"is_applied": True, "preview_json_snapshot": xss_snapshot})
         wizard = self._create_wizard(cr)
         wizard.invalidate_recordset()

--- a/spp_change_request_v2/wizards/preview_changes_wizard.py
+++ b/spp_change_request_v2/wizards/preview_changes_wizard.py
@@ -3,6 +3,8 @@
 
 import json
 
+from markupsafe import escape as html_escape
+
 from odoo import api, fields, models
 
 
@@ -61,7 +63,7 @@ class CRPreviewChangesWizard(models.TransientModel):
             html_parts = ['<div class="o_preview_changes">']
 
             action = changes.pop("_action", "update")
-            html_parts.append(f'<p class="mb-3"><strong>Action:</strong> {action}</p>')
+            html_parts.append(f'<p class="mb-3"><strong>Action:</strong> {html_escape(str(action))}</p>')
 
             if changes:
                 html_parts.append('<table class="table table-sm table-striped">')
@@ -70,10 +72,10 @@ class CRPreviewChangesWizard(models.TransientModel):
 
                 for key, value in changes.items():
                     # Format the key
-                    display_key = key.replace("_", " ").title()
+                    display_key = html_escape(key.replace("_", " ").title())
                     # Format the value
                     if isinstance(value, list):
-                        display_value = "<br/>".join(str(v) for v in value)
+                        display_value = "<br/>".join(html_escape(str(v)) for v in value)
                     elif value is None:
                         display_value = '<span class="text-muted">Not set</span>'
                     elif isinstance(value, bool):
@@ -83,7 +85,7 @@ class CRPreviewChangesWizard(models.TransientModel):
                             else '<span class="badge text-bg-secondary">No</span>'
                         )
                     else:
-                        display_value = str(value)
+                        display_value = html_escape(str(value))
 
                     html_parts.append(f"<tr><td><strong>{display_key}</strong></td><td>{display_value}</td></tr>")
 


### PR DESCRIPTION
## Summary

- Escape dynamic values with `markupsafe.escape()` in computed `fields.Html` that build HTML via f-strings, preventing stored XSS
- **`spp_audit`**: Escape values in `data_html` and `parent_data_html` audit log tables
- **`spp_change_request_v2`**: Escape registrant name/ID/address in `registrant_summary_html`, and field diff values in `preview_html` (both model and wizard)

Fixes #50

## Test plan

- [x] `spp_audit` tests pass (19/19)
- [x] `spp_change_request_v2` tests pass (286/286)
- [x] Linting passes (ruff, ruff-format)
- [ ] Verify audit log HTML renders correctly in UI
- [ ] Verify CR preview HTML renders correctly in UI