### PR TITLE
fix(fastapi): restore retrying tests for Odoo 19

### DIFF
--- a/fastapi/routers/demo_router.py
+++ b/fastapi/routers/demo_router.py
@@ -8,7 +8,7 @@ integration with odoo.
 from typing import Annotated
 
 from psycopg2 import errorcodes
-from psycopg2.errors import OperationalError
+from psycopg2.errors import SerializationFailure
 
 from odoo.api import Environment
 from odoo.exceptions import AccessError, MissingError, UserError, ValidationError
@@ -138,7 +138,7 @@ async def retrying_post(
     return JSONResponse(content={"retries": tryno, "file": file.decode("utf-8")})
 
 
-class FakeConcurrentUpdateError(OperationalError):
+class FakeConcurrentUpdateError(SerializationFailure):
     @property
     def pgcode(self):
         return errorcodes.SERIALIZATION_FAILURE

--- a/fastapi/tests/test_fastapi.py
+++ b/fastapi/tests/test_fastapi.py
@@ -108,7 +108,6 @@ class FastAPIHttpCase(HttpCase):
         self._assert_expected_lang("fr-FR,en;q=0.7,en-GB;q=0.3", b'"fr_BE"')
         self._assert_expected_lang("fr-FR;q=0.1,en;q=1.0,en-GB;q=0.8", b'"en_US"')
 
-    @unittest.skip("Odoo 19: FastAPI retrying mechanism returns 500 in test mode (#53)")
     def test_retrying(self):
         """Test that the retrying mechanism is working as expected with the
         FastAPI endpoints.
@@ -119,7 +118,6 @@ class FastAPIHttpCase(HttpCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(int(response.content), nbr_retries)
 
-    @unittest.skip("Odoo 19: FastAPI retrying mechanism returns 500 in test mode (#53)")
     def test_retrying_post(self):
         """Test that the retrying mechanism is working as expected with the
         FastAPI endpoints in case of POST request with a file.


### PR DESCRIPTION
## Summary
- Fix `FakeConcurrentUpdateError` to inherit from `psycopg2.errors.SerializationFailure` instead of `OperationalError`
- Odoo 19's `retrying()` uses `isinstance` checks against `PG_CONCURRENCY_EXCEPTIONS_TO_RETRY` rather than pgcode-based checks, so the fake exception was not recognized as retryable
- Remove `@unittest.skip` decorators from `test_retrying` and `test_retrying_post`

Closes #53

## Test plan
- [x] `./scripts/test_single_module.sh fastapi` — 19/19 tests pass (previously 17 + 2 skipped)
- [x] Linter passes on changed files