### PR TITLE
feat(spp_farmer_registry): filters + banners for incomplete groups (#939)

### DIFF
--- a/spp_farmer_registry/models/farm.py
+++ b/spp_farmer_registry/models/farm.py
@@ -149,6 +149,27 @@ class Farm(models.Model):
     )
 
     # ═══════════════════════════════════════════════════════════════════════
+    # MEMBERSHIP COMPLETENESS (#939)
+    # ═══════════════════════════════════════════════════════════════════════
+    # Farm-registry users need to surface farms that aren't usable yet because
+    # nobody is associated with them, or because no member is flagged as the
+    # head of household. Stored so the search filters and list-row decoration
+    # can use them without triggering N+1 reads.
+
+    member_count = fields.Integer(
+        string="# Members",
+        compute="_compute_member_membership_state",
+        store=True,
+        help="Number of non-ended members linked to this farm/group.",
+    )
+    has_head_member = fields.Boolean(
+        string="Has Head Member",
+        compute="_compute_member_membership_state",
+        store=True,
+        help="True when at least one non-ended member carries the 'head' membership type.",
+    )
+
+    # ═══════════════════════════════════════════════════════════════════════
     # COMPUTED METHODS
     # ═══════════════════════════════════════════════════════════════════════
 
@@ -195,6 +216,21 @@ class Farm(models.Model):
         """Sum all livestock activity quantities."""
         for record in self:
             record.total_livestock_heads = sum(act.quantity or 0 for act in record.farm_livestock_act_ids)
+
+    @api.depends(
+        "group_membership_ids",
+        "group_membership_ids.is_ended",
+        "group_membership_ids.membership_type_ids",
+    )
+    def _compute_member_membership_state(self):
+        """Compute member_count and has_head_member from non-ended memberships."""
+        head_code = self.env["spp.vocabulary.code"].get_code("urn:openspp:vocab:group-membership-type", "head")
+        for record in self:
+            active_members = record.group_membership_ids.filtered(lambda m: not m.is_ended)
+            record.member_count = len(active_members)
+            record.has_head_member = bool(
+                head_code and active_members.filtered(lambda m: head_code in m.membership_type_ids)
+            )
 
     # ═══════════════════════════════════════════════════════════════════════
     # HELPER METHODS

--- a/spp_farmer_registry/views/farm_views.xml
+++ b/spp_farmer_registry/views/farm_views.xml
@@ -215,6 +215,81 @@
         </field>
     </record>
 
+    <!-- ═══════════════════════════════════════════════════════════════════════
+         Farm membership-completeness UX (#939)
+         ═══════════════════════════════════════════════════════════════════════ -->
+
+    <!-- Search filters: surface farms with no members or no head member -->
+    <record id="view_registry_groups_filter_farm" model="ir.ui.view">
+        <field name="name">res.partner.search.farm.member_completeness</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="spp_registry.view_registry_groups_filter" />
+        <field name="priority">50</field>
+        <field name="arch" type="xml">
+            <xpath expr="//filter[@name='has_phone']" position="after">
+                <separator />
+                <filter
+                    string="No Members"
+                    name="no_members"
+                    domain="[('member_count', '=', 0)]"
+                />
+                <filter
+                    string="No Head Member"
+                    name="no_head_member"
+                    domain="[('has_head_member', '=', False)]"
+                />
+            </xpath>
+        </field>
+    </record>
+
+    <!-- List view: warning decoration + optional column for member count.
+         The decoration scopes to farm records (those with farm_type_id set)
+         so it doesn't fire on plain group registrants. -->
+    <record id="view_groups_list_tree_farm" model="ir.ui.view">
+        <field name="name">res.partner.list.farm.member_completeness</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="spp_registry.view_groups_list_tree" />
+        <field name="priority">50</field>
+        <field name="arch" type="xml">
+            <xpath expr="//list" position="inside">
+                <field name="member_count" optional="hide" />
+                <field name="has_head_member" optional="hide" widget="boolean" />
+            </xpath>
+        </field>
+    </record>
+
+    <!-- Form-top banners: warn when a group has no members, or has members
+         but no designated head. The two banners are mutually exclusive:
+         no-members fires only when member_count == 0; no-head fires only
+         when there are members but none flagged as head. Scoped to
+         is_group so neither appears on individuals. -->
+    <record id="view_individuals_form_farm_no_members" model="ir.ui.view">
+        <field name="name">res.partner.form.farm.member_completeness_banners</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="spp_registry.view_individuals_form" />
+        <field name="priority">50</field>
+        <field name="arch" type="xml">
+            <xpath expr="//div[@name='button_box']" position="before">
+                <div
+                    class="alert alert-warning text-center"
+                    role="alert"
+                    invisible="not is_group or member_count != 0"
+                >
+                    <i class="fa fa-exclamation-triangle me-2" title="Warning" />
+                    No members linked to this group yet.
+                </div>
+                <div
+                    class="alert alert-danger text-center"
+                    role="alert"
+                    invisible="not is_group or member_count == 0 or has_head_member"
+                >
+                    <i class="fa fa-exclamation-triangle me-2" title="Warning" />
+                    No head member designated.
+                </div>
+            </xpath>
+        </field>
+    </record>
+
     <!-- Add view activity actions to res.partner -->
     <record id="res_partner_view_crop_activities" model="ir.actions.server">
         <field name="name">View Crop Activities</field>


### PR DESCRIPTION
## Why is this change needed?

Group registrants in the Farmer Registry can exist with no members linked at all, or with members but none flagged as the head of household. Either state makes the group unusable for eligibility / compliance, but there was no way to surface it: users had to open each group form to spot the issue. OP#939 asks for filters and form banners to make incomplete groups visible at a glance.

## How was the change implemented?

Two stored computed fields on `res.partner` so the search filters and banners can reason about non-ended memberships without N+1 reads:

- `member_count` — non-ended memberships count
- `has_head_member` — `True` iff at least one non-ended membership has the head-of-household flag

Then:

- **Two new search filters** on the registry groups search view: *No Members* (`member_count = 0`) and *No Head Member* (`has_head_member = False`). They work on any Groups menu once `spp_farmer_registry` is installed.
- **Two centered form banners** at the top of the registrant form, scoped to `is_group`:
  - yellow warning when the group has no members at all
  - red danger banner when the group has members but none flagged as head
  - mutually exclusive — they never both show
- **Two optional columns** on the groups list view (`# Members`, `Has Head Member`), both hidden by default but toggleable from the column-config menu.

## How to test manually

- [ ] Apps → Upgrade `spp_farmer_registry`.
- [ ] Registry → Groups → search filter dropdown shows *No Members* and *No Head Member*.
- [ ] Apply *No Members* → list narrows to groups with zero non-ended memberships.
- [ ] Toggle the optional columns from the column-config menu → `# Members` and `Has Head Member` appear.
- [ ] Open a group with no members → yellow "no members" banner across the top.
- [ ] Add a member but don't flag a head → banner switches to the red "no head" variant.
- [ ] Flag the member as head → both banners disappear.

## Related links

- OP#939 — https://projects.acn.fr/work_packages/939