### PR TITLE
test(spp_api_v2): fix hardcoded ended_date breaking CI since 2026-06-01

### DIFF
--- a/spp_api_v2/tests/test_group_api.py
+++ b/spp_api_v2/tests/test_group_api.py
@@ -3,6 +3,8 @@
 
 import json
 
+from odoo import fields
+
 from .common import ApiV2HttpTestCase
 
 
@@ -1083,7 +1085,7 @@ class TestGroupAPIEndpoints(ApiV2HttpTestCase):
             ],
             limit=1,
         )
-        membership.write({"ended_date": "2026-06-01 10:00:00"})
+        membership.write({"ended_date": fields.Datetime.now()})
 
         # Get membership history
         url = f"{self.api_base_url}/urn:openspp:vocab:id-type%23test_household_id|HH-HISTORY-002/membership-history"

--- a/spp_api_v2/tests/test_group_service.py
+++ b/spp_api_v2/tests/test_group_service.py
@@ -1,6 +1,7 @@
 # Part of OpenSPP. See LICENSE file for full copyright and licensing details.
 """Tests for GroupService"""
 
+from odoo import fields
 from odoo.exceptions import ValidationError
 
 from ..schemas.base import Address, CodeableConcept, Coding, Identifier, Reference
@@ -709,7 +710,7 @@ class TestGroupServiceMembershipHistory(ApiV2TestCase):
             [("group", "=", self.group.id), ("individual", "=", self.members[0].id)],
             limit=1,
         )
-        membership.sudo().write({"ended_date": "2026-06-01 10:00:00"})
+        membership.sudo().write({"ended_date": fields.Datetime.now()})
 
         count = self.service.get_membership_history_count(self.group)
         # 5 added + 1 removed = 6


### PR DESCRIPTION
## Summary
- Two membership-history tests hardcoded `ended_date = "2026-06-01 10:00:00"` (`test_group_service.py`, `test_group_api.py`)
- Memberships are created at test runtime, so once the wall clock passed 2026-06-01 the write violates the "End Date cannot be earlier than Start Date" constraint — `spp_api_v2` CI fails for **every PR** since then
- Replace the literals with `fields.Datetime.now()`: always ≥ start date, still counts as a "removed" history event

## OpenProject
- No linked work package (CI unblock fix)

## Test plan
- [x] Reproduced both failures locally on current `19.0` (`ValidationError: End Date cannot be earlier than Start Date`)
- [x] Both tests pass with the fix: `Passed: 2 | Failed: 0 | Errors: 0`
- [x] pre-commit hooks pass on changed files