### PR TITLE
fix(spp_user_roles): remove _default_role_lines that copies roles from arbitrary users

### DIFF
--- a/spp_area/models/user.py
+++ b/spp_area/models/user.py
@@ -25,16 +25,3 @@ class SPPUserCustom(models.Model):
                         center_area_ids.append(Command.link(area.id))
                 if center_area_ids:
                     user.update({"center_area_ids": center_area_ids})
-
-    @api.model
-    def _default_role_lines(self):
-        default_values = super()._default_role_lines()
-
-        default_user = self.env.ref("base.default_user", raise_if_not_found=False)
-        if default_user:
-            for default_value in default_values:
-                for role_line in default_user.with_context(active_test=False).role_line_ids:
-                    if role_line.role_id.id == default_value["role_id"]:
-                        default_value["local_area_ids"] = [Command.set(role_line.local_area_ids.ids)]
-                        break
-        return default_values

--- a/spp_user_roles/models/user.py
+++ b/spp_user_roles/models/user.py
@@ -21,33 +21,6 @@ class ResUsersCustomSPP(models.Model):
         for user in self:
             user.role_ids_stored = user.role_line_ids.filtered(lambda r: r.is_enabled).mapped("role_id")
 
-    @api.model
-    def _default_role_lines(self):
-        """Build default role lines from a template user when available.
-
-        ``base.default_user`` disappeared in Odoo 19.0, so we gracefully fall
-        back to the first user that already has role lines defined. This keeps
-        the feature working while remaining backward compatible when the XMLID
-        is present.
-        """
-
-        default_user = self.env.ref("base.default_user", raise_if_not_found=False)
-        if not default_user:
-            default_user = self.env["res.users"].search([("role_line_ids", "!=", False)], limit=1)
-
-        default_values = []
-        if default_user:
-            for role_line in default_user.with_context(active_test=False).role_line_ids:
-                default_values.append(
-                    {
-                        "role_id": role_line.role_id.id,
-                        "date_from": role_line.date_from,
-                        "date_to": role_line.date_to,
-                        "is_enabled": role_line.is_enabled,
-                    }
-                )
-        return default_values
-
     def set_groups_from_roles(self, force=False):
         """Override the original method to exclude some groups in removing."""
         DO_NOT_REMOVE_GROUPS = [

--- a/spp_user_roles/tests/test_user.py
+++ b/spp_user_roles/tests/test_user.py
@@ -27,8 +27,8 @@ class TestUserRole(TransactionCase):
                 "name": "Test User",
                 "login": "test_user",
                 "role_line_ids": [
-                    (0, 0, {"role_id": cls.role_user.id}),
-                    (0, 0, {"role_id": cls.role_no_one.id}),
+                    Command.create({"role_id": cls.role_user.id}),
+                    Command.create({"role_id": cls.role_no_one.id}),
                 ],
             }
         )
@@ -44,19 +44,26 @@ class TestUserRole(TransactionCase):
         self.assertIn(self.env.ref("base.group_user").id, self.user.group_ids.ids)
         self.assertIn(self.env.ref("base.group_no_one").id, self.user.group_ids.ids)
 
-    def test_default_role_lines(self):
+    def test_default_role_lines_uses_is_default(self):
+        """Default role lines come from roles with is_default=True, not from arbitrary users."""
+        # Neither role is marked as default, so no defaults should be returned
         default_values = self.env["res.users"]._default_role_lines()
+        default_role_ids = [v["role_id"] for v in default_values]
+        self.assertNotIn(self.role_user.id, default_role_ids)
+        self.assertNotIn(self.role_no_one.id, default_role_ids)
 
-        self.assertTrue(bool(default_values))
-        self.assertEqual(len(default_values), 2)
-        self.assertEqual(default_values[0]["role_id"], self.role_user.id)
-        self.assertEqual(default_values[1]["role_id"], self.role_no_one.id)
-        self.assertTrue(default_values[0]["is_enabled"])
-        self.assertTrue(default_values[1]["is_enabled"])
-        self.assertFalse(default_values[0]["date_from"])
-        self.assertFalse(default_values[1]["date_from"])
-        self.assertFalse(default_values[0]["date_to"])
-        self.assertFalse(default_values[1]["date_to"])
+        # Mark one role as default
+        self.role_user.is_default = True
+        default_values = self.env["res.users"]._default_role_lines()
+        default_role_ids = [v["role_id"] for v in default_values]
+        self.assertIn(self.role_user.id, default_role_ids)
+        self.assertNotIn(self.role_no_one.id, default_role_ids)
+
+        # New user without explicit role_line_ids gets the default role
+        new_user = self.env["res.users"].create({"name": "New User", "login": "new_test_user"})
+        new_user_role_ids = new_user.role_line_ids.mapped("role_id").ids
+        self.assertIn(self.role_user.id, new_user_role_ids)
+        self.assertNotIn(self.role_no_one.id, new_user_role_ids)
 
     @unittest.skip("center_area_ids computation not available in Odoo 19 build")
     def test_compute_center_area_ids(self):


### PR DESCRIPTION
## Summary

Closes #156

- Remove the buggy `_default_role_lines()` override from `spp_user_roles` that copied roles from an arbitrary user to all newly created users (the `base.default_user` XMLID was removed in Odoo 19, so the fallback always fired)
- Remove the dead `_default_role_lines()` override from `spp_area` that enriched defaults with area data from `base.default_user` (was a no-op since Odoo 19)
- The upstream `base_user_role` OCA module already provides the correct mechanism via an `is_default` boolean on `res.users.role` — admins can mark specific roles to be auto-assigned to new users
- Rewrite test to verify the `is_default` mechanism instead of the old buggy behavior
- Fix pre-existing tuple syntax `(0, 0, {...})` → `Command.create()` per Odoo 19 conventions

## Test plan

- [x] `spp_user_roles` — 3/3 pass
- [x] `spp_area` — 50/50 pass
- [x] `spp_approval` — 128/128 pass (creates users, depends indirectly on role system)
- [x] `spp_programs` — 579/579 pass (depends on `spp_user_roles`)
- [x] Lint clean (`ruff`, `ruff-format`)
- [x] Expert review: code reviewer, UX expert, module verification — no critical issues