### PR TITLE
fix(fastapi): restore commit/rollback assertion test for Odoo 19

### DIFF
--- a/fastapi/tests/test_fastapi.py
+++ b/fastapi/tests/test_fastapi.py
@@ -104,11 +104,14 @@ class FastAPIHttpCase(HttpCase):
             if thread.name.startswith("odoo.service.http.request."):
                 # Walk the call stack to check if we're inside retrying().
                 frame = sys._getframe(1)
-                while frame is not None:
-                    if frame.f_code.co_name == "retrying":
-                        tracker()
-                        break
-                    frame = frame.f_back
+                try:
+                    while frame is not None:
+                        if frame.f_code.co_name == "retrying":
+                            tracker()
+                            break
+                        frame = frame.f_back
+                finally:
+                    del frame
             return original_commit(cursor_self)
 
         with unittest.mock.patch.object(TestCursor, "commit", new=tracked_commit):
@@ -237,7 +240,7 @@ class FastAPIHttpCase(HttpCase):
             url = "/fastapi_demo/demo"
             response = self.url_open(url, timeout=600)
             self.assertEqual(response.status_code, 200)
-            mocked_commit.assert_called()
+            mocked_commit.assert_called_once()
 
         self.assert_exception_processed(
             exception_type=DemoExceptionType.http_exception,

--- a/fastapi/tests/test_fastapi.py
+++ b/fastapi/tests/test_fastapi.py
@@ -5,7 +5,7 @@ import os
 import unittest
 from contextlib import contextmanager
 
-from odoo import Command, sql_db
+from odoo import Command
 from odoo.tests.common import HttpCase
 from odoo.tools import mute_logger
 
@@ -86,9 +86,33 @@ class FastAPIHttpCase(HttpCase):
 
     @contextmanager
     def _mocked_commit(self):
-        cursor_cls = getattr(sql_db, "TestCursor", None) or sql_db.BaseCursor
-        with unittest.mock.patch.object(cursor_cls, "commit", return_value=None) as mocked_commit:
-            yield mocked_commit
+        # Odoo 19 moved TestCursor from sql_db to odoo.tests.test_cursor.
+        # HttpCase uses TestCursor (not Cursor) for the HTTP server thread.
+        # We track only commits originating from odoo.service.model.retrying()
+        # to avoid false positives from unrelated commits (e.g., routing map
+        # generation in endpoint_route_handler opens its own cursor).
+        import sys
+        import threading
+
+        from odoo.tests.test_cursor import TestCursor
+
+        original_commit = TestCursor.commit
+        tracker = unittest.mock.MagicMock()
+
+        def tracked_commit(cursor_self):
+            thread = threading.current_thread()
+            if thread.name.startswith("odoo.service.http.request."):
+                # Walk the call stack to check if we're inside retrying().
+                frame = sys._getframe(1)
+                while frame is not None:
+                    if frame.f_code.co_name == "retrying":
+                        tracker()
+                        break
+                    frame = frame.f_back
+            return original_commit(cursor_self)
+
+        with unittest.mock.patch.object(TestCursor, "commit", new=tracked_commit):
+            yield tracker
 
     def _assert_expected_lang(self, accept_language, expected_lang):
         route = "/fastapi_demo/demo/lang"
@@ -206,7 +230,6 @@ class FastAPIHttpCase(HttpCase):
             mocked_commit.assert_not_called()
             self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
 
-    @unittest.skip("Odoo 19: BaseCursor.commit mock not invoked by HTTP test runner (#54)")
     def test_no_commit_on_exception(self) -> None:
         # this test check that the way we mock the cursor is working as expected
         # and that the transaction is rolled back in case of exception.
@@ -214,7 +237,7 @@ class FastAPIHttpCase(HttpCase):
             url = "/fastapi_demo/demo"
             response = self.url_open(url, timeout=600)
             self.assertEqual(response.status_code, 200)
-            mocked_commit.assert_called_once()
+            mocked_commit.assert_called()
 
         self.assert_exception_processed(
             exception_type=DemoExceptionType.http_exception,


### PR DESCRIPTION
## Summary
- Fix `_mocked_commit()` to target `TestCursor` from `odoo.tests.test_cursor` (moved from `sql_db` in Odoo 19)
- Use a real function replacement instead of `MagicMock` (which is not a descriptor and doesn't pass `self` for instance methods)
- Track only commits from `retrying()` via stack frame walk to filter out unrelated commits (e.g., routing map generation in `endpoint_route_handler`)
- Remove `@unittest.skip` from `test_no_commit_on_exception`

Closes #54

## Test plan
- [x] `./scripts/test_single_module.sh fastapi` — 19/19 tests pass (previously 18 + 1 skipped)
- [x] Linter passes on changed files