### PR TITLE
fix(spp): restart jobworker alongside Odoo on ./spp restart

### DIFF
--- a/spp
+++ b/spp
@@ -284,6 +284,36 @@ def _find_running_odoo() -> tuple:
     return None, None
 
 
+def _is_jobworker_running(profile: str) -> bool:
+    """Return True when the jobworker container is up under this profile.
+
+    `./spp restart` only restarts the Odoo service by default, but module
+    code that runs inside delayed jobs (async batch scoring, eligibility
+    checks, anything routed through job_worker.delay) lives in the
+    jobworker process. Without restarting the worker too, the developer
+    sees stale Python after Apps -> Upgrade. See OP#986.
+    """
+    result = run(
+        docker_compose("ps", "--format", "json", profile=profile),
+        capture=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return False
+
+    for line in result.stdout.strip().split("\n"):
+        if not line:
+            continue
+        try:
+            container = json.loads(line)
+            if container.get("Service") == "jobworker" and container.get("State") == "running":
+                return True
+        except json.JSONDecodeError:
+            continue
+
+    return False
+
+
 # ============================================================================
 # Commands
 # ============================================================================
@@ -697,8 +727,12 @@ def cmd_restart(args):
         print("Error: No Odoo container running. Start with './spp start' first.")
         sys.exit(1)
 
-    print(f"Restarting {service}...")
-    run(docker_compose("restart", service, profile=profile))
+    services_to_restart = [service]
+    if _is_jobworker_running(profile):
+        services_to_restart.append("jobworker")
+
+    print(f"Restarting {', '.join(services_to_restart)}...")
+    run(docker_compose("restart", *services_to_restart, profile=profile))
     print("Done.")
 
     _show_url()


### PR DESCRIPTION
## Why is this change needed?

`./spp restart` only restarted the `openspp` / `openspp-dev` service. The `jobworker` container kept running with whatever Python code it had loaded at start-up, so any module change touching code paths the worker executes (async batch scoring, eligibility verification, anything routed through `job_worker.delay`) silently kept running stale code. Diagnosing this required noticing the jobworker container's `RunningFor` was days while `openspp-dev` was fresh.

## How was the change implemented?

- New helper `_is_jobworker_running(profile)` mirrors `_find_running_odoo` but scans for the `jobworker` service and returns `True` only when its container state is `running`.
- `cmd_restart` now builds a list `[odoo_service, "jobworker"]` (the worker is appended only if running) and passes it to `docker compose restart` in one call.
- Output now reads `Restarting openspp-dev, jobworker...` instead of `Restarting openspp-dev...`.
- When the jobworker isn't running (e.g. `start --no-jobworker`, non-dev profiles), the original behaviour is preserved.

## How to test manually

- `./spp start` (jobworker present), edit any module file, `./spp restart` → output lists both services, `docker compose ps` shows both freshly restarted.
- `./spp start --no-jobworker` (or whichever profile excludes it), `./spp restart` → only the Odoo service is restarted; no error.

## Related links

OP#986 — https://projects.acn.fr/work_packages/986