### PR TITLE
Bug: CEL Expressions tab crashes and hidden menus reset on upgrade

### DIFF
--- a/spp_approval/README.rst
+++ b/spp_approval/README.rst
@@ -157,6 +157,16 @@ Dependencies
 Changelog
 =========
 
+19.0.2.0.1
+~~~~~~~~~~
+
+- Fix CEL Expressions tab crash: the ace editor fields used the invalid
+  CodeEditor mode ``text``; changed to ``javascript`` (Odoo 19 only
+  accepts ``javascript``/``xml``/``qweb``/``scss``/``python``).
+  ``javascript`` is used because the CEL dialect uses
+  ``&&``/``||``/``!``, ``true``/``false``/ ``null`` and ``? :``
+  ternaries, which it highlights correctly.
+
 19.0.2.0.0
 ~~~~~~~~~~
 

--- a/spp_approval/__manifest__.py
+++ b/spp_approval/__manifest__.py
@@ -2,7 +2,7 @@
 {
     "name": "OpenSPP Approval",
     "summary": "Standardized approval workflows with multi-tier sequencing and CEL rules",
-    "version": "19.0.2.0.0",
+    "version": "19.0.2.0.1",
     "license": "LGPL-3",
     "development_status": "Production/Stable",
     "author": "OpenSPP.org, OpenSPP Community",

--- a/spp_approval/readme/HISTORY.md
+++ b/spp_approval/readme/HISTORY.md
@@ -1,8 +1,10 @@
 ### 19.0.2.0.1
 
 - Fix CEL Expressions tab crash: the ace editor fields used the invalid
-  CodeEditor mode ``text``; changed to ``python`` (Odoo 19 only accepts
-  ``javascript``/``xml``/``qweb``/``scss``/``python``).
+  CodeEditor mode ``text``; changed to ``javascript`` (Odoo 19 only accepts
+  ``javascript``/``xml``/``qweb``/``scss``/``python``). ``javascript`` is
+  used because the CEL dialect uses ``&&``/``||``/``!``, ``true``/``false``/
+  ``null`` and ``? :`` ternaries, which it highlights correctly.
 
 ### 19.0.2.0.0
 

--- a/spp_approval/readme/HISTORY.md
+++ b/spp_approval/readme/HISTORY.md
@@ -1,3 +1,9 @@
+### 19.0.2.0.1
+
+- Fix CEL Expressions tab crash: the ace editor fields used the invalid
+  CodeEditor mode ``text``; changed to ``python`` (Odoo 19 only accepts
+  ``javascript``/``xml``/``qweb``/``scss``/``python``).
+
 ### 19.0.2.0.0
 
 - Initial migration to OpenSPP2

--- a/spp_approval/static/description/index.html
+++ b/spp_approval/static/description/index.html
@@ -536,6 +536,17 @@ matching logic</li>
 </div>
 </div>
 <div class="section" id="section-1">
+<h1>19.0.2.0.1</h1>
+<ul class="simple">
+<li>Fix CEL Expressions tab crash: the ace editor fields used the invalid
+CodeEditor mode <tt class="docutils literal">text</tt>; changed to <tt class="docutils literal">javascript</tt> (Odoo 19 only
+accepts <tt class="docutils literal">javascript</tt>/<tt class="docutils literal">xml</tt>/<tt class="docutils literal">qweb</tt>/<tt class="docutils literal">scss</tt>/<tt class="docutils literal">python</tt>).
+<tt class="docutils literal">javascript</tt> is used because the CEL dialect uses
+<tt class="docutils literal">&amp;&amp;</tt>/<tt class="docutils literal">||</tt>/<tt class="docutils literal">!</tt>, <tt class="docutils literal">true</tt>/<tt class="docutils literal">false</tt>/ <tt class="docutils literal">null</tt> and <tt class="docutils literal">? :</tt>
+ternaries, which it highlights correctly.</li>
+</ul>
+</div>
+<div class="section" id="section-2">
 <h1>19.0.2.0.0</h1>
 <ul class="simple">
 <li>Initial migration to OpenSPP2</li>

--- a/spp_approval/tests/__init__.py
+++ b/spp_approval/tests/__init__.py
@@ -4,3 +4,4 @@ from . import test_approval_mixin
 from . import test_approval_review
 from . import test_approval_security
 from . import test_cel_evaluator_security
+from . import test_cel_view

--- a/spp_approval/tests/test_cel_view.py
+++ b/spp_approval/tests/test_cel_view.py
@@ -1,0 +1,56 @@
+# Part of OpenSPP. See LICENSE file for full copyright and licensing details.
+"""Guardrail for the CEL Expressions view's ace editor configuration.
+
+Odoo 19's ``CodeEditor`` OWL component validates its ``mode`` prop against
+a fixed allow-list:
+
+    addons/web/static/src/core/code_editor/code_editor.js
+        static MODES = ["javascript", "xml", "qweb", "scss", "python"];
+
+A field declaring ``widget="ace" options="{'mode': '<invalid>'}"`` crashes
+the client the moment the editor mounts (the field is only rendered when
+its ``use_cel_*`` toggle is enabled). The original view used
+``'mode': 'text'`` — not in MODES — which is exactly that crash. This test
+parses the view arch and fails if any ace field declares a mode the
+component would reject, so the regression can't silently come back.
+"""
+
+import ast
+
+from lxml import etree
+
+from odoo.tests import TransactionCase, tagged
+
+# Mirror of CodeEditor.MODES (see module docstring). Kept here as a literal
+# because the allow-list lives in JS and isn't importable from Python.
+VALID_ACE_MODES = {"javascript", "xml", "qweb", "scss", "python"}
+
+
+@tagged("post_install", "-at_install")
+class TestCelViewAceMode(TransactionCase):
+    """The CEL Expressions form must only use ace modes CodeEditor accepts."""
+
+    def test_cel_ace_fields_use_valid_mode(self):
+        view = self.env.ref("spp_approval.view_spp_approval_definition_form_cel")
+        arch = etree.fromstring(view.arch)
+
+        ace_fields = arch.xpath("//field[@widget='ace']")
+        self.assertTrue(
+            ace_fields,
+            "Expected at least one widget='ace' field in the CEL view — did the view change?",
+        )
+
+        for field in ace_fields:
+            options = field.get("options")
+            self.assertTrue(
+                options,
+                f"ace field {field.get('name')!r} must declare options with a mode",
+            )
+            mode = ast.literal_eval(options).get("mode")
+            self.assertIn(
+                mode,
+                VALID_ACE_MODES,
+                f"ace field {field.get('name')!r} uses mode {mode!r}, which "
+                f"CodeEditor rejects (valid: {sorted(VALID_ACE_MODES)}). "
+                "This crashes the client when the field is rendered.",
+            )

--- a/spp_approval/views/approval_definition_views_cel.xml
+++ b/spp_approval/views/approval_definition_views_cel.xml
@@ -15,7 +15,7 @@
                             <field
                                 name="cel_condition"
                                 widget="ace"
-                                options="{'mode': 'text'}"
+                                options="{'mode': 'python'}"
                                 invisible="not use_cel_condition"
                                 placeholder="record.amount > 10000"
                             />
@@ -42,7 +42,7 @@
                             <field
                                 name="cel_reviewer_expression"
                                 widget="ace"
-                                options="{'mode': 'text'}"
+                                options="{'mode': 'python'}"
                                 invisible="not use_cel_reviewer"
                                 placeholder="record.manager_id.user_id.id"
                             />

--- a/spp_approval/views/approval_definition_views_cel.xml
+++ b/spp_approval/views/approval_definition_views_cel.xml
@@ -15,7 +15,7 @@
                             <field
                                 name="cel_condition"
                                 widget="ace"
-                                options="{'mode': 'python'}"
+                                options="{'mode': 'javascript'}"
                                 invisible="not use_cel_condition"
                                 placeholder="record.amount > 10000"
                             />
@@ -42,7 +42,7 @@
                             <field
                                 name="cel_reviewer_expression"
                                 widget="ace"
-                                options="{'mode': 'python'}"
+                                options="{'mode': 'javascript'}"
                                 invisible="not use_cel_reviewer"
                                 placeholder="record.manager_id.user_id.id"
                             />

--- a/spp_hide_menus_base/README.rst
+++ b/spp_hide_menus_base/README.rst
@@ -103,6 +103,15 @@ Dependencies
 Changelog
 =========
 
+19.0.2.0.1
+~~~~~~~~~~
+
+- Keep hidden menus hidden after a module upgrade resets their
+  ``group_ids`` via XML. Re-applying now runs from ``_register_hook`` so
+  it covers every upgrade path (immediate, ``base.module.upgrade``
+  wizard, and CLI ``-u``), not just the immediate path handled by
+  ``next()``.
+
 19.0.2.0.0
 ~~~~~~~~~~
 

--- a/spp_hide_menus_base/__manifest__.py
+++ b/spp_hide_menus_base/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "OpenSPP Hide Non-OpenSPP Menus: Base",
     "category": "OpenSPP",
-    "version": "19.0.2.0.0",
+    "version": "19.0.2.0.1",
     "summary": "Administrators can manage the visibility of OpenSPP navigation menus, streamlining the user interface for specific user groups. The module modifies ir.ui.menu records to control menu visibility, providing a foundation for other modules to selectively hide non-essential navigation items.",
     "sequence": 1,
     "author": "OpenSPP.org",

--- a/spp_hide_menus_base/models/hide_menu.py
+++ b/spp_hide_menus_base/models/hide_menu.py
@@ -40,6 +40,17 @@ class SppHideMenu(models.Model):
                 )
                 rec.state = "hide"
 
+    def _reapply_hide(self):
+        """Re-apply hiding when module upgrade reset group_ids via XML."""
+        try:
+            hide_group = self.env.ref("spp_hide_menus_base.group_hide_menus_user")
+        except ValueError:
+            hide_group = self.env.ref("spp_hide_menus_base.group_menu_visibility")
+        for rec in self:
+            if rec.menu_id and hide_group not in rec.menu_id.group_ids:
+                rec.default_group_ids = rec.menu_id.group_ids
+                rec.menu_id.write({"group_ids": [Command.set([hide_group.id])]})
+
     def show_menu(self):
         for rec in self:
             if rec.state == "hide" and rec.menu_id:

--- a/spp_hide_menus_base/models/ir_module_module.py
+++ b/spp_hide_menus_base/models/ir_module_module.py
@@ -89,3 +89,15 @@ class IrModuleModule(models.Model):
         self.hide_menus()
         # Then call the original Odoo logic
         return super().next()
+
+    def _register_hook(self):
+        # next() only runs on the immediate install/upgrade path
+        # (button_immediate_*). Upgrades through the base.module.upgrade
+        # wizard or the CLI (-u) reload menu XML — resetting group_ids via
+        # noupdate="0" — but never call next(), leaving hidden menus visible.
+        # _register_hook runs at the end of every registry load (startup,
+        # install, upgrade — all paths), so re-applying hiding here keeps
+        # menus hidden regardless of how the upgrade was triggered.
+        res = super()._register_hook()
+        self.hide_menus()
+        return res

--- a/spp_hide_menus_base/models/ir_module_module.py
+++ b/spp_hide_menus_base/models/ir_module_module.py
@@ -79,6 +79,10 @@ class IrModuleModule(models.Model):
                         hidden_menu.hide_menu()
                     elif hidden_menus.state == "show":
                         hidden_menus.hide_menu()
+                    elif hidden_menus.state == "hide":
+                        # Module upgrade may have reset group_ids via XML
+                        # (noupdate="0"). Re-apply hiding if stale.
+                        hidden_menus._reapply_hide()
 
     def next(self):
         # Call your menu hiding logic first

--- a/spp_hide_menus_base/readme/HISTORY.md
+++ b/spp_hide_menus_base/readme/HISTORY.md
@@ -1,3 +1,10 @@
+### 19.0.2.0.1
+
+- Keep hidden menus hidden after a module upgrade resets their
+  ``group_ids`` via XML. Re-applying now runs from ``_register_hook`` so
+  it covers every upgrade path (immediate, ``base.module.upgrade`` wizard,
+  and CLI ``-u``), not just the immediate path handled by ``next()``.
+
 ### 19.0.2.0.0
 
 - Initial migration to OpenSPP2

--- a/spp_hide_menus_base/static/description/index.html
+++ b/spp_hide_menus_base/static/description/index.html
@@ -474,6 +474,16 @@ custom menus to auto-hide list</li>
 </div>
 </div>
 <div class="section" id="section-1">
+<h1>19.0.2.0.1</h1>
+<ul class="simple">
+<li>Keep hidden menus hidden after a module upgrade resets their
+<tt class="docutils literal">group_ids</tt> via XML. Re-applying now runs from <tt class="docutils literal">_register_hook</tt> so
+it covers every upgrade path (immediate, <tt class="docutils literal">base.module.upgrade</tt>
+wizard, and CLI <tt class="docutils literal"><span class="pre">-u</span></tt>), not just the immediate path handled by
+<tt class="docutils literal">next()</tt>.</li>
+</ul>
+</div>
+<div class="section" id="section-2">
 <h1>19.0.2.0.0</h1>
 <ul class="simple">
 <li>Initial migration to OpenSPP2</li>

--- a/spp_hide_menus_base/tests/test_hide_menu.py
+++ b/spp_hide_menus_base/tests/test_hide_menu.py
@@ -245,6 +245,50 @@ class TestSppHideMenu(TransactionCase):
             "hide_menus() should re-hide a menu whose group_ids were reset on upgrade",
         )
 
+    def test_register_hook_rehides_after_reset(self):
+        """``_register_hook()`` re-applies hiding on every registry load.
+
+        ``ir.module.module.next()`` only runs on the immediate
+        install/upgrade path (button_immediate_*). Upgrades performed
+        through the ``base.module.upgrade`` wizard or the CLI (``-u``)
+        reload module XML — resetting ``group_ids`` — but never call
+        ``next()``. ``_register_hook`` runs at the end of *every* registry
+        load, so it must re-hide regardless of the upgrade path. We can't
+        run a real upgrade in a test, so we reset the groups by hand and
+        call the hook the way the loader does.
+        """
+        IrModuleModule = self.env["ir.module.module"]
+        HideMenu = self.env["spp.hide.menu"]
+        hide_group = self.env.ref("spp_hide_menus_base.group_hide_menus_user")
+
+        target = None
+        for module_name, info in IrModuleModule.MENU_APP.items():
+            menu = self.env.ref(info["menu_xml_id"], raise_if_not_found=False)
+            module = IrModuleModule.search([("name", "=", module_name)], limit=1)
+            if menu and module:
+                target = menu
+                break
+        if target is None:
+            self.skipTest("No MENU_APP entries are resolvable in this test DB")
+
+        HideMenu.search([]).unlink()
+        IrModuleModule.hide_menus()
+        self.assertIn(hide_group, target.group_ids, "precondition: menu should be hidden")
+
+        # Simulate the wizard/CLI upgrade path: group_ids reset, next() not called.
+        reset_groups = self.env.ref("base.group_user")
+        target.write({"group_ids": [Command.set([reset_groups.id])]})
+        self.assertNotIn(hide_group, target.group_ids)
+
+        IrModuleModule._register_hook()
+
+        self.assertIn(
+            hide_group,
+            target.group_ids,
+            "_register_hook() should re-hide menus on every registry load, "
+            "covering upgrade paths that never call next()",
+        )
+
     def test_hide_menus_skips_unknown_modules(self):
         """An ir.module.module record whose name isn't in MENU_APP must be
         ignored by hide_menus() — no spp.hide.menu record is created for it.

--- a/spp_hide_menus_base/tests/test_hide_menu.py
+++ b/spp_hide_menus_base/tests/test_hide_menu.py
@@ -9,6 +9,7 @@ the model's state transition without depending on a real "Apps install"
 flow.
 """
 
+from odoo import Command
 from odoo.tests import TransactionCase, tagged
 
 
@@ -148,6 +149,101 @@ class TestSppHideMenu(TransactionCase):
         self.assertEqual(set(after_first.ids), set(after_second.ids))
         for record in after_second:
             self.assertEqual(record.state, "hide")
+
+    def test_reapply_hide_after_simulated_upgrade_reset(self):
+        """_reapply_hide() re-applies the hide group after a module upgrade
+        reset the menu's group_ids via XML (noupdate="0").
+
+        A real module upgrade can't run inside a test transaction, so we
+        simulate its effect: hide the menu, then overwrite group_ids the way
+        an XML data reload would, dropping the hide group. _reapply_hide()
+        must detect the stale state and restore the hidden configuration.
+        """
+        hide_group = self.env.ref("spp_hide_menus_base.group_hide_menus_user")
+        record = self.env["spp.hide.menu"].create({"menu_id": self.menu.id, "xml_id": "test.hide_menu_target"})
+        record.hide_menu()
+        self.assertIn(hide_group, self.menu.group_ids, "precondition: menu should be hidden")
+
+        # Simulate the upgrade resetting group_ids to the module's XML default
+        # (some real group, without the hide group).
+        reset_groups = self.env.ref("base.group_user")
+        self.menu.write({"group_ids": [Command.set([reset_groups.id])]})
+        self.assertNotIn(hide_group, self.menu.group_ids, "precondition: reset must drop the hide group")
+
+        record._reapply_hide()
+
+        self.assertIn(
+            hide_group,
+            self.menu.group_ids,
+            "_reapply_hide() should restore the hide group after an upgrade reset",
+        )
+        # The reset groups become the new restore snapshot so show_menu()
+        # returns the menu to its real post-upgrade default.
+        self.assertEqual(record.default_group_ids, reset_groups)
+
+    def test_reapply_hide_noop_when_already_hidden(self):
+        """_reapply_hide() is a no-op when the hide group is still present.
+
+        If no upgrade reset happened, the guard (hide_group not in
+        group_ids) is False, so neither group_ids nor the saved snapshot
+        should change.
+        """
+        hide_group = self.env.ref("spp_hide_menus_base.group_hide_menus_user")
+        record = self.env["spp.hide.menu"].create({"menu_id": self.menu.id, "xml_id": "test.hide_menu_target"})
+        record.hide_menu()
+        groups_before = self.menu.group_ids
+        snapshot_before = record.default_group_ids
+        self.assertIn(hide_group, groups_before, "precondition: menu should be hidden")
+
+        record._reapply_hide()
+
+        self.assertEqual(self.menu.group_ids, groups_before)
+        self.assertEqual(record.default_group_ids, snapshot_before)
+
+    def test_hide_menus_reapplies_after_reset(self):
+        """``hide_menus()`` re-hides an already-hidden menu whose group_ids
+        were reset, exercising the ``elif ... state == "hide"`` branch.
+
+        This is the end-to-end shape of the upgrade bug: a menu is hidden,
+        a later module upgrade resets its group_ids, and the next
+        install/upgrade pass through hide_menus() must put the hide group
+        back.
+        """
+        IrModuleModule = self.env["ir.module.module"]
+        HideMenu = self.env["spp.hide.menu"]
+        hide_group = self.env.ref("spp_hide_menus_base.group_hide_menus_user")
+
+        # Find one resolvable MENU_APP entry to drive the real entry point.
+        target = None
+        for module_name, info in IrModuleModule.MENU_APP.items():
+            menu = self.env.ref(info["menu_xml_id"], raise_if_not_found=False)
+            module = IrModuleModule.search([("name", "=", module_name)], limit=1)
+            if menu and module:
+                target = menu
+                break
+        if target is None:
+            self.skipTest("No MENU_APP entries are resolvable in this test DB")
+
+        # First pass creates the record and hides the menu.
+        HideMenu.search([]).unlink()
+        IrModuleModule.hide_menus()
+        record = HideMenu.search([("menu_id", "=", target.id)], limit=1)
+        self.assertTrue(record, "hide_menus() should have created a hide record")
+        self.assertEqual(record.state, "hide")
+        self.assertIn(hide_group, target.group_ids)
+
+        # Simulate an upgrade resetting the menu's group_ids via XML.
+        reset_groups = self.env.ref("base.group_user")
+        target.write({"group_ids": [Command.set([reset_groups.id])]})
+        self.assertNotIn(hide_group, target.group_ids)
+
+        # Second pass must re-hide via the state == "hide" branch.
+        IrModuleModule.hide_menus()
+        self.assertIn(
+            hide_group,
+            target.group_ids,
+            "hide_menus() should re-hide a menu whose group_ids were reset on upgrade",
+        )
 
     def test_hide_menus_skips_unknown_modules(self):
         """An ir.module.module record whose name isn't in MENU_APP must be


### PR DESCRIPTION
### 1. CodeEditor crash on Approval Definition CEL Expressions tab

**Steps to reproduce:**
1. Go to Approvals > Configuration > Approval Definitions
2. Open any approval definition
3. Click the "CEL Expressions" tab
4. **Tick "Use CEL Condition"** (or **"Use CEL for Reviewers"**) — this step is required. The ace editor field is `invisible="not use_cel_condition"` (and `use_cel_*` defaults to `False`), so the `CodeEditor` component only mounts once the toggle is enabled. Opening the tab alone does **not** crash, which is why the issue could not be reproduced from the steps as originally written.

**Expected:** The CEL expression editor renders normally
**Actual:** JS crash: `Invalid props for component 'CodeEditor': 'mode' is not valid`

**Root cause:** `spp_approval/views/approval_definition_views_cel.xml` uses `options="{'mode': 'text'}"` on `widget="ace"` fields. Odoo 19's `CodeEditor` component only accepts modes: `javascript`, `xml`, `qweb`, `scss`, `python`. `text` is not a valid mode.

### 2. Hidden menus become visible after module upgrade

**Steps to reproduce:**
1. Hide a menu via spp_hide_menus_base (e.g. Discuss, Contacts)
2. Upgrade any module that defines that menu
3. The menu reappears despite being marked as hidden

**Root cause:** Module upgrade re-applies menu XML data (`noupdate="0"`), resetting `group_ids`. The `hide_menus()` hook in `ir.module.module.next()` skips menus with `state="hide"`, so the reset is never corrected.
