### PR TITLE
chore: use ConfigDict instead of class-based Config in API v2 schemas

### DIFF
--- a/spp_api_v2_change_request/schemas/change_request.py
+++ b/spp_api_v2_change_request/schemas/change_request.py
@@ -4,7 +4,7 @@
 from datetime import datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class ChangeRequestType(BaseModel):
@@ -29,8 +29,7 @@ class ChangeRequestMeta(BaseModel):
     last_updated: datetime | None = Field(None, alias="lastUpdated")
     source: str | None = Field(None, description="Source system URI")
 
-    class Config:
-        populate_by_name = True
+    model_config = ConfigDict(populate_by_name=True)
 
 
 class ChangeRequestCreate(BaseModel):
@@ -70,9 +69,9 @@ class ChangeRequestCreate(BaseModel):
     description: str | None = None
     notes: str | None = None
 
-    class Config:
-        populate_by_name = True
-        json_schema_extra = {
+    model_config = ConfigDict(
+        populate_by_name=True,
+        json_schema_extra={
             "example": {
                 "type": "ChangeRequest",
                 "requestType": {"code": "edit_individual"},
@@ -86,7 +85,8 @@ class ChangeRequestCreate(BaseModel):
                     "phone": "+639171234567",
                 },
             }
-        }
+        },
+    )
 
 
 class ChangeRequestResponse(BaseModel):
@@ -137,8 +137,7 @@ class ChangeRequestResponse(BaseModel):
     # Metadata
     meta: ChangeRequestMeta | None = None
 
-    class Config:
-        populate_by_name = True
+    model_config = ConfigDict(populate_by_name=True)
 
 
 class ChangeRequestUpdate(BaseModel):
@@ -149,8 +148,8 @@ class ChangeRequestUpdate(BaseModel):
         description="Type-specific detail fields to update",
     )
 
-    class Config:
-        json_schema_extra = {
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "detail": {
                     "given_name": "Maria Elena",
@@ -158,6 +157,7 @@ class ChangeRequestUpdate(BaseModel):
                 }
             }
         }
+    )
 
 
 class ApproveActionData(BaseModel):
@@ -206,8 +206,7 @@ class ChangeRequestTypeInfo(BaseModel):
     )
     requires_applicant: bool = Field(False, alias="requiresApplicant", description="Whether an applicant is required")
 
-    class Config:
-        populate_by_name = True
+    model_config = ConfigDict(populate_by_name=True)
 
 
 class ChangeRequestTypeSchema(BaseModel):
@@ -226,5 +225,4 @@ class ChangeRequestTypeSchema(BaseModel):
         default_factory=list, alias="requiredDocuments", description="Documents that must be attached"
     )
 
-    class Config:
-        populate_by_name = True
+    model_config = ConfigDict(populate_by_name=True)

--- a/spp_api_v2_cycles/schemas/cycle.py
+++ b/spp_api_v2_cycles/schemas/cycle.py
@@ -4,7 +4,7 @@
 from datetime import datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from odoo.addons.spp_api_v2.schemas.base import Period, Reference, ResourceMeta
 
@@ -18,8 +18,7 @@ class CycleStatistics(BaseModel):
     total_amount: float | None = Field(None, alias="totalAmount", description="Total amount allocated")
     currency: str | None = Field(None, description="Currency code")
 
-    class Config:
-        populate_by_name = True
+    model_config = ConfigDict(populate_by_name=True)
 
 
 class Cycle(BaseModel):
@@ -63,9 +62,9 @@ class Cycle(BaseModel):
     # Metadata
     meta: ResourceMeta | None = None
 
-    class Config:
-        populate_by_name = True
-        json_schema_extra = {
+    model_config = ConfigDict(
+        populate_by_name=True,
+        json_schema_extra={
             "example": {
                 "type": "Cycle",
                 "identifier": "4Ps-2024-Q1",
@@ -87,4 +86,5 @@ class Cycle(BaseModel):
                     "currency": "PHP",
                 },
             }
-        }
+        },
+    )

--- a/spp_api_v2_entitlements/schemas/entitlement.py
+++ b/spp_api_v2_entitlements/schemas/entitlement.py
@@ -4,7 +4,7 @@
 from datetime import date
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from odoo.addons.spp_api_v2.schemas.base import Period, Reference, ResourceMeta
 
@@ -85,9 +85,9 @@ class Entitlement(BaseModel):
     # Metadata
     meta: ResourceMeta | None = None
 
-    class Config:
-        populate_by_name = True
-        json_schema_extra = {
+    model_config = ConfigDict(
+        populate_by_name=True,
+        json_schema_extra={
             "example": {
                 "type": "Entitlement",
                 "identifier": "abc123-def456",
@@ -114,4 +114,5 @@ class Entitlement(BaseModel):
                     "currency": "PHP",
                 },
             }
-        }
+        },
+    )

--- a/spp_api_v2_products/schemas/product.py
+++ b/spp_api_v2_products/schemas/product.py
@@ -3,7 +3,7 @@
 
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from odoo.addons.spp_api_v2.schemas.base import Reference, ResourceMeta
 
@@ -48,9 +48,9 @@ class Product(BaseModel):
     # Metadata
     meta: ResourceMeta | None = None
 
-    class Config:
-        populate_by_name = True
-        json_schema_extra = {
+    model_config = ConfigDict(
+        populate_by_name=True,
+        json_schema_extra={
             "example": {
                 "resourceType": "Product",
                 "identifier": "RICE-25KG",
@@ -68,4 +68,5 @@ class Product(BaseModel):
                 "currency": "PHP",
                 "active": True,
             }
-        }
+        },
+    )

--- a/spp_api_v2_products/schemas/product_category.py
+++ b/spp_api_v2_products/schemas/product_category.py
@@ -3,7 +3,7 @@
 
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from odoo.addons.spp_api_v2.schemas.base import Reference, ResourceMeta
 
@@ -31,9 +31,9 @@ class ProductCategory(BaseModel):
     # Metadata
     meta: ResourceMeta | None = None
 
-    class Config:
-        populate_by_name = True
-        json_schema_extra = {
+    model_config = ConfigDict(
+        populate_by_name=True,
+        json_schema_extra={
             "example": {
                 "resourceType": "ProductCategory",
                 "identifier": "Food",
@@ -43,4 +43,5 @@ class ProductCategory(BaseModel):
                     "display": "All",
                 },
             }
-        }
+        },
+    )

--- a/spp_api_v2_products/schemas/uom.py
+++ b/spp_api_v2_products/schemas/uom.py
@@ -3,7 +3,7 @@
 
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from odoo.addons.spp_api_v2.schemas.base import Reference, ResourceMeta
 
@@ -36,9 +36,9 @@ class UnitOfMeasure(BaseModel):
     # Metadata
     meta: ResourceMeta | None = None
 
-    class Config:
-        populate_by_name = True
-        json_schema_extra = {
+    model_config = ConfigDict(
+        populate_by_name=True,
+        json_schema_extra={
             "example": {
                 "resourceType": "UnitOfMeasure",
                 "identifier": "kg",
@@ -50,4 +50,5 @@ class UnitOfMeasure(BaseModel):
                 },
                 "factor": 1.0,
             }
-        }
+        },
+    )

--- a/spp_api_v2_service_points/schemas/service_point.py
+++ b/spp_api_v2_service_points/schemas/service_point.py
@@ -3,7 +3,7 @@
 
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from odoo.addons.spp_api_v2.schemas.base import (
     Address,
@@ -54,9 +54,9 @@ class ServicePoint(BaseModel):
     # Metadata
     meta: ResourceMeta | None = None
 
-    class Config:
-        populate_by_name = True
-        json_schema_extra = {
+    model_config = ConfigDict(
+        populate_by_name=True,
+        json_schema_extra={
             "example": {
                 "resourceType": "ServicePoint",
                 "identifier": "SP-MANILA-001",
@@ -72,4 +72,5 @@ class ServicePoint(BaseModel):
                     }
                 ],
             }
-        }
+        },
+    )


### PR DESCRIPTION
## Summary

Pydantic v2 deprecated the class-based `class Config` pattern. Every import of the API v2 schema modules emitted a `PydanticDeprecatedSince20` warning (with a full traceback) into the Odoo server logs:

```
WARNING ... py.warnings: .../spp_api_v2_products/schemas/product.py:11: PydanticDeprecatedSince20:
Support for class-based `config` is deprecated, use ConfigDict instead.
```

This converts all API v2 resource schemas to the `model_config = ConfigDict(...)` form already used in `spp_api_v2/schemas/base.py`, silencing the warnings.

## Files changed

- `spp_api_v2_products/schemas/product.py`
- `spp_api_v2_products/schemas/product_category.py`
- `spp_api_v2_products/schemas/uom.py`
- `spp_api_v2_service_points/schemas/service_point.py`
- `spp_api_v2_change_request/schemas/change_request.py` (6 classes)
- `spp_api_v2_cycles/schemas/cycle.py` (2 classes)
- `spp_api_v2_entitlements/schemas/entitlement.py`

## Notes

- Behavior is unchanged — `ConfigDict` is the drop-in replacement Pydantic recommends. `populate_by_name` and `json_schema_extra` are preserved verbatim.
- No logic touched; purely a deprecation cleanup.

## Test plan

- [x] `ruff` / `ruff format` / `pylint` / `bandit` pass via pre-commit
- [x] Files parse cleanly (`ast.parse`)