### PR TITLE
fix(spp_user_roles): exclude role-backing groups from Groups dropdown

### DIFF
--- a/spp_user_roles/views/role.xml
+++ b/spp_user_roles/views/role.xml
@@ -20,6 +20,11 @@
             <xpath expr="//field[@name='name']" position="after">
                 <field name="role_type" />
             </xpath>
+            <xpath expr="//field[@name='implied_ids']" position="attributes">
+                <attribute
+                    name="domain"
+                >[('role_id', '=', False)]</attribute>
+            </xpath>
             <xpath
                 expr="//field[@name='line_ids']/list/field[@name='user_id']"
                 position="attributes"

--- a/spp_user_roles/views/role.xml
+++ b/spp_user_roles/views/role.xml
@@ -20,10 +20,12 @@
             <xpath expr="//field[@name='name']" position="after">
                 <field name="role_type" />
             </xpath>
-            <xpath expr="//field[@name='implied_ids']" position="attributes">
-                <attribute
-                    name="domain"
-                >[('role_id', '=', False)]</attribute>
+            <xpath expr="//field[@name='implied_ids']" position="replace">
+                <field
+                    name="implied_ids"
+                    nolabel="1"
+                    domain="[('role_id', '=', False)]"
+                />
             </xpath>
             <xpath
                 expr="//field[@name='line_ids']/list/field[@name='user_id']"

--- a/spp_user_roles/views/role.xml
+++ b/spp_user_roles/views/role.xml
@@ -20,12 +20,9 @@
             <xpath expr="//field[@name='name']" position="after">
                 <field name="role_type" />
             </xpath>
-            <xpath expr="//field[@name='implied_ids']" position="replace">
-                <field
-                    name="implied_ids"
-                    nolabel="1"
-                    domain="[('role_id', '=', False)]"
-                />
+            <xpath expr="//field[@name='implied_ids']" position="attributes">
+                <attribute name="domain">[('role_id', '=', False)]</attribute>
+                <attribute name="widget">many2many</attribute>
             </xpath>
             <xpath
                 expr="//field[@name='line_ids']/list/field[@name='user_id']"


### PR DESCRIPTION
## Why is this change needed?

When creating a role via the UI (Settings → Users & Companies → User Roles → New), Odoo 19 auto-creates a backing `res.groups` record. These role-backing groups then appear in the Groups tab dropdown of other roles alongside legitimate permission groups, causing confusion.

## How was the change implemented?

Added a domain filter `[('role_id', '=', False)]` on the `implied_ids` field in the role form view. This excludes any `res.groups` record that has a linked `res.users.role` — i.e., role-backing groups are hidden from the dropdown while standard permission groups remain visible.

## New unit tests

N/A — view-only change.

## Unit tests executed by the author

Existing spp_user_roles tests pass.

## How to test manually

1. Go to Settings → Users & Companies → User Roles
2. Create a new role (e.g., "Test Role") — this auto-creates a backing group
3. Open any other role (e.g., "Local Support")
4. Go to the Groups tab and search — "Test Role" should NOT appear in the dropdown
5. Module-defined groups (e.g., "HDX User / HDX User") should still appear

## Related links

https://projects.acn.fr/projects/acn-eng/work_packages/888