### PR TITLE
fix(spp_farmer_registry_vocabularies): add Farm group type code (#938)

### DIFF
--- a/spp_farmer_registry_vocabularies/__manifest__.py
+++ b/spp_farmer_registry_vocabularies/__manifest__.py
@@ -17,6 +17,7 @@
     "external_dependencies": {},
     "data": [
         "security/ir.model.access.csv",
+        "data/vocab_group_type_farm.xml",
         "data/vocab_farm_type.xml",
         "data/vocab_land_tenure.xml",
         "data/vocab_land_use.xml",

--- a/spp_farmer_registry_vocabularies/data/vocab_group_type_farm.xml
+++ b/spp_farmer_registry_vocabularies/data/vocab_group_type_farm.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo noupdate="1">
+    <!-- Adds 'farm' as a group type, completing the household/family/farm
+         set referenced in spp_vocabulary's Group Type description. Scoped to
+         this module so core stays minimal for non-agricultural deployments. -->
+    <record id="code_group_type_farm" model="spp.vocabulary.code">
+        <field name="vocabulary_id" ref="spp_vocabulary.vocab_group_type" />
+        <field name="code">farm</field>
+        <field name="display">Farm</field>
+        <field
+            name="definition"
+        >An agricultural holding managed as a single economic unit (crops, livestock, aquaculture).</field>
+        <field name="sequence">3</field>
+    </record>
+</odoo>


### PR DESCRIPTION
## Why is this change needed?

`spp_vocabulary`'s `Group Type` vocabulary ships with `household` and `family` only. Its own description comment references "farm" as one of the intended values, but no `farm` code is ever defined. After installing `spp_starter_farmer_registry`, users creating a farm group through the registry can't classify it as `Farm` — the dropdown lacks the option even though farms are the entity this stack exists to manage. (See OP#938.)

## How was the change implemented?

Added a single XML data record in `spp_farmer_registry_vocabularies` that creates the `farm` code on `spp_vocabulary.vocab_group_type`:

- `code`: `farm`
- `display`: `Farm`
- `definition`: "An agricultural holding managed as a single economic unit (crops, livestock, aquaculture)."
- `sequence`: 3 (after `household` and `family`)

Scoped to this module rather than `spp_vocabulary` so non-agricultural deployments stay minimal — only stacks that install farmer-registry vocabularies pick up the entry. `noupdate="1"` means existing records aren't clobbered on subsequent upgrades, but the entry is created on first install.

## How to test manually

- [ ] Apps → Upgrade `spp_farmer_registry_vocabularies` (or install on a fresh DB).
- [ ] **Registry → Configuration → Vocabularies** → Group Type → confirm a third `Farm` row exists.
- [ ] **Registry → Groups → New** → the **Group Type** dropdown now offers `Farm` alongside `Household` and `Family`.

## Related links

- OP#938 — https://projects.acn.fr/work_packages/938