### PR TITLE
refactor: migrate _sql_constraints to models.Constraint (Odoo 19)

### DIFF
--- a/spp_analytics/models/service_cache.py
+++ b/spp_analytics/models/service_cache.py
@@ -413,13 +413,10 @@ class AnalyticsCacheEntry(models.Model):
         help="When this result was computed",
     )
 
-    _sql_constraints = [
-        (
-            "cache_key_unique",
-            "UNIQUE(cache_key)",
-            "Cache key must be unique",
-        ),
-    ]
+    _cache_key_unique = models.Constraint(
+        "UNIQUE(cache_key)",
+        "Cache key must be unique",
+    )
 
     @api.model
     def cron_cleanup_expired(self):

--- a/spp_metric/models/metric_category.py
+++ b/spp_metric/models/metric_category.py
@@ -59,7 +59,7 @@ class MetricCategory(models.Model):
         help="Parent category for hierarchical organization",
     )
 
-    _sql_constraints = [("code_unique", "UNIQUE(code)", "Category code must be unique!")]
+    _code_unique = models.Constraint("UNIQUE(code)", "Category code must be unique!")
 
     @api.constrains("parent_id")
     def _check_parent_recursion(self):

--- a/spp_metric/tests/test_metric_category.py
+++ b/spp_metric/tests/test_metric_category.py
@@ -30,7 +30,7 @@ class TestMetricCategory(TransactionCase):
         This test verifies the constraint is defined in the model.
         """
         # Verify the SQL constraint is defined
-        constraints = {name for name, _, _ in self.env["spp.metric.category"]._sql_constraints}
+        constraints = {obj.name for obj in self.env["spp.metric.category"]._table_objects.values()}
         self.assertIn("code_unique", constraints, "SQL unique constraint should be defined for code field")
 
     def test_category_parent_child(self):

--- a/spp_scoring/models/scoring_invalid_value.py
+++ b/spp_scoring/models/scoring_invalid_value.py
@@ -57,13 +57,10 @@ class SppScoringInvalidValue(models.Model):
         ),
     )
 
-    _sql_constraints = [
-        (
-            "spp_scoring_invalid_value_name_uniq",
-            "unique(name)",
-            "An invalid-value entry with this string already exists.",
-        ),
-    ]
+    _name_uniq = models.Constraint(
+        "unique(name)",
+        "An invalid-value entry with this string already exists.",
+    )
 
     @api.constrains("name", "match_type")
     def _check_regex_compiles(self):


### PR DESCRIPTION
## Summary
- Odoo 19 removed the `_sql_constraints = [(name, sql, message), ...]` pattern; it's replaced by `models.Constraint(sql, message)` class attributes.
- Migrates the three remaining sites: `spp_scoring`, `spp_metric`, `spp_analytics`.
- Updates `spp_metric/tests/test_metric_category.py` to introspect constraints via `_table_objects` instead of `_sql_constraints`.

## Notes on DB constraint names
The new system auto-prefixes the constraint name as `{table}_{attr_name_without_underscore}`:
- `spp_scoring.scoring.invalid.value`: attr `_name_uniq` → `spp_scoring_invalid_value_name_uniq` (matches the previous name exactly).
- `spp_metric.metric.category`: attr `_code_unique` → `spp_metric_category_code_unique` (previously `code_unique` — name changes, but follows the same migration pattern already in use across `spp_consent`, `spp_drims`, `spp_cel_domain`, etc.).
- `spp_analytics.analytics.cache`: attr `_cache_key_unique` → `spp_analytics_cache_cache_key_unique` (previously `cache_key_unique`).

The legacy (unprefixed) DB constraints on `spp_metric_category` and `spp_analytics_cache` won't be auto-dropped; if that's important for existing databases, a pre-init hook can be added in a follow-up.

## Test plan
- [ ] `pytest spp_metric/tests/test_metric_category.py` — verifies the constraint is reported via `_table_objects`
- [ ] Module install/upgrade on a fresh DB for `spp_scoring`, `spp_metric`, `spp_analytics`
- [ ] Verify UNIQUE violation raises the expected message on each model