### PR TITLE
fix(spp_user_roles): prevent validation error when assigning groups to a new role

### DIFF
--- a/spp_user_roles/README.rst
+++ b/spp_user_roles/README.rst
@@ -129,6 +129,20 @@ Dependencies
 Changelog
 =========
 
+19.0.2.0.1
+~~~~~~~~~~
+
+- fix(role): allow assigning groups to a brand-new role in a single
+  save. Clicking **Add a line** in the role form's Groups tab used to
+  trigger inline creation of a blank ``res.groups`` row, which raised a
+  required-field validation error and aborted the save. The
+  ``implied_ids`` field's inner list now uses ``create="0"`` so the
+  button opens an "Add" picker against existing groups, and
+  ``res.users.role.create()`` extracts ``implied_ids`` before
+  ``super().create()`` and writes them to the role's ``group_id``
+  afterwards — mirroring the existing ``write()`` workaround in
+  ``base_user_role`` for the same ``_inherits`` cache-clearing bug.
+
 19.0.2.0.0
 ~~~~~~~~~~
 

--- a/spp_user_roles/__manifest__.py
+++ b/spp_user_roles/__manifest__.py
@@ -2,7 +2,7 @@
 {
     "name": "OpenSPP User Roles",
     "category": "OpenSPP",
-    "version": "19.0.2.0.0",
+    "version": "19.0.2.0.1",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/OpenSPP2",

--- a/spp_user_roles/models/role.py
+++ b/spp_user_roles/models/role.py
@@ -29,7 +29,7 @@ class ResUsersRoleCustomSPP(models.Model):
 
         new_records = super().create(vals_list)
 
-        for record, group_vals in zip(new_records, groups_vals_list):
+        for record, group_vals in zip(new_records, groups_vals_list, strict=True):
             if group_vals:
                 record.group_id.write(group_vals)
 

--- a/spp_user_roles/models/role.py
+++ b/spp_user_roles/models/role.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 _logger = logging.getLogger(__name__)
 
@@ -11,6 +11,29 @@ class ResUsersRoleCustomSPP(models.Model):
     _inherit = "res.users.role"
 
     role_type = fields.Selection([("local", "Local"), ("global", "Global")], default="global")
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        # Workaround: same Odoo cache-clearing bug as in base_user_role's write()
+        # override. When res.groups fields are set via _inherits on create(),
+        # implied_ids gets dropped. Extract group fields and write them to
+        # group_id directly after creation, mirroring the write() fix.
+        groups_vals_list = []
+        group_fields = set(self.env["res.groups"]._fields) - {"name"}
+        for vals in vals_list:
+            group_vals = {}
+            for field in group_fields:
+                if field in vals:
+                    group_vals[field] = vals.pop(field)
+            groups_vals_list.append(group_vals)
+
+        new_records = super().create(vals_list)
+
+        for record, group_vals in zip(new_records, groups_vals_list):
+            if group_vals:
+                record.group_id.write(group_vals)
+
+        return new_records
 
     def action_update_users(self):
         """

--- a/spp_user_roles/readme/HISTORY.md
+++ b/spp_user_roles/readme/HISTORY.md
@@ -1,3 +1,7 @@
+### 19.0.2.0.1
+
+- fix(role): allow assigning groups to a brand-new role in a single save. Clicking **Add a line** in the role form's Groups tab used to trigger inline creation of a blank `res.groups` row, which raised a required-field validation error and aborted the save. The `implied_ids` field's inner list now uses `create="0"` so the button opens an "Add" picker against existing groups, and `res.users.role.create()` extracts `implied_ids` before `super().create()` and writes them to the role's `group_id` afterwards — mirroring the existing `write()` workaround in `base_user_role` for the same `_inherits` cache-clearing bug.
+
 ### 19.0.2.0.0
 
 - Initial migration to OpenSPP2

--- a/spp_user_roles/static/description/index.html
+++ b/spp_user_roles/static/description/index.html
@@ -503,6 +503,21 @@ role synchronization</li>
 </div>
 </div>
 <div class="section" id="section-1">
+<h1>19.0.2.0.1</h1>
+<ul class="simple">
+<li>fix(role): allow assigning groups to a brand-new role in a single
+save. Clicking <strong>Add a line</strong> in the role form’s Groups tab used to
+trigger inline creation of a blank <tt class="docutils literal">res.groups</tt> row, which raised a
+required-field validation error and aborted the save. The
+<tt class="docutils literal">implied_ids</tt> field’s inner list now uses <tt class="docutils literal"><span class="pre">create=&quot;0&quot;</span></tt> so the
+button opens an “Add” picker against existing groups, and
+<tt class="docutils literal">res.users.role.create()</tt> extracts <tt class="docutils literal">implied_ids</tt> before
+<tt class="docutils literal"><span class="pre">super().create()</span></tt> and writes them to the role’s <tt class="docutils literal">group_id</tt>
+afterwards — mirroring the existing <tt class="docutils literal">write()</tt> workaround in
+<tt class="docutils literal">base_user_role</tt> for the same <tt class="docutils literal">_inherits</tt> cache-clearing bug.</li>
+</ul>
+</div>
+<div class="section" id="section-2">
 <h1>19.0.2.0.0</h1>
 <ul class="simple">
 <li>Initial migration to OpenSPP2</li>

--- a/spp_user_roles/views/role.xml
+++ b/spp_user_roles/views/role.xml
@@ -20,9 +20,16 @@
             <xpath expr="//field[@name='name']" position="after">
                 <field name="role_type" />
             </xpath>
-            <xpath expr="//field[@name='implied_ids']" position="attributes">
-                <attribute name="domain">[('role_id', '=', False)]</attribute>
-                <attribute name="widget">many2many</attribute>
+            <xpath expr="//field[@name='implied_ids']" position="replace">
+                <field
+                    name="implied_ids"
+                    nolabel="1"
+                    domain="[('role_id', '=', False)]"
+                >
+                    <list create="0">
+                        <field name="full_name" string="Group" />
+                    </list>
+                </field>
             </xpath>
             <xpath
                 expr="//field[@name='line_ids']/list/field[@name='user_id']"

--- a/spp_user_roles/views/role.xml
+++ b/spp_user_roles/views/role.xml
@@ -20,16 +20,19 @@
             <xpath expr="//field[@name='name']" position="after">
                 <field name="role_type" />
             </xpath>
-            <xpath expr="//field[@name='implied_ids']" position="replace">
-                <field
-                    name="implied_ids"
-                    nolabel="1"
-                    domain="[('role_id', '=', False)]"
-                >
-                    <list create="0">
-                        <field name="full_name" string="Group" />
-                    </list>
-                </field>
+            <!-- Restrict the Groups m2m to access groups not already
+                 owned by another role, and embed a list view that
+                 disables inline creation (avoids OP#979's "Add a line
+                 creates a new empty record" trap). Done via attributes
+                 + inside instead of replace so the OCA xml-view-
+                 dangerous-replace check stays happy. -->
+            <xpath expr="//field[@name='implied_ids']" position="attributes">
+                <attribute name="domain">[('role_id', '=', False)]</attribute>
+            </xpath>
+            <xpath expr="//field[@name='implied_ids']" position="inside">
+                <list create="0">
+                    <field name="full_name" string="Group" />
+                </list>
             </xpath>
             <xpath
                 expr="//field[@name='line_ids']/list/field[@name='user_id']"


### PR DESCRIPTION
Clicking "Add a line" in the Groups tab triggered inline creation of a
new res.groups record. Since res.groups.name is required and left blank,
Odoo threw a validation error and blocked the save entirely.

Two changes:
- role.xml: replace implied_ids field with an inner list using create="0"
  so "Add a line" opens a search dialog to select existing groups instead
  of creating an inline row
- role.py: override create() to extract implied_ids from vals and write it
  directly to group_id after creation, mirroring the existing write()
  workaround in base_user_role for the same Odoo _inherits cache-clearing bug


## **Why is this change needed?**
Users unable to create a role and assign a group in one save. previously users must create an empty role first then save, then add a group into it. which is inneficient

## **How was the change implemented?**

## How was the change implemented?

**1. `spp_user_roles/views/role.xml`**
Replaced the `implied_ids` field override with one that includes an explicit
inner `<list create="0">`. Setting `create="0"` on the inner list tells Odoo
to replace the "Add a line" inline row with an "Add" button that opens a
search/select dialog. This ensures only existing `res.groups` records can be
linked to a role — no blank inline records are ever created.

**2. `spp_user_roles/models/role.py`**
Added a `create()` override that mirrors the existing `write()` workaround
already present in `base_user_role`. The `res.users.role` model uses Odoo's
`_inherits` delegation to `res.groups`, which means fields like `implied_ids`
belong to the parent `res.groups` record. On create, passing `implied_ids`
through the `_inherits` mechanism triggers an Odoo cache-clearing bug
(documented in the upstream `write()` override) that causes the value to be
dropped. The fix extracts `implied_ids` from vals before calling
`super().create()`, lets the role and its associated `group_id` be created
first, then writes `implied_ids` directly to `group_id` — bypassing the bug.

## **New unit tests**

## **Unit tests executed by the author**

## **How to test manually**

## **Related links**
https://projects.acn.fr/projects/acn-eng/work_packages/979/activity

