### PR TITLE
fix(spp_registry): fix Registrant Tags EvalError on ref() in context

### DIFF
--- a/spp_registry/views/tags_view.xml
+++ b/spp_registry/views/tags_view.xml
@@ -15,7 +15,8 @@
         >[('namespace_uri', '=', 'urn:openspp:vocab:registrant-tags')]</field>
         <field
             name="context"
-        >{'default_vocabulary_id': ref('spp_registry.vocab_registrant_tags')}</field>
+            eval="{'default_vocabulary_id': ref('spp_registry.vocab_registrant_tags')}"
+        />
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 Add a Registrant Tag!


### PR DESCRIPTION
## Why is this change needed?

Navigating to Studio > Settings > Registrant Tags throws `EvalError: Name 'ref' is not defined`. The `ref()` function in the action's context field is evaluated client-side in Odoo 19 where it's not available.

## How was the change implemented?

Moved `ref()` from the field body to the `eval` attribute, which is processed server-side during XML data loading where `ref()` is available.

## New unit tests

N/A — XML data fix

## How to test manually

1. Go to Studio > Settings > Registrant Tags
2. Should open without error
3. Create a new tag — should default to correct vocabulary

## Related links

- Ticket: https://projects.acn.fr/projects/openspp/work_packages/879