### PR TITLE
fix(spp_import_match): conditional rows act as pure gates, hide UI columns (#991)

### DIFF
--- a/spp_import_match/README.rst
+++ b/spp_import_match/README.rst
@@ -393,6 +393,26 @@ Test 12: Security — Non-Admin Access
 Changelog
 =========
 
+19.0.2.0.2
+~~~~~~~~~~
+
+- chore(views): hide the conditional-gate columns (``Is Conditional``,
+  ``Condition Field``, ``Condition Value``) from the match-rule fields
+  list — the schema and matching-engine wiring stay in place, but no
+  current import flow uses the gate, so the columns are kept out of the
+  UI until a real use case lands.
+
+19.0.2.0.1
+~~~~~~~~~~
+
+- fix(matching): add a ``condition_field_id`` Many2one column to
+  ``spp.import.match.fields`` and rewrite the matching loop so
+  conditional rows act as pure gates — never added to the DB search
+  domain. Renames the IMPORTED VALUE column heading to **Condition
+  Value**. Fixes the case where a CSV-only metadata column (e.g.
+  ``data_source``) was being injected into the search domain and causing
+  zero matches.
+
 19.0.2.0.0
 ~~~~~~~~~~
 

--- a/spp_import_match/__manifest__.py
+++ b/spp_import_match/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "OpenSPP Import Match",
     "summary": "OpenSPP Import Match enhances data import processes by intelligently matching incoming records against existing data, preventing duplication and ensuring registry integrity. It provides configurable matching logic and supports seamless updates to existing records during bulk data onboarding.",
     "category": "OpenSPP/Integration",
-    "version": "19.0.2.0.0",
+    "version": "19.0.2.0.1",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/OpenSPP2",

--- a/spp_import_match/__manifest__.py
+++ b/spp_import_match/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "OpenSPP Import Match",
     "summary": "OpenSPP Import Match enhances data import processes by intelligently matching incoming records against existing data, preventing duplication and ensuring registry integrity. It provides configurable matching logic and supports seamless updates to existing records during bulk data onboarding.",
     "category": "OpenSPP/Integration",
-    "version": "19.0.2.0.1",
+    "version": "19.0.2.0.2",
     "sequence": 1,
     "author": "OpenSPP.org",
     "website": "https://github.com/OpenSPP/OpenSPP2",

--- a/spp_import_match/models/import_match.py
+++ b/spp_import_match/models/import_match.py
@@ -77,11 +77,7 @@ class SPPImportMatch(models.Model):
                     # to the DB search domain — the gate column may be a
                     # CSV-only metadata field (e.g. `data_source`) that
                     # doesn't exist on the registrant model.
-                    gate_field_name = (
-                        field.condition_field_id.name
-                        if field.condition_field_id
-                        else field.field_id.name
-                    )
+                    gate_field_name = field.condition_field_id.name if field.condition_field_id else field.field_id.name
                     if imported_row.get(gate_field_name) != field.imported_value:
                         combination_valid = False
                         break

--- a/spp_import_match/models/import_match.py
+++ b/spp_import_match/models/import_match.py
@@ -68,9 +68,25 @@ class SPPImportMatch(models.Model):
             domain = list()
             for field in combination.field_ids:
                 if field.is_conditional:
-                    if imported_row[field.name] != field.imported_value:
+                    # Conditional rows are pure *gates* — they decide whether
+                    # the rule applies to this CSV row. The CSV column that
+                    # carries the gate value is `condition_field_id` when
+                    # set; otherwise we fall back to `field_id` for
+                    # backwards compatibility with rules created before
+                    # OP#991. Crucially, a conditional row is **not** added
+                    # to the DB search domain — the gate column may be a
+                    # CSV-only metadata field (e.g. `data_source`) that
+                    # doesn't exist on the registrant model.
+                    gate_field_name = (
+                        field.condition_field_id.name
+                        if field.condition_field_id
+                        else field.field_id.name
+                    )
+                    if imported_row.get(gate_field_name) != field.imported_value:
                         combination_valid = False
                         break
+                    continue
+
                 if field.field_id.name in converted_row:
                     row_value = converted_row[field.field_id.name]
                     # Skip matching on empty values to avoid false matches
@@ -141,7 +157,29 @@ class SPPImportMatchFields(models.Model):
     match_id = fields.Many2one("spp.import.match", string="Match", ondelete="cascade")
     model_id = fields.Many2one(related="match_id.model_id")
     is_conditional = fields.Boolean()
-    imported_value = fields.Char(help="This will be used as a condition to disregard this field if matched")
+    condition_field_id = fields.Many2one(
+        "ir.model.fields",
+        string="Condition Field",
+        ondelete="cascade",
+        domain="[('model_id', '=', model_id)]",
+        help=(
+            "When `Is Conditional` is set, the rule only fires for CSV rows "
+            "whose value in this field equals `Condition Value`. The "
+            "condition field is used purely as a gate — it is **not** added "
+            "to the database search domain, so it can safely be a CSV-only "
+            "metadata column (e.g. `data_source`) that doesn't have data on "
+            "the registrant. Leave empty to fall back to the legacy "
+            "behaviour where `Field` is used as both the gate and the "
+            "search predicate."
+        ),
+    )
+    imported_value = fields.Char(
+        string="Condition Value",
+        help=(
+            "Expected value of the condition field. The rule only applies "
+            "when the imported row's `Condition Field` matches this value."
+        ),
+    )
 
     def _compute_name(self):
         for rec in self:

--- a/spp_import_match/readme/HISTORY.md
+++ b/spp_import_match/readme/HISTORY.md
@@ -1,3 +1,11 @@
+### 19.0.2.0.2
+
+- chore(views): hide the conditional-gate columns (`Is Conditional`, `Condition Field`, `Condition Value`) from the match-rule fields list — the schema and matching-engine wiring stay in place, but no current import flow uses the gate, so the columns are kept out of the UI until a real use case lands.
+
+### 19.0.2.0.1
+
+- fix(matching): add a `condition_field_id` Many2one column to `spp.import.match.fields` and rewrite the matching loop so conditional rows act as pure gates — never added to the DB search domain. Renames the IMPORTED VALUE column heading to **Condition Value**. Fixes the case where a CSV-only metadata column (e.g. `data_source`) was being injected into the search domain and causing zero matches.
+
 ### 19.0.2.0.0
 
 - Initial migration to OpenSPP2

--- a/spp_import_match/static/description/index.html
+++ b/spp_import_match/static/description/index.html
@@ -804,6 +804,28 @@ the name of the first matched record)</li>
 </div>
 </div>
 <div class="section" id="section-1">
+<h1>19.0.2.0.2</h1>
+<ul class="simple">
+<li>chore(views): hide the conditional-gate columns (<tt class="docutils literal">Is Conditional</tt>,
+<tt class="docutils literal">Condition Field</tt>, <tt class="docutils literal">Condition Value</tt>) from the match-rule fields
+list — the schema and matching-engine wiring stay in place, but no
+current import flow uses the gate, so the columns are kept out of the
+UI until a real use case lands.</li>
+</ul>
+</div>
+<div class="section" id="section-2">
+<h1>19.0.2.0.1</h1>
+<ul class="simple">
+<li>fix(matching): add a <tt class="docutils literal">condition_field_id</tt> Many2one column to
+<tt class="docutils literal">spp.import.match.fields</tt> and rewrite the matching loop so
+conditional rows act as pure gates — never added to the DB search
+domain. Renames the IMPORTED VALUE column heading to <strong>Condition
+Value</strong>. Fixes the case where a CSV-only metadata column (e.g.
+<tt class="docutils literal">data_source</tt>) was being injected into the search domain and causing
+zero matches.</li>
+</ul>
+</div>
+<div class="section" id="section-3">
 <h1>19.0.2.0.0</h1>
 <ul class="simple">
 <li>Initial migration to OpenSPP2</li>

--- a/spp_import_match/tests/test_import_match_model.py
+++ b/spp_import_match/tests/test_import_match_model.py
@@ -130,9 +130,7 @@ class TestImportMatchModel(TransactionCase):
         provide the actual search predicate. Here `name` is the gate and
         `email` is the search predicate.
         """
-        partner = self.env["res.partner"].create(
-            {"name": "ConditionalMatchTest", "email": "conditional@example.com"}
-        )
+        partner = self.env["res.partner"].create({"name": "ConditionalMatchTest", "email": "conditional@example.com"})
         match = self._create_match_rule(
             [
                 {

--- a/spp_import_match/tests/test_import_match_model.py
+++ b/spp_import_match/tests/test_import_match_model.py
@@ -120,21 +120,33 @@ class TestImportMatchModel(TransactionCase):
         self.assertFalse(result.id)
 
     def test_match_find_conditional_match(self):
-        """Test _match_find uses rule when conditional value matches."""
-        partner = self.env["res.partner"].create({"name": "ConditionalMatchTest"})
+        """Test _match_find applies the rule when the conditional gate passes.
+
+        Under OP#991 semantics, an `is_conditional=True` row is a pure gate —
+        it decides whether the rule applies to this CSV row but is never
+        added to the DB search domain (the gate column may be a CSV-only
+        metadata field that doesn't exist on the registrant model). The
+        combination must include at least one non-conditional row to
+        provide the actual search predicate. Here `name` is the gate and
+        `email` is the search predicate.
+        """
+        partner = self.env["res.partner"].create(
+            {"name": "ConditionalMatchTest", "email": "conditional@example.com"}
+        )
         match = self._create_match_rule(
             [
                 {
                     "field_id": self.name_field.id,
                     "is_conditional": True,
                     "imported_value": "ConditionalMatchTest",
-                }
+                },
+                {"field_id": self.email_field.id},
             ]
         )
         result = match._match_find(
             self.env["res.partner"],
-            {"name": "ConditionalMatchTest"},
-            {"name": "ConditionalMatchTest", "id": None},
+            {"email": "conditional@example.com"},
+            {"name": "ConditionalMatchTest", "email": "conditional@example.com", "id": None},
         )
         self.assertEqual(result, partner)
 

--- a/spp_import_match/views/import_match_view.xml
+++ b/spp_import_match/views/import_match_view.xml
@@ -53,9 +53,18 @@
                                         <field name="match_id" column_invisible="1" />
                                         <field name="model_id" column_invisible="1" />
                                         <field name="is_conditional" />
-                                        <!-- Odoo 19: Converted attrs to individual attributes -->
+                                        <!-- Condition Field is a separate gate column from
+                                             the match field; only populated when the rule
+                                             is conditional. See OP#991. -->
+                                        <field
+                                            name="condition_field_id"
+                                            string="Condition Field"
+                                            readonly="is_conditional == False"
+                                            options="{'no_create': True}"
+                                        />
                                         <field
                                             name="imported_value"
+                                            string="Condition Value"
                                             readonly="is_conditional == False"
                                         />
                                     </list>

--- a/spp_import_match/views/import_match_view.xml
+++ b/spp_import_match/views/import_match_view.xml
@@ -52,20 +52,26 @@
                                         />
                                         <field name="match_id" column_invisible="1" />
                                         <field name="model_id" column_invisible="1" />
-                                        <field name="is_conditional" />
-                                        <!-- Condition Field is a separate gate column from
-                                             the match field; only populated when the rule
-                                             is conditional. See OP#991. -->
+                                        <!-- Conditional gate columns hidden for now —
+                                             the schema (is_conditional / condition_field_id /
+                                             imported_value) and the matching-engine wiring
+                                             stay in place, but no current import flow needs
+                                             the gate, so the columns are kept out of the UI
+                                             until a use case lands. See OP#991. -->
+                                        <field
+                                            name="is_conditional"
+                                            column_invisible="1"
+                                        />
                                         <field
                                             name="condition_field_id"
                                             string="Condition Field"
-                                            readonly="is_conditional == False"
+                                            column_invisible="1"
                                             options="{'no_create': True}"
                                         />
                                         <field
                                             name="imported_value"
                                             string="Condition Value"
-                                            readonly="is_conditional == False"
+                                            column_invisible="1"
                                         />
                                     </list>
                                 </field>


### PR DESCRIPTION
## Why is this change needed?

Per OP#991 ([\"Condition Field\" is missing for spp_import_match](https://projects.acn.fr/projects/openspp/work_packages/991)): `is_conditional=True` rows on `spp.import.match.fields` were being used both as the gate (CSV value check) *and* as a search predicate (`field_id` injected into the DB domain). When the CSV had a metadata column that didn't exist on the registrant model — e.g. `data_source` — the generated search query either failed or silently returned zero matches, defeating the whole conditional-rule mechanism.

## How was the change implemented?

Two commits, one fix and one polish:

**`da3f563e` — fix(matching): add Condition Field, treat conditional rows as pure gates**
- Add a `condition_field_id` Many2one column on `spp.import.match.fields`, separate from the now-existing `field_id`.
- Rewrite the matching loop in `_match_find` so conditional rows are evaluated as pure gates (CSV value compared to `condition_value`) and **never** added to the DB search domain.
- Rename the IMPORTED VALUE column heading to **Condition Value** for clarity.
- Backwards-compatible: existing rules without `condition_field_id` fall back to `field_id.name` for the gate check.

**`7d7c8796` — chore(views): hide conditional-gate columns until a use case lands**
Reviewers asked to keep the new UI surface dormant until a real import flow needs the gate. Set `column_invisible=\"1\"` on `Is Conditional`, `Condition Field`, and `Condition Value` in the match-rule fields list. The model schema, the `_match_find` gate semantics, and the backwards-compat fallback to `field_id.name` all stay in place — only the column rendering is suppressed.

Module version bumped:
- `spp_import_match` 19.0.2.0.0 → 19.0.2.0.2 (two HISTORY entries: one per commit)

## New unit tests

None — the matching logic change is exercised by existing import-match scenarios that QA already validated. The column-hide commit is presentation-only.

## Unit tests executed by the author

`pre-commit run --files <scoped paths>` passed locally in the CI-matched container.

## How to test manually

QA already passed this branch (status `Test pass` on OP#991). For re-verification:

1. Install / upgrade `spp_import_match`.
2. Open **Imports → Match Rules → Fields tab** — the `Is Conditional`, `Condition Field`, `Condition Value` columns should NOT be visible.
3. Existing rules with `is_conditional=True` and a `condition_value` set should still correctly gate imports without injecting non-model columns into the search domain.

## Related links

- OP#991: https://projects.acn.fr/projects/openspp/work_packages/991