### PR TITLE
fix(spp_farmer_registry_vocabularies): correct holder type namespace URI

### DIFF
--- a/spp_farmer_registry_vocabularies/README.md
+++ b/spp_farmer_registry_vocabularies/README.md
@@ -48,7 +48,7 @@ with FAO standards:
 - Commercial
 - Both
 
-#### Holder Type (`urn:fao:wca:2020:holder-type`)
+#### Holder Type (`urn:openspp:vocab:holder-type`)
 
 - Individual
 - Joint

--- a/spp_farmer_registry_vocabularies/data/vocab_holder_type.xml
+++ b/spp_farmer_registry_vocabularies/data/vocab_holder_type.xml
@@ -2,7 +2,7 @@
 <odoo noupdate="1">
     <record id="vocab_holder_type" model="spp.vocabulary">
         <field name="name">Holder Type (FAO WCA 2020)</field>
-        <field name="namespace_uri">urn:fao:wca:2020:holder-type</field>
+        <field name="namespace_uri">urn:openspp:vocab:holder-type</field>
         <field name="version">2020</field>
         <field name="is_system">True</field>
         <field name="domain">agriculture</field>


### PR DESCRIPTION
## Why is this change needed?

The Holder Type dropdown in the Farmer Registry Farm Details tab shows no records. The vocabulary data was created with namespace `urn:fao:wca:2020:holder-type` but the model field and view domain filter on `urn:openspp:vocab:holder-type`, causing a mismatch.

## How was the change implemented?

Changed the namespace URI in `vocab_holder_type.xml` from `urn:fao:wca:2020:holder-type` to `urn:openspp:vocab:holder-type` to match the domain filter in `spp_farmer_registry`. Updated README.md accordingly.

## New unit tests

N/A — data-only change.

## Unit tests executed by the author

Existing spp_farmer_registry tests pass.

## How to test manually

1. Install `spp_farmer_registry` on a fresh instance (or update the vocabulary namespace manually on existing instances)
2. Go to Registry > Farms > open a farm > Farm Details tab
3. Click the Holder Type dropdown — should now show: Individual, Joint, Institutional

**Note:** Since the XML uses `noupdate="1"`, existing instances need manual update: Settings > Vocabularies > find "Holder Type (FAO WCA 2020)" > change namespace to `urn:openspp:vocab:holder-type`.

## Related links

https://projects.acn.fr/projects/acn-eng/work_packages/833