### PR TITLE
fix(spp_analytics): rename legacy groups_id to group_ids for Odoo 19

### DIFF
--- a/spp_analytics/tests/test_integration_demo.py
+++ b/spp_analytics/tests/test_integration_demo.py
@@ -249,7 +249,7 @@ class TestAggregationIntegrationDemo(TransactionCase):
             {
                 "name": "Test Researcher",
                 "login": "test_researcher",
-                "groups_id": [(6, 0, [self.ref("base.group_user")])],
+                "group_ids": [(6, 0, [self.ref("base.group_user")])],
             }
         )
 
@@ -423,7 +423,7 @@ class TestAggregationIntegrationDemo(TransactionCase):
             {
                 "name": "Test Attacker",
                 "login": "test_attacker",
-                "groups_id": [(6, 0, [self.ref("base.group_user")])],
+                "group_ids": [(6, 0, [self.ref("base.group_user")])],
             }
         )
 
@@ -633,7 +633,7 @@ class TestAggregationIntegrationDemo(TransactionCase):
             {
                 "name": "Test Complement User",
                 "login": "test_complement",
-                "groups_id": [(6, 0, [self.ref("base.group_user")])],
+                "group_ids": [(6, 0, [self.ref("base.group_user")])],
             }
         )
 


### PR DESCRIPTION
## Summary
- The `res.users` field was renamed from `groups_id` to `group_ids` in Odoo 19, but `spp_analytics/tests/test_integration_demo.py` still used the pre-19 name in three `res.users.create()` calls (lines 252, 426, 636), which would fail at test setup time.
- Renamed all three occurrences. No behavior change intended — the legacy `(6, 0, [...])` tuple form is preserved to match surrounding style.

## Test plan
- [ ] Run `spp_analytics` test suite — `TestAggregationIntegrationDemo` user creations should succeed (previously raised on the unknown `groups_id` field).
- [ ] Confirm no remaining `groups_id` references inside `spp_analytics/` (`grep -rn groups_id spp_analytics/` returns nothing).