### PR TITLE
security(dci): deny sensitive parameterized DCI metrics in external predicate searches

### DIFF
--- a/spp_dci_server_social/services/search_service.py
+++ b/spp_dci_server_social/services/search_service.py
@@ -41,7 +41,7 @@ _ACCEPTED_SOCIAL_REG_TYPES = {
 # deny these sensitive metrics before compiling the expression.  Keep this
 # local instead of importing spp_dci_indicators: that addon is optional and is
 # not a dependency of the DCI Social Registry server.
-_DCI_PREDICATE_DENIED_METRICS = frozenset(("dr.dci.severity", "crvs.dci.has_event"))
+_DCI_PREDICATE_DENIED_METRICS = frozenset(("r.dci.dr.severity", "r.dci.crvs.has_event"))
 
 
 class DCISocialSearchService:
@@ -408,7 +408,11 @@ class DCISocialSearchService:
         guard only applies to external Social Registry predicate search.
         """
         for accessor in _DCI_PREDICATE_DENIED_METRICS:
-            method_pattern = rf"(?<![\w.]){re.escape(accessor)}\s*\("
+            # CEL ignores whitespace around member-selection dots, so
+            # `r . dci . dr . severity(...)` is equivalent to the bare form and
+            # must not slip past the accessor-call check.
+            accessor_pattern = r"\s*\.\s*".join(map(re.escape, accessor.split(".")))
+            method_pattern = rf"(?<![\w.]){accessor_pattern}\s*\("
             metric_pattern = rf"(?<![\w.])metric\s*\(\s*(['\"]){re.escape(accessor)}\1"
             if re.search(method_pattern, expression) or re.search(metric_pattern, expression):
                 raise ValueError(_("Predicate searches cannot filter on sensitive DCI metric '%s'.") % accessor)

--- a/spp_dci_server_social/services/search_service.py
+++ b/spp_dci_server_social/services/search_service.py
@@ -35,13 +35,36 @@ _ACCEPTED_SOCIAL_REG_TYPES = {
     "social",
 }
 
-# Parameterized DCI CEL metrics that expose registry-derived facts which are
-# not safe for unauthorised external predicate filtering.  DCI Social Registry
-# search predicates are a caller-supplied oracle (including total_count), so
-# deny these sensitive metrics before compiling the expression.  Keep this
-# local instead of importing spp_dci_indicators: that addon is optional and is
-# not a dependency of the DCI Social Registry server.
-_DCI_PREDICATE_DENIED_METRICS = frozenset(("r.dci.dr.severity", "r.dci.crvs.has_event"))
+# DCI CEL metrics that expose registry-derived facts which are not safe for
+# unauthorised external predicate filtering.  DCI Social Registry search
+# predicates are a caller-supplied oracle (including total_count), so a boolean
+# metric like r.dci.crvs.is_alive == false discloses the value one query at a
+# time even though it never appears in the response schema.  Deny these
+# sensitive metrics before compiling the expression.
+#
+# Scope: disability (r.dci.dr.*) and vital/civil-status (r.dci.crvs.*)
+# accessors -- the private-data tier this guard protects.  Lower-risk Social
+# Registry / inter-registry metrics (r.dci.sr.*, r.dci.ibr.*) are intentionally
+# left filterable.
+#
+# Keep this list local instead of importing spp_dci_indicators: that addon is
+# optional and is not a dependency of the DCI Social Registry server.
+_DCI_PREDICATE_DENIED_METRICS = frozenset(
+    (
+        # Disability registry (functional severity + disability flags)
+        "r.dci.dr.severity",
+        "r.dci.dr.has_disability",
+        "r.dci.dr.assessed",
+        "r.dci.dr.vision_severe",
+        "r.dci.dr.hearing_severe",
+        "r.dci.dr.mobility_severe",
+        # CRVS (vital events / civil status)
+        "r.dci.crvs.has_event",
+        "r.dci.crvs.is_alive",
+        "r.dci.crvs.birth_verified",
+        "r.dci.crvs.is_married",
+    )
+)
 
 
 class DCISocialSearchService:
@@ -408,13 +431,15 @@ class DCISocialSearchService:
         guard only applies to external Social Registry predicate search.
         """
         for accessor in _DCI_PREDICATE_DENIED_METRICS:
-            # CEL ignores whitespace around member-selection dots, so
-            # `r . dci . dr . severity(...)` is equivalent to the bare form and
-            # must not slip past the accessor-call check.
+            # Match the accessor as a dotted member path in any spelling that
+            # resolves to the metric: bare (r.dci.dr.has_disability), called
+            # (r.dci.dr.severity('Vision')), or quoted inside metric('...').
+            # CEL ignores whitespace around member-selection dots, so allow it
+            # (`r . dci . dr . severity`).  The boundaries reject a denied name
+            # that is only a prefix/substring of a longer identifier
+            # (r.dci.dr.severity_score, my_r.dci..., r.dci.crvs.is_alive_x).
             accessor_pattern = r"\s*\.\s*".join(map(re.escape, accessor.split(".")))
-            method_pattern = rf"(?<![\w.]){accessor_pattern}\s*\("
-            metric_pattern = rf"(?<![\w.])metric\s*\(\s*(['\"]){re.escape(accessor)}\1"
-            if re.search(method_pattern, expression) or re.search(metric_pattern, expression):
+            if re.search(rf"(?<![\w.]){accessor_pattern}(?![\w.])", expression):
                 raise ValueError(_("Predicate searches cannot filter on sensitive DCI metric '%s'.") % accessor)
 
     def _parse_expression(self, expression) -> list:

--- a/spp_dci_server_social/services/search_service.py
+++ b/spp_dci_server_social/services/search_service.py
@@ -2,6 +2,7 @@
 """DCI Social Registry Search Service - Maps Odoo partners to DCI schemas."""
 
 import logging
+import re
 import uuid
 from datetime import UTC, datetime
 from typing import Any
@@ -33,6 +34,14 @@ _ACCEPTED_SOCIAL_REG_TYPES = {
     "social_registry",
     "social",
 }
+
+# Parameterized DCI CEL metrics that expose registry-derived facts which are
+# not safe for unauthorised external predicate filtering.  DCI Social Registry
+# search predicates are a caller-supplied oracle (including total_count), so
+# deny these sensitive metrics before compiling the expression.  Keep this
+# local instead of importing spp_dci_indicators: that addon is optional and is
+# not a dependency of the DCI Social Registry server.
+_DCI_PREDICATE_DENIED_METRICS = frozenset(("dr.dci.severity", "crvs.dci.has_event"))
 
 
 class DCISocialSearchService:
@@ -366,6 +375,8 @@ class DCISocialSearchService:
         if not expression or not expression.strip():
             return []
 
+        self._validate_external_predicate_expression(expression)
+
         # Use CEL service to compile expression to domain
         cel_service = self.env["spp.cel.service"]
 
@@ -386,6 +397,21 @@ class DCISocialSearchService:
             raise ValueError(f"Invalid predicate expression: {error_msg}")
 
         return result.get("domain", [])
+
+    def _validate_external_predicate_expression(self, expression: str) -> None:
+        """Reject sensitive DCI metrics in sender-supplied predicates.
+
+        DCI predicate searches return counts and pageable matches, so allowing
+        callers to filter on raw DCI indicator cache values can disclose the
+        value by repeated queries even when the value is not present in the
+        response schema.  Internal CEL use can still compile these metrics; this
+        guard only applies to external Social Registry predicate search.
+        """
+        for accessor in _DCI_PREDICATE_DENIED_METRICS:
+            method_pattern = rf"(?<![\w.]){re.escape(accessor)}\s*\("
+            metric_pattern = rf"(?<![\w.])metric\s*\(\s*(['\"]){re.escape(accessor)}\1"
+            if re.search(method_pattern, expression) or re.search(metric_pattern, expression):
+                raise ValueError(_("Predicate searches cannot filter on sensitive DCI metric '%s'.") % accessor)
 
     def _parse_expression(self, expression) -> list:
         """

--- a/spp_dci_server_social/tests/test_search_service_internals.py
+++ b/spp_dci_server_social/tests/test_search_service_internals.py
@@ -86,16 +86,43 @@ class TestSearchServiceInternals(DCISocialServerCommon):
 
     def test_parse_predicate_rejects_sensitive_dci_method_metrics(self):
         blocked = [
+            # Parameterized methods (accessor-call + metric() forms, incl. spaced dots)
             "r.dci.dr.severity('Vision') >= 3",
             "r . dci . dr . severity('Vision') >= 3",
             "r.dci.crvs.has_event('death') == true",
             "metric('r.dci.dr.severity', me, arg='Vision') >= 3",
             'metric("r.dci.crvs.has_event", me, arg="death") == true',
+            # Non-parameterized disability flags (boolean oracles)
+            "r.dci.dr.has_disability == true",
+            "r.dci.dr.vision_severe == true",
+            "metric('r.dci.dr.mobility_severe', me) == true",
+            # Non-parameterized CRVS vital/civil status (boolean oracles)
+            "r.dci.crvs.is_alive == false",
+            "r.dci.crvs.is_married == true",
+            "metric('r.dci.crvs.birth_verified', me) == true",
         ]
         for expression in blocked:
+            # Through _parse_predicate so the test also pins that the guard is
+            # wired in ahead of CEL compilation (it raises before the compiler).
             with self.assertRaises(ValueError) as ctx:
                 self.service._parse_predicate(expression)
             self.assertIn("sensitive DCI metric", str(ctx.exception))
+
+    def test_validate_external_predicate_allows_benign_and_lower_risk_metrics(self):
+        # The guard must not over-match: benign registry predicates, identifiers
+        # that merely contain a denied name as a substring, and the intentionally
+        # allowed lower-risk SR/IBR metrics all pass validation untouched.
+        allowed = [
+            "r.gender == 'female'",
+            "age_years(r.birthdate) >= 18",
+            "r.dci.dr.severity_score >= 3",  # not a call, different accessor
+            "my_r.dci.dr.severity('Vision') >= 3",  # prefixed identifier
+            "r.dci.sr.household_size >= 5",
+            "r.dci.ibr.has_duplicate == true",
+        ]
+        for expression in allowed:
+            # Should not raise.
+            self.service._validate_external_predicate_expression(expression)
 
     # --- _to_dci_member ------------------------------------------------------
 

--- a/spp_dci_server_social/tests/test_search_service_internals.py
+++ b/spp_dci_server_social/tests/test_search_service_internals.py
@@ -84,6 +84,18 @@ class TestSearchServiceInternals(DCISocialServerCommon):
                 self.service._parse_predicate("r.broken ==")
         self.assertIn("bad syntax", str(ctx.exception))
 
+    def test_parse_predicate_rejects_sensitive_dci_method_metrics(self):
+        blocked = [
+            "dr.dci.severity('Vision') >= 3",
+            "crvs.dci.has_event('death') == true",
+            "metric('dr.dci.severity', me, arg='Vision') >= 3",
+            'metric("crvs.dci.has_event", me, arg="death") == true',
+        ]
+        for expression in blocked:
+            with self.assertRaises(ValueError) as ctx:
+                self.service._parse_predicate(expression)
+            self.assertIn("sensitive DCI metric", str(ctx.exception))
+
     # --- _to_dci_member ------------------------------------------------------
 
     def test_to_dci_member_with_identifier_and_demographics(self):

--- a/spp_dci_server_social/tests/test_search_service_internals.py
+++ b/spp_dci_server_social/tests/test_search_service_internals.py
@@ -86,10 +86,11 @@ class TestSearchServiceInternals(DCISocialServerCommon):
 
     def test_parse_predicate_rejects_sensitive_dci_method_metrics(self):
         blocked = [
-            "dr.dci.severity('Vision') >= 3",
-            "crvs.dci.has_event('death') == true",
-            "metric('dr.dci.severity', me, arg='Vision') >= 3",
-            'metric("crvs.dci.has_event", me, arg="death") == true',
+            "r.dci.dr.severity('Vision') >= 3",
+            "r . dci . dr . severity('Vision') >= 3",
+            "r.dci.crvs.has_event('death') == true",
+            "metric('r.dci.dr.severity', me, arg='Vision') >= 3",
+            'metric("r.dci.crvs.has_event", me, arg="death") == true',
         ]
         for expression in blocked:
             with self.assertRaises(ValueError) as ctx:


### PR DESCRIPTION
### Motivation
- DCI CEL metrics in the disability (`r.dci.dr.*`) and vital/civil-status (`r.dci.crvs.*`) tiers were registered and could be rewritten into `metric(...)` calls, allowing authenticated external DCI predicate searches to filter/count/page on sensitive values and thereby infer private disability/event information. A boolean metric such as `r.dci.crvs.is_alive == false` discloses the value one query at a time via `total_count`, even though it never appears in the response schema. 
- The goal is to prevent external Social Registry predicate queries from using these sensitive cached metrics as an oracle while preserving internal/optional module behavior and existing CEL compilation paths.

### Description
- Add a local denylist `_DCI_PREDICATE_DENIED_METRICS` to the Social Registry search service (kept local to avoid importing the optional `spp_dci_indicators` addon). It covers the full **disability** and **CRVS** accessor tier — `r.dci.dr.severity`, `r.dci.dr.has_disability`, `r.dci.dr.assessed`, `r.dci.dr.vision_severe`, `r.dci.dr.hearing_severe`, `r.dci.dr.mobility_severe`, `r.dci.crvs.has_event`, `r.dci.crvs.is_alive`, `r.dci.crvs.birth_verified`, `r.dci.crvs.is_married`. Lower-risk Social Registry / inter-registry metrics (`r.dci.sr.*`, `r.dci.ibr.*`) are intentionally left filterable. 
- Introduce `_validate_external_predicate_expression(expression: str)`, which matches each denied accessor as a bounded dotted member path in any spelling that resolves to the metric — bare (`r.dci.dr.has_disability`), called (`r.dci.dr.severity('Vision')`), and quoted (`metric('r.dci.dr.severity', ...)`) — and raises `ValueError` when present. Optional whitespace around member-selection dots (`r . dci . dr . severity`) is tolerated since CEL treats it as equivalent, and word boundaries prevent prefix/substring false positives (`r.dci.dr.severity_score`, `r.dci.crvs.is_alive_x`). 
- Invoke the validation from `_parse_predicate` before calling the CEL compiler so sensitive metrics are rejected prior to compilation/execution. Internal CEL use is unaffected — this guard only applies to external Social Registry predicate search. 
- Tests: `test_parse_predicate_rejects_sensitive_dci_method_metrics` asserts the parameterized, boolean, bare, `metric(...)`, and whitespace-dot forms are all rejected; `test_validate_external_predicate_allows_benign_and_lower_risk_metrics` pins that benign predicates and the intentionally-allowed SR/IBR metrics are not blocked (guards against over-matching and documents the scope decision). 

### Notes on the rebase / review
- This branch predated the 19.0 `r.dci.<registry>.<metric>` accessor rename. The original denylist/test used the pre-rename names (`dr.dci.severity`, `crvs.dci.has_event`), which no longer exist on 19.0 — so on the current base the guard matched nothing and the test passed against obsolete names. Corrected to the real accessors.
- Expanded from the two parameterized methods to the full DR/CRVS tier after review: the non-parameterized boolean flags leak the same class of data through the same predicate path and are referenced without parentheses.
- The denylist remains a best-effort string guard. A durable follow-up is to enforce an allowlist of safe metrics against the parsed AST / translated `MetricCompare.metric` rather than raw text (tracked separately).

### Testing
- `./spp t spp_dci_server_social` → 70 passed, 0 failed, 0 errors (Docker test runner, full Odoo stack).
- Lint clean (`ruff`, `ruff-format`). CI green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28f19066d48323a11c508aa9a27456)
