### PR TITLE
Restrict DCI sync and cached value access

### DIFF
--- a/spp_cel_domain/security/ir.model.access.csv
+++ b/spp_cel_domain/security/ir.model.access.csv
@@ -1,5 +1,5 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-access_spp_data_value_user,spp.data.value user,model_spp_data_value,base.group_user,1,0,0,0
+access_spp_data_value_user,spp.data.value base user disabled,model_spp_data_value,base.group_user,0,0,0,0
 access_cel_rule_wizard_manager,access_cel_rule_wizard_manager,model_spp_cel_rule_wizard,spp_cel_domain.group_cel_domain_manager,1,1,1,0
 access_cel_rule_wizard_metric_manager,access_cel_rule_wizard_metric_manager,model_spp_cel_rule_wizard_metric,spp_cel_domain.group_cel_domain_manager,1,0,1,1
 access_cel_variable_category_viewer,access_cel_variable_category_viewer,model_spp_cel_variable_category,spp_cel_domain.group_cel_domain_viewer,1,0,0,0

--- a/spp_dci_indicators/data/dci_sync.xml
+++ b/spp_dci_indicators/data/dci_sync.xml
@@ -7,7 +7,10 @@
         <field name="binding_model_id" ref="base.model_res_partner" />
         <field name="binding_view_types">list,form</field>
         <field name="state">code</field>
-        <field name="group_ids" eval="[Command.link(ref('spp_cel_domain.group_cel_domain_manager'))]" />
+        <field
+            name="group_ids"
+            eval="[Command.link(ref('spp_cel_domain.group_cel_domain_manager'))]"
+        />
         <field name="code">
 if records:
     count = env["spp.dci.cel.fetcher"].sync_for_partners(records.ids)

--- a/spp_dci_indicators/data/dci_sync.xml
+++ b/spp_dci_indicators/data/dci_sync.xml
@@ -7,6 +7,7 @@
         <field name="binding_model_id" ref="base.model_res_partner" />
         <field name="binding_view_types">list,form</field>
         <field name="state">code</field>
+        <field name="group_ids" eval="[Command.link(ref('spp_cel_domain.group_cel_domain_manager'))]" />
         <field name="code">
 if records:
     count = env["spp.dci.cel.fetcher"].sync_for_partners(records.ids)
@@ -28,6 +29,7 @@ if records:
         <field name="name">DCI: Sync CEL metrics</field>
         <field name="model_id" ref="base.model_res_partner" />
         <field name="state">code</field>
+        <field name="user_id" ref="base.user_root" />
         <field
             name="code"
         >env["spp.dci.cel.fetcher"].cron_sync_all_registrants()</field>

--- a/spp_dci_indicators/models/dci_cel_fetcher.py
+++ b/spp_dci_indicators/models/dci_cel_fetcher.py
@@ -96,6 +96,8 @@ class DCICelFetcher(models.AbstractModel):
     @api.model
     def _check_dci_sync_access(self):
         """Require CEL manager privileges before triggering outbound DCI sync."""
+        if self.env.su:
+            return  # System/cron (e.g. the scheduled sync) runs in superuser mode
         if not self.env.user.has_group("spp_cel_domain.group_cel_domain_manager"):
             raise AccessError(_("Only CEL Domain Managers can sync DCI-backed CEL values."))
 

--- a/spp_dci_indicators/models/dci_cel_fetcher.py
+++ b/spp_dci_indicators/models/dci_cel_fetcher.py
@@ -13,7 +13,8 @@ by its cel_accessor, following the r.dci.<registry>.<metric> convention.
 
 import logging
 
-from odoo import api, models
+from odoo import _, api, models
+from odoo.exceptions import AccessError
 
 _logger = logging.getLogger(__name__)
 
@@ -93,6 +94,12 @@ class DCICelFetcher(models.AbstractModel):
         )
 
     @api.model
+    def _check_dci_sync_access(self):
+        """Require CEL manager privileges before triggering outbound DCI sync."""
+        if not self.env.user.has_group("spp_cel_domain.group_cel_domain_manager"):
+            raise AccessError(_("Only CEL Domain Managers can sync DCI-backed CEL values."))
+
+    @api.model
     def sync_for_partners(self, partner_ids, variables=None):
         """Fetch + cache all DCI-backed variables for the given partners.
 
@@ -100,6 +107,7 @@ class DCICelFetcher(models.AbstractModel):
         manager's precompute path, which calls this fetcher and stores the result
         in spp.data.value.
         """
+        self._check_dci_sync_access()
         partner_ids = list(partner_ids or [])
         if not partner_ids:
             return 0

--- a/spp_dci_indicators/tests/test_dci_cel_fetcher.py
+++ b/spp_dci_indicators/tests/test_dci_cel_fetcher.py
@@ -9,6 +9,8 @@ mocked - we exercise the fetch/routing/identifier logic, not real HTTP.
 
 from unittest.mock import patch
 
+from odoo import Command
+from odoo.exceptions import AccessError
 from odoo.tests import TransactionCase, tagged
 
 from odoo.addons.spp_dci.schemas.constants import RegistryType
@@ -150,6 +152,19 @@ class TestDCICelFetcher(TransactionCase):
 
     def test_sync_for_partners_empty_is_noop(self):
         self.assertEqual(self.Fetcher.sync_for_partners([]), 0)
+
+    def test_sync_for_partners_requires_cel_manager(self):
+        plain_user = self.env["res.users"].create(
+            {
+                "name": "DCI Sync Plain User",
+                "login": "dci_sync_plain_user@example.test",
+                "group_ids": [Command.set([self.env.ref("base.group_user").id])],
+            }
+        )
+        with self.assertRaises(AccessError):
+            self.Fetcher.with_user(plain_user).sync_for_partners(
+                [self.partner.id], variables=self.var_is_alive
+            )
 
     def test_dci_backed_variables_excludes_plain_providers(self):
         plain = self.env["spp.data.provider"].create({"name": "Plain", "code": "plain_excl_t"})

--- a/spp_dci_indicators/tests/test_dci_cel_fetcher.py
+++ b/spp_dci_indicators/tests/test_dci_cel_fetcher.py
@@ -162,9 +162,45 @@ class TestDCICelFetcher(TransactionCase):
             }
         )
         with self.assertRaises(AccessError):
-            self.Fetcher.with_user(plain_user).sync_for_partners(
-                [self.partner.id], variables=self.var_is_alive
+            self.Fetcher.with_user(plain_user).sync_for_partners([self.partner.id], variables=self.var_is_alive)
+
+    def test_check_dci_sync_access_allows_cel_manager(self):
+        manager = self.env["res.users"].create(
+            {
+                "name": "DCI Sync CEL Manager",
+                "login": "dci_sync_cel_manager@example.test",
+                "group_ids": [
+                    Command.set(
+                        [
+                            self.env.ref("base.group_user").id,
+                            self.env.ref("spp_cel_domain.group_cel_domain_manager").id,
+                        ]
+                    )
+                ],
+            }
+        )
+        # A CEL Domain Manager must pass the access gate (no AccessError raised).
+        self.Fetcher.with_user(manager)._check_dci_sync_access()
+
+    def test_sync_for_partners_allows_superuser_for_cron(self):
+        """The scheduled cron runs in superuser mode (user_id=base.user_root).
+        A user without the CEL manager group must still sync when in su mode,
+        otherwise the cron would fail its own access check."""
+        plain_user = self.env["res.users"].create(
+            {
+                "name": "DCI Sync Cron User",
+                "login": "dci_sync_cron_user@example.test",
+                "group_ids": [Command.set([self.env.ref("base.group_user").id])],
+            }
+        )
+        self.assertFalse(plain_user.has_group("spp_cel_domain.group_cel_domain_manager"))
+        with patch(CHECK_DEATH, return_value=False):
+            count = (
+                self.Fetcher.with_user(plain_user)
+                .sudo()
+                .sync_for_partners([self.partner.id], variables=self.var_is_alive)
             )
+        self.assertGreaterEqual(count, 1)
 
     def test_dci_backed_variables_excludes_plain_providers(self):
         plain = self.env["spp.data.provider"].create({"name": "Plain", "code": "plain_excl_t"})


### PR DESCRIPTION
### Motivation
- The manual server action and the `sync_for_partners()` entrypoint allowed arbitrary internal users to trigger outbound DCI lookups and populate sensitive disability/health indicators into the shared cache `spp.data.value` without authorization. 
- Cached DCI-backed indicators (e.g. `dr.dci.has_disability`, severity flags) are sensitive and were readable by `base.group_user` via existing ACLs, creating a confidentiality risk. 
- The sync cron also ran without an explicit privileged `user_id`, making scheduled execution ambiguous and potentially privileged operations less explicit.

### Description
- Added a service-layer authorization check `_check_dci_sync_access()` to `spp.dci.cel.fetcher` which raises `AccessError` unless the caller has the `spp_cel_domain.group_cel_domain_manager` group, and invoked it at the start of `sync_for_partners()` to block low-privileged RPC/server calls. 
- Restricted the bound server action `action_sync_dci_values` to CEL Domain Managers by adding a `group_ids` entry and set the scheduled cron `user_id` to `base.user_root` so scheduled syncs remain explicit and privileged. 
- Removed the broad `base.group_user` read permission for `model_spp_data_value` in `spp_cel_domain/security/ir.model.access.csv` (set read to `0`) so cached DCI values are no longer globally visible to basic internal users. 
- Added a regression test that a plain internal user (only `base.group_user`) receives `AccessError` when calling `sync_for_partners()` directly (`test_sync_for_partners_requires_cel_manager`).

### Testing
- Ran `python3 -m py_compile` on the modified files (`spp_dci_indicators/models/dci_cel_fetcher.py` and tests) and compilation succeeded. 
- Parsed the updated XML (`spp_dci_indicators/data/dci_sync.xml`) with `xml.etree.ElementTree.parse` and performed a static ACL check on `spp_cel_domain/security/ir.model.access.csv`, both of which succeeded. 
- Ran `git diff --check` and static checks with no reported issues. 
- Attempted to run the Odoo `TransactionCase` test suite but `import odoo` failed in this environment so full integration/unit test execution could not be performed here; a new unit test was added and should run in CI where Odoo is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28ef4115dc83239602002c654f4ea9)