### PR TITLE
fix(spp_graduation): expose Graduation Criteria via menu + standalone views

### DIFF
--- a/spp_graduation/README.rst
+++ b/spp_graduation/README.rst
@@ -632,6 +632,20 @@ Test 10: Edge Cases
 Changelog
 =========
 
+19.0.2.0.1
+~~~~~~~~~~
+
+- fix(views): add a "Graduation Criteria" menu item directly under the
+  Graduation root, plus a list/form/search view and action for
+  ``spp.graduation.criteria``. The model and ACL were already shipped,
+  but no UI surface existed — criteria could only be edited indirectly
+  through the pathway form. Visible to ``group_spp_graduation_user`` and
+  above.
+- fix(security): rename the module's ``res.groups`` and
+  ``res.groups.privilege`` records from generic "User" / "Manager" to
+  "Graduation User" / "Graduation Manager" so they are unambiguous in
+  the Settings → Users access-rights UI.
+
 19.0.2.0.0
 ~~~~~~~~~~
 

--- a/spp_graduation/__manifest__.py
+++ b/spp_graduation/__manifest__.py
@@ -2,7 +2,7 @@
 {
     "name": "OpenSPP Graduation Management",
     "summary": "Manage graduation and exit from time-bound social protection programs",
-    "version": "19.0.2.0.0",
+    "version": "19.0.2.0.1",
     "category": "OpenSPP",
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/OpenSPP2",
@@ -23,6 +23,7 @@
         "security/ir.model.access.csv",
         "views/graduation_pathway_views.xml",
         "views/graduation_assessment_views.xml",
+        "views/graduation_criteria_views.xml",
         "views/graduation_menus.xml",
         "data/graduation_data.xml",
     ],

--- a/spp_graduation/readme/HISTORY.md
+++ b/spp_graduation/readme/HISTORY.md
@@ -1,6 +1,7 @@
 ### 19.0.2.0.1
 
 - fix(views): add a "Graduation Criteria" menu item directly under the Graduation root, plus a list/form/search view and action for `spp.graduation.criteria`. The model and ACL were already shipped, but no UI surface existed — criteria could only be edited indirectly through the pathway form. Visible to `group_spp_graduation_user` and above.
+- fix(security): rename the module's `res.groups` and `res.groups.privilege` records from generic "User" / "Manager" to "Graduation User" / "Graduation Manager" so they are unambiguous in the Settings → Users access-rights UI.
 
 ### 19.0.2.0.0
 

--- a/spp_graduation/readme/HISTORY.md
+++ b/spp_graduation/readme/HISTORY.md
@@ -1,3 +1,7 @@
+### 19.0.2.0.1
+
+- fix(views): add a "Graduation Criteria" menu item directly under the Graduation root, plus a list/form/search view and action for `spp.graduation.criteria`. The model and ACL were already shipped, but no UI surface existed — criteria could only be edited indirectly through the pathway form. Visible to `group_spp_graduation_user` and above.
+
 ### 19.0.2.0.0
 
 - Initial migration to OpenSPP2

--- a/spp_graduation/security/graduation_security.xml
+++ b/spp_graduation/security/graduation_security.xml
@@ -2,7 +2,7 @@
 <odoo>
     <!-- User Group -->
     <record id="group_spp_graduation_user" model="res.groups">
-        <field name="name">User</field>
+        <field name="name">Graduation User</field>
         <field name="privilege_id" ref="privilege_graduation_user" />
         <field
             name="comment"
@@ -12,7 +12,7 @@
 
     <!-- Manager Group -->
     <record id="group_spp_graduation_manager" model="res.groups">
-        <field name="name">Manager</field>
+        <field name="name">Graduation Manager</field>
         <field name="privilege_id" ref="privilege_graduation_manager" />
         <field
             name="comment"

--- a/spp_graduation/security/privileges.xml
+++ b/spp_graduation/security/privileges.xml
@@ -5,14 +5,14 @@
 
     <!-- User privilege -->
     <record id="privilege_graduation_user" model="res.groups.privilege">
-        <field name="name">User</field>
+        <field name="name">Graduation User</field>
         <field name="category_id" ref="spp_security.category_spp_graduation" />
         <field name="sequence">10</field>
     </record>
 
     <!-- Manager privilege -->
     <record id="privilege_graduation_manager" model="res.groups.privilege">
-        <field name="name">Manager</field>
+        <field name="name">Graduation Manager</field>
         <field name="category_id" ref="spp_security.category_spp_graduation" />
         <field name="sequence">20</field>
     </record>

--- a/spp_graduation/static/description/index.html
+++ b/spp_graduation/static/description/index.html
@@ -1005,6 +1005,21 @@ pathways</li>
 </div>
 </div>
 <div class="section" id="section-1">
+<h1>19.0.2.0.1</h1>
+<ul class="simple">
+<li>fix(views): add a “Graduation Criteria” menu item directly under the
+Graduation root, plus a list/form/search view and action for
+<tt class="docutils literal">spp.graduation.criteria</tt>. The model and ACL were already shipped,
+but no UI surface existed — criteria could only be edited indirectly
+through the pathway form. Visible to <tt class="docutils literal">group_spp_graduation_user</tt> and
+above.</li>
+<li>fix(security): rename the module’s <tt class="docutils literal">res.groups</tt> and
+<tt class="docutils literal">res.groups.privilege</tt> records from generic “User” / “Manager” to
+“Graduation User” / “Graduation Manager” so they are unambiguous in
+the Settings → Users access-rights UI.</li>
+</ul>
+</div>
+<div class="section" id="section-2">
 <h1>19.0.2.0.0</h1>
 <ul class="simple">
 <li>Initial migration to OpenSPP2</li>

--- a/spp_graduation/views/graduation_criteria_views.xml
+++ b/spp_graduation/views/graduation_criteria_views.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <!-- Graduation Criteria Search View -->
+    <record id="view_graduation_criteria_search" model="ir.ui.view">
+        <field name="name">spp.graduation.criteria.search</field>
+        <field name="model">spp.graduation.criteria</field>
+        <field name="arch" type="xml">
+            <search string="Graduation Criteria">
+                <field name="name" />
+                <field name="code" />
+                <field name="pathway_id" />
+                <separator />
+                <filter
+                    string="Required"
+                    name="required"
+                    domain="[('is_required', '=', True)]"
+                />
+                <filter
+                    string="Optional"
+                    name="optional"
+                    domain="[('is_required', '=', False)]"
+                />
+                <separator />
+                <filter
+                    string="Archived"
+                    name="archived"
+                    domain="[('active', '=', False)]"
+                />
+                <group>
+                    <filter
+                        string="Pathway"
+                        name="group_by_pathway"
+                        context="{'group_by': 'pathway_id'}"
+                    />
+                    <filter
+                        string="Assessment Method"
+                        name="group_by_method"
+                        context="{'group_by': 'assessment_method'}"
+                    />
+                </group>
+            </search>
+        </field>
+    </record>
+
+    <!-- Graduation Criteria List View -->
+    <record id="view_graduation_criteria_tree" model="ir.ui.view">
+        <field name="name">spp.graduation.criteria.list</field>
+        <field name="model">spp.graduation.criteria</field>
+        <field name="arch" type="xml">
+            <list string="Graduation Criteria">
+                <field name="sequence" widget="handle" />
+                <field name="name" />
+                <field name="code" optional="show" />
+                <field name="pathway_id" />
+                <field name="assessment_method" />
+                <field name="weight" />
+                <field name="is_required" />
+                <field name="description" optional="hide" />
+                <field name="active" widget="boolean_toggle" />
+            </list>
+        </field>
+    </record>
+
+    <!-- Graduation Criteria Form View -->
+    <record id="view_graduation_criteria_form" model="ir.ui.view">
+        <field name="name">spp.graduation.criteria.form</field>
+        <field name="model">spp.graduation.criteria</field>
+        <field name="arch" type="xml">
+            <form string="Graduation Criterion">
+                <sheet>
+                    <widget
+                        name="web_ribbon"
+                        title="Archived"
+                        bg_color="text-bg-danger"
+                        invisible="active"
+                    />
+                    <div class="oe_title">
+                        <h1>
+                            <field name="name" placeholder="Criterion name..." />
+                        </h1>
+                    </div>
+                    <group col="2">
+                        <group name="main_info">
+                            <field name="code" />
+                            <field name="pathway_id" options="{'no_create': True}" />
+                            <field name="sequence" />
+                            <field name="active" invisible="1" />
+                        </group>
+                        <group name="scoring">
+                            <field name="assessment_method" />
+                            <field name="weight" />
+                            <field name="is_required" widget="boolean_toggle" />
+                        </group>
+                    </group>
+                    <group name="description_section" string="Description" col="2">
+                        <field
+                            name="description"
+                            nolabel="1"
+                            colspan="2"
+                            placeholder="Describe the criterion and how it is assessed..."
+                        />
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <!-- Graduation Criteria Action -->
+    <record id="action_graduation_criteria" model="ir.actions.act_window">
+        <field name="name">Graduation Criteria</field>
+        <field name="res_model">spp.graduation.criteria</field>
+        <field name="view_mode">list,form</field>
+        <field name="search_view_id" ref="view_graduation_criteria_search" />
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Create a new Graduation Criterion
+            </p>
+            <p>
+                Define weighted criteria within a pathway, each with its own
+                assessment method (self-report, verification, computed, or
+                field observation) and a flag for whether it is required.
+            </p>
+        </field>
+    </record>
+</odoo>

--- a/spp_graduation/views/graduation_menus.xml
+++ b/spp_graduation/views/graduation_menus.xml
@@ -33,6 +33,16 @@
         sequence="20"
     />
 
+    <!-- Graduation Criteria — direct child of root, visible to user role+ -->
+    <menuitem
+        id="menu_graduation_criteria"
+        name="Graduation Criteria"
+        parent="menu_graduation_root"
+        action="action_graduation_criteria"
+        sequence="20"
+        groups="group_spp_graduation_user"
+    />
+
     <!-- Configuration Menu -->
     <menuitem
         id="menu_graduation_configuration"


### PR DESCRIPTION
## Why is this change needed?

The `spp.graduation.criteria` model shipped with the module along with ACL entries and the `criteria_ids` One2many on `spp.graduation.pathway`, but had **no menu, no action_window, and no standalone list/form views**. Users could only edit criteria indirectly through the embedded list on the pathway form — the documented `Graduation > Graduation Criteria` nav path resolved to nothing.

Refs OP#990.

## How was the change implemented?

**1. New view file `spp_graduation/views/graduation_criteria_views.xml`:** list, form, and search views plus an `action_graduation_criteria` action_window. The search view groups by pathway and assessment method, filters required vs optional, and surfaces the archived flag.

**2. Menu wiring in `views/graduation_menus.xml`:** new `menu_graduation_criteria` as a **direct child of `menu_graduation_root`** (sequence 20, between Assessments and Configuration), gated on `group_spp_graduation_user` per the OP's suggested fix.

**3. Manifest + HISTORY:** new view file added to the data list, version bumped 19.0.2.0.0 → 19.0.2.0.1.

## New unit tests

None — pure view/menu wiring; no model changes.

## Unit tests executed by the author

Manual verification on a running instance: upgraded `spp_graduation`, confirmed the new "Graduation Criteria" menu appears as a direct child of Graduation (between Assessments and Configuration), opened the list/form, created a record, exercised the Required / Optional / Archived filters and the Group By options, and verified the existing `weight > 0` ValidationError still fires from the form.

## How to test manually

1. Pull the branch and upgrade `spp_graduation` (XML-only round, no full reset needed).
2. Top-left app switcher → **Graduation** → confirm the left nav now reads: Assessments → Graduation Criteria (new) → Configuration.
3. Click Graduation Criteria → list opens with columns Name / Code / Pathway / Assessment Method / Weight / Is Required / Active.
4. Open any record → form shows Name (h1), Code, Pathway, Sequence, Assessment Method, Weight, Is Required toggle, Description.
5. Create a new record with Weight = 0 → confirm the `Weight must be greater than zero` validation fires.
6. Verify the menu is visible to users with the Graduation User role (not just Manager) — ACL was already permissive for the model.

## Related links

OP#990 — QA passed Round 1.