### PR TITLE
fix(spp_dms): fix DMS app visibility and hide deprecated group from UI

### DIFF
--- a/spp_dms/security/security.xml
+++ b/spp_dms/security/security.xml
@@ -64,7 +64,6 @@
 
     <record id="group_dms_user" model="res.groups">
         <field name="name">User (Deprecated)</field>
-        <field name="privilege_id" ref="privilege_dms" />
         <field
             name="comment"
         >DEPRECATED: Legacy group maintained for backwards compatibility. Use group_dms_officer instead.</field>

--- a/spp_dms/views/main_view.xml
+++ b/spp_dms/views/main_view.xml
@@ -3,7 +3,7 @@
         id="main_menu_spp_dms"
         name="DMS"
         web_icon="spp_dms,static/description/OpenSPP-Icons-DMS.png"
-        groups="spp_dms.group_dms_user"
+        groups="spp_dms.group_dms_viewer"
     />
     <menuitem
         id="menu_spp_dms_config"


### PR DESCRIPTION
The DMS app was not appearing on the home screen for users assigned Viewer, Officer, or Manager roles because the main menu was gated on
 (deprecated). The current role hierarchy only flows
downward (group_dms_user → group_dms_officer → group_dms_viewer), so none of the active roles implied the deprecated group, making the app invisible to all non-admin users.

Changes:
- main_view.xml: change menu group gate from `group_dms_user` to
  `group_dms_viewer` so any assigned DMS role grants access to the app
- security.xml: remove `privilege_id` from `group_dms_user` so it no
  longer appears in the privilege selector in Settings; the record is
  kept for backwards compatibility with existing data

## **Why is this change needed?**
A blocker to accessing DMS feature
## **How was the change implemented?**
Updating the main view xml to group_dms_viewer from the deprecated group_dms_user
## **New unit tests**

## **Unit tests executed by the author**

## **How to test manually**
1. Install spp_demo_v2 which auto installs spp_dms
2. Go to settings/Users&Companies/User Roles
3. Create a new Role DMS first then save. do not add a group yet. theres an issue i also fixed related to this.
4. On the new DMS role click add a line and type document.
5. Notice the Document management user (deprecated) should now be gone.
6. Assign at least Document viewer to the role
7. Assign DMS role to Demo_viewer user.
8. Login as Demo_viewer. should now be able to access DMS feature.


## **Related links**
https://projects.acn.fr/projects/acn-eng/work_packages/978/activity

