### PR TITLE
fix id dropdown incorrectly showing wrong values in program create wizard

### DIFF
--- a/spp_programs/__manifest__.py
+++ b/spp_programs/__manifest__.py
@@ -4,7 +4,7 @@
     "name": "OpenSPP Programs",
     "summary": "Manage programs, cycles, beneficiary enrollment, entitlements (cash and in-kind), payments, and fund tracking for social protection.",
     "category": "OpenSPP/Core",
-    "version": "19.0.2.0.10",
+    "version": "19.0.2.0.11",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/OpenSPP2",

--- a/spp_programs/models/managers/entitlement_manager.py
+++ b/spp_programs/models/managers/entitlement_manager.py
@@ -5,4 +5,8 @@ from odoo import fields, models
 class BaseEntitlementManager(models.AbstractModel):
     _inherit = "spp.base.program.entitlement.manager"
 
-    id_type_id = fields.Many2one("spp.id.type", "ID Type to store in entitlements")
+    id_type_id = fields.Many2one(
+        "spp.vocabulary.code",
+        "ID Type for Entitlement Collection",
+        domain="[('vocabulary_id.namespace_uri', '=', 'urn:openspp:vocab:id-type')]",
+    )

--- a/spp_programs/wizard/create_program_wizard.py
+++ b/spp_programs/wizard/create_program_wizard.py
@@ -271,7 +271,11 @@ class SPPCreateNewProgramWiz(models.TransientModel):
         default="default_eligibility",
     )
 
-    id_type_id = fields.Many2one("spp.id.type", "ID Type to store in entitlements")
+    id_type_id = fields.Many2one(
+        "spp.vocabulary.code",
+        "ID Type for Entitlement Collection",
+        domain="[('vocabulary_id.namespace_uri', '=', 'urn:openspp:vocab:id-type')]",
+    )
     view_id = fields.Many2one(
         "ir.ui.view",
         "Program UI Template",


### PR DESCRIPTION
fix id dropdown incorrectly showing wrong values in program create wizard

## **Why is this change needed?**

The id_type_id field on both the entitlement manager base and the program creation wizard incorrectly referenced spp.id.type instead of spp.vocabulary.code. Since spp.registry.id records store their id_type_id as spp.vocabulary.code, the ID lookup filter at entitlement preparation time always compared IDs across two different tables, causing it to return empty results — meaning id_number was never stamped on the entitlement. With spp_dci installed, the dropdown in the wizard also showed civil registry codes (BRN, DRN, MRN, UIN) instead of identity document types (National ID, Passport, etc.).
 
## **How was the change implemented?**

- Changed id_type_id in BaseEntitlementManager and SPPCreateNewProgramWiz from spp.id.type to spp.vocabulary.code, with a domain filter scoped to the urn:openspp:vocab:id-type vocabulary.
- Added migrations/19.0.2.0.11/pre_migrate.py to remap existing id_type_id values from spp.id.type IDs to matching spp.vocabulary.code IDs by name. Records with no match are set to NULL.
- Bumped module version to 19.0.2.0.11 to trigger the migration.

No changes were needed to the lambda filters in the cash, in-kind, or default entitlement managers — once both sides of the comparison use spp.vocabulary.code, they work correctly.

## **New unit tests**

## **Unit tests executed by the author**

## **How to test manually**

1. Upgrade spp_programs.
2. Open Programs > Create Program → Step 1 → Redemption ID dropdown.
3. Should list vocabulary-based ID types (e.g. National ID, Passport) — not BRN/DRN/MRN/UIN.
4. Create a cash program with Redemption ID = National ID.
5. Enroll a beneficiary who has a National ID registry record (spp.registry.id).
6. Prepare entitlements — the entitlement record's id_number field should be populated with the beneficiary's National ID value.

## **Related links**
ticket [#945](https://projects.acn.fr/projects/acn-eng/work_packages/945/activity)
