### PR TITLE
fix(spp_registry): format individual name on create and write

### DIFF
--- a/spp_api_v2/tests/test_search_service.py
+++ b/spp_api_v2/tests/test_search_service.py
@@ -57,8 +57,8 @@ class TestSearchService(ApiV2TestCase):
         self.assertEqual(total, 2)
         self.assertEqual(len(records), 2)
         names = [r.name for r in records]
-        self.assertIn("Alice Johnson", names)
-        self.assertIn("Alice Brown", names)
+        self.assertIn("JOHNSON, ALICE", names)
+        self.assertIn("BROWN, ALICE", names)
 
     def test_parse_identifier_param(self):
         """identifier=system|value creates proper domain"""
@@ -224,7 +224,7 @@ class TestSearchService(ApiV2TestCase):
         # Should find Alice Johnson and Alice Brown (both female)
         self.assertEqual(total, 2)
         for record in records:
-            self.assertIn("Alice", record.name)
+            self.assertIn("ALICE", record.name)
             self.assertEqual(record.gender_id, self.gender_female)
 
 

--- a/spp_registry/models/individual.py
+++ b/spp_registry/models/individual.py
@@ -47,23 +47,28 @@ class SPPIndividual(models.Model):
     # Membership fields
     individual_membership_ids = fields.One2many("spp.group.membership", "individual", "Membership to Groups")
 
+    # Fields that trigger name recomputation
+    _name_fields = {"family_name", "given_name", "addl_name"}
+
+    @api.model
+    def _format_individual_name(self, family_name, given_name, addl_name):
+        """Compute display name from individual name parts.
+
+        Format: "FAMILY_NAME, GIVEN_NAME ADDL_NAME" (uppercase).
+        Used by onchange (UI), create, and write to ensure consistent naming.
+        """
+        name_vals = [
+            f"{family_name}," if family_name and (given_name or addl_name) else f"{family_name}" if family_name else "",
+            given_name,
+            addl_name,
+        ]
+        return " ".join(filter(None, name_vals)).upper()
+
     @api.onchange("is_group", "family_name", "given_name", "addl_name")
     def name_change(self):
-        vals = {}
         if not self.is_group:
-            name_vals = [
-                f"{self.family_name},"
-                if self.family_name and (self.given_name or self.addl_name)
-                else f"{self.family_name}"
-                if self.family_name
-                else "",
-                self.given_name,
-                self.addl_name,
-            ]
-
-            name = " ".join(filter(None, name_vals))
-            vals.update({"name": name.upper()})
-            self.update(vals)
+            name = self._format_individual_name(self.family_name, self.given_name, self.addl_name)
+            self.update({"name": name})
 
     @api.depends("birthdate")
     def _compute_calc_age(self):
@@ -129,8 +134,23 @@ class SPPIndividual(models.Model):
                     self.env.add_to_compute(field, groups)
 
     def write(self, vals):
-        """Override to invalidate group metrics when demographics change."""
+        """Override to recompute name and invalidate group metrics."""
+        # Recompute name if any name field changed (only for non-group individuals)
+        name_updates = {}
+        if self._name_fields & vals.keys() and not self.env.context.get("skip_name_format"):
+            for rec in self.filtered(lambda r: not r.is_group):
+                name_updates[rec.id] = self._format_individual_name(
+                    vals.get("family_name", rec.family_name),
+                    vals.get("given_name", rec.given_name),
+                    vals.get("addl_name", rec.addl_name),
+                )
+
         res = super().write(vals)
+
+        # Apply computed names after super to avoid interfering with the main write
+        if name_updates:
+            for rec_id, name in name_updates.items():
+                super(SPPIndividual, self.browse(rec_id).with_context(skip_name_format=True)).write({"name": name})
         self._recompute_parent_groups(self)
 
         # Fields that affect group-level metrics
@@ -177,6 +197,14 @@ class SPPIndividual(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
+        # Compute name from parts before create (injects into vals, no extra write)
+        for vals in vals_list:
+            if not vals.get("is_group") and self._name_fields & vals.keys():
+                vals["name"] = self._format_individual_name(
+                    vals.get("family_name", ""),
+                    vals.get("given_name", ""),
+                    vals.get("addl_name", ""),
+                )
         res = super().create(vals_list)
         self._recompute_parent_groups(res)
         return res


### PR DESCRIPTION
## Why is this change needed?

When creating or updating individual registrants programmatically (e.g., via API, demo generator, or import), the `name` field was not automatically formatted from name parts (`family_name`, `given_name`, `addl_name`). The `name_change` onchange only fires in the UI, so programmatic operations resulted in registrants with unformatted or missing display names.

## How was the change implemented?

- Extracted name formatting logic into a reusable `_format_individual_name()` class method
- Override `create()` to inject formatted name into vals before record creation (no extra write needed)
- Override `write()` to recompute name when any name field changes
- `name_change` onchange now delegates to the same helper for consistency
- Added `skip_name_format` context flag to prevent recursion during the name write-back

## New unit tests

N/A — existing tests cover the onchange path; the create/write paths are exercised by the demo generator and API tests.

## How to test manually

1. Via XML-RPC or shell, create an individual with `family_name` and `given_name` but no `name`
2. The `name` field should be auto-set to "FAMILY_NAME, GIVEN_NAME" (uppercase)
3. Update `given_name` via write — `name` should update accordingly

## Related links