### PR TITLE
security(dci): allowlist external predicate symbols (fields + metrics)

### DIFF
--- a/spp_cel_domain/models/cel_service.py
+++ b/spp_cel_domain/models/cel_service.py
@@ -47,6 +47,7 @@ class CELService(models.AbstractModel):
         offset=0,
         fields=None,
         materialize_sql=False,
+        predicate_policy=None,
     ):
         """Compile a CEL expression and return results.
 
@@ -57,6 +58,12 @@ class CELService(models.AbstractModel):
             limit: Max number of IDs to return (0 = count only)
             fields: Optional list of field names to include in preview_records
             materialize_sql: If True, execute SQL subqueries to get actual IDs (needed for window actions)
+            predicate_policy: Optional dict to restrict externally-supplied
+                predicates. When set, the resolved expression is checked against
+                a positive allowlist (default-deny) before translation/execution.
+                Keys: allowed_fields (set[str]), allowed_functions (set[str]),
+                allowed_metric_prefixes (tuple[str]), allow_relations (bool).
+                A violation marks the result invalid with an explanatory error.
 
         Returns:
             dict with keys:
@@ -109,6 +116,13 @@ class CELService(models.AbstractModel):
             resolution = resolver.resolve_for_evaluation(expression, context_type=context_type)
             expanded_expression = resolution.get("expression", expression)
 
+            # Enforce a caller-supplied predicate allowlist on the resolved
+            # expression before it is translated or executed. Runs on the same
+            # expanded string the executor will use, so the gate cannot diverge
+            # from what actually runs (no time-of-check/time-of-use gap).
+            if predicate_policy is not None:
+                self._enforce_predicate_policy(expanded_expression, predicate_policy)
+
             # Execute compilation with expanded expression
             executor = self.env["spp.cel.executor"].with_context(cel_profile=profile, cel_cfg=cfg)
             exec_result = executor.compile_and_preview(
@@ -150,6 +164,43 @@ class CELService(models.AbstractModel):
             result["error"] = f"Compilation error: {str(e)}"
 
         return result
+
+    @api.model
+    def _enforce_predicate_policy(self, expression, policy):
+        """Reject a resolved predicate that references non-allowlisted symbols.
+
+        Walks the parsed AST and checks every referenced field, function,
+        relation/method and DCI metric against the positive allowlist in
+        ``policy`` (see ``compile_expression``). Raises ``CELValidationError``
+        naming every offending symbol; the caller (compile_expression) converts
+        that into an invalid-expression result. Default-deny: an unknown symbol
+        is rejected, so the gate fails closed.
+        """
+        from ..exceptions import CELValidationError
+        from ..services.cel_parser import parse
+        from ..services.cel_predicate_guard import collect_referenced_symbols
+
+        if not expression or not expression.strip():
+            return
+
+        allowed_fields = set(policy.get("allowed_fields") or ())
+        allowed_functions = set(policy.get("allowed_functions") or ())
+        allowed_metric_prefixes = tuple(policy.get("allowed_metric_prefixes") or ())
+        allow_relations = bool(policy.get("allow_relations"))
+
+        syms = collect_referenced_symbols(parse(expression))
+
+        denied = []
+        denied += [f"field:{f}" for f in syms.fields if f not in allowed_fields]
+        denied += [f"function:{fn}" for fn in syms.functions if fn not in allowed_functions]
+        if not allow_relations:
+            denied += [f"relation:{m}" for m in syms.methods]
+        denied += [f"metric:{m}" for m in syms.metrics if not m.startswith(allowed_metric_prefixes)]
+
+        if denied:
+            raise CELValidationError(
+                "Predicate references symbols that are not permitted in external searches: " + ", ".join(sorted(denied))
+            )
 
     @api.model
     def validate_expression(self, expression, profile):

--- a/spp_cel_domain/services/cel_predicate_guard.py
+++ b/spp_cel_domain/services/cel_predicate_guard.py
@@ -1,0 +1,191 @@
+# Part of OpenSPP. See LICENSE file for full copyright and licensing details.
+"""Allowlist enforcement for externally-supplied CEL predicates.
+
+External callers (e.g. the DCI Social Registry search service) accept
+sender-supplied CEL predicates and compile them to Odoo domains. Because a
+predicate search returns counts and pageable matches, letting a sender filter on
+sensitive data turns ``total_count``/pagination into an oracle that discloses a
+value one query at a time even when the value never appears in the response body.
+
+This module walks a *parsed* CEL AST and reports every symbol it references --
+field paths, plain function calls, relation/namespaced method calls, and DCI
+metric accessors -- so a caller can enforce a positive (default-deny) allowlist
+*before* the expression is translated or executed. Working on the AST (rather
+than the lowered query plan) is robust against source-text obfuscation
+(backslash-escaped dots in ``metric('r\\.dci\\.dr\\.severity', ...)``) and
+against domain rewriting (``_smart_op_domain`` turning ``r.gender`` into a
+``gender_id`` domain): we see what the author wrote, not how it lowered.
+
+DCI metric accessors are recognised both as the expanded ``metric('r.dci.…', me)``
+call and as the raw dotted accessor ``r.dci.…`` (called or bare), so the same
+allowlist governs an expression whether or not the cached-variable expansion has
+run -- making the guard independent of which indicator variables are seeded.
+"""
+
+from dataclasses import dataclass, field
+
+from . import cel_parser as P
+
+# A metric() call whose first argument is not a plain string literal (e.g.
+# string concatenation): its true name cannot be determined statically, so it is
+# reported under this sentinel and will fail any positive allowlist.
+DYNAMIC_METRIC = "<dynamic>"
+
+# Roots that denote the record(s) under evaluation, not a field reference.
+_RECORD_ROOTS = ("r", "me")
+
+# Dotted accessor namespaces that denote DCI metrics (e.g. r.dci.dr.severity).
+_DCI_METRIC_ROOTS = ("dci",)
+
+
+@dataclass
+class ReferencedSymbols:
+    """Symbols a CEL expression references, grouped by kind."""
+
+    fields: set = field(default_factory=set)
+    functions: set = field(default_factory=set)
+    methods: set = field(default_factory=set)
+    metrics: set = field(default_factory=set)
+
+
+def collect_referenced_symbols(ast) -> ReferencedSymbols:
+    """Walk a parsed CEL AST and return the symbols it references.
+
+    Args:
+        ast: a node produced by ``cel_parser.parse``.
+
+    Returns:
+        ReferencedSymbols with:
+          - fields:    dotted field paths (root ``r``/``me`` stripped), and bare
+                       identifiers used as fields.
+          - functions: names of plain ``name(...)`` calls (excluding ``metric``).
+          - methods:   flattened names of ``a.b(...)`` calls that are not DCI
+                       metric accessors (relation methods like
+                       ``enrollments.exists``, namespaced calls, ...).
+          - metrics:   canonical DCI metric names (``r.dci.…``) and the decoded
+                       names of ``metric('…', …)`` calls; ``DYNAMIC_METRIC`` when
+                       a metric name cannot be determined statically.
+    """
+    out = ReferencedSymbols()
+    _walk(ast, out)
+    return out
+
+
+def _flatten_attr(node):
+    """Flatten an Attr/Ident chain to a dotted string, or return None.
+
+    ``r.dci.dr.severity`` -> "r.dci.dr.severity"; returns None if the chain is
+    not rooted at a plain identifier (e.g. it is built on a call result).
+    """
+    parts = []
+    cur = node
+    while isinstance(cur, P.Attr):
+        parts.append(cur.name)
+        cur = cur.obj
+    if isinstance(cur, P.Ident):
+        parts.append(cur.name)
+        return ".".join(reversed(parts))
+    return None
+
+
+def _classify_path(path, out):
+    """Classify a flattened ``root.a.b`` path as a metric or a field."""
+    head, _, rest = path.partition(".")
+    if head in _RECORD_ROOTS:
+        if rest:
+            first = rest.split(".", 1)[0]
+            if first in _DCI_METRIC_ROOTS:
+                # Canonicalise me.dci.* to r.dci.* so the allowlist is uniform.
+                out.metrics.add("r." + rest)
+            else:
+                out.fields.add(rest)
+        # bare `r` / `me` alone is the record, not a field
+        return
+    # A dotted path not rooted at the record (e.g. a relation lambda var
+    # `m.partner_id.x`): record the whole path so it fails the field allowlist.
+    out.fields.add(path)
+
+
+def _walk(node, out):  # noqa: C901 - explicit per-node dispatch is clearest here
+    if node is None:
+        return
+
+    if isinstance(node, P.Call):
+        _walk_call(node, out)
+        return
+
+    if isinstance(node, P.Attr):
+        path = _flatten_attr(node)
+        if path is not None:
+            _classify_path(path, out)
+        else:
+            # Chain rooted at something other than an identifier (e.g. a call
+            # result): walk the base so nested references are still seen.
+            _walk(node.obj, out)
+        return
+
+    if isinstance(node, P.Ident):
+        if node.name not in _RECORD_ROOTS:
+            # The translator treats a bare identifier as a field on the root
+            # model, so an external predicate could reference a field this way.
+            out.fields.add(node.name)
+        return
+
+    if isinstance(node, P.Literal):
+        return
+
+    # Structural nodes: recurse into every child expression.
+    for child in _children(node):
+        _walk(child, out)
+
+
+def _walk_call(node, out):
+    func = node.func
+    if isinstance(func, P.Ident):
+        if func.name == "metric":
+            out.metrics.add(_metric_name(node))
+            # Skip the name literal; still walk the remaining args/kwargs.
+            for arg in node.args[1:]:
+                _walk(arg, out)
+            for v in (node.kwargs or {}).values():
+                _walk(v, out)
+            return
+        out.functions.add(func.name)
+    elif isinstance(func, P.Attr):
+        flat = _flatten_attr(func)
+        if flat and _is_dci_metric_path(flat):
+            head, _, rest = flat.partition(".")
+            out.metrics.add("r." + rest)
+        else:
+            # Relation method (enrollments.exists), namespaced call, etc.
+            out.methods.add(flat if flat is not None else "<dynamic-method>")
+            if flat is None:
+                _walk(func.obj, out)
+    # Walk arguments and keyword-argument values of any call.
+    for arg in node.args:
+        _walk(arg, out)
+    for v in (node.kwargs or {}).values():
+        _walk(v, out)
+
+
+def _is_dci_metric_path(path):
+    head, _, rest = path.partition(".")
+    return head in _RECORD_ROOTS and bool(rest) and rest.split(".", 1)[0] in _DCI_METRIC_ROOTS
+
+
+def _metric_name(call):
+    """Return the static name of a ``metric('name', ...)`` call, or DYNAMIC_METRIC."""
+    if call.args and isinstance(call.args[0], P.Literal) and isinstance(call.args[0].value, str):
+        return call.args[0].value
+    return DYNAMIC_METRIC
+
+
+def _children(node):
+    """Yield the child expression nodes of a structural AST node."""
+    for attr in ("left", "right", "expr", "condition", "true_expr", "false_expr"):
+        child = getattr(node, attr, None)
+        if child is not None:
+            yield child
+    items = getattr(node, "items", None)
+    if items:
+        yield from items

--- a/spp_cel_domain/tests/__init__.py
+++ b/spp_cel_domain/tests/__init__.py
@@ -8,6 +8,7 @@ from . import test_cel_field_aggregations
 from . import test_cel_metric_conjunction
 from . import test_cel_functions
 from . import test_cel_parser
+from . import test_cel_predicate_guard
 from . import test_cel_security
 from . import test_cel_service
 from . import test_cel_sql_generation

--- a/spp_cel_domain/tests/test_cel_predicate_guard.py
+++ b/spp_cel_domain/tests/test_cel_predicate_guard.py
@@ -1,0 +1,122 @@
+# Part of OpenSPP. See LICENSE file for full copyright and licensing details.
+"""Tests for the external-predicate allowlist guard.
+
+Covers the AST symbol collector (cel_predicate_guard) and the CEL service
+enforcement entry point (_enforce_predicate_policy) used to keep sender-supplied
+DCI predicates from filtering on sensitive fields/metrics.
+"""
+
+from odoo.tests import TransactionCase, tagged
+
+from ..exceptions import CELValidationError
+from ..services.cel_parser import parse
+from ..services.cel_predicate_guard import DYNAMIC_METRIC, collect_referenced_symbols
+
+
+def _syms(expression):
+    return collect_referenced_symbols(parse(expression))
+
+
+@tagged("post_install", "-at_install")
+class TestCelPredicateGuardCollector(TransactionCase):
+    """Unit tests for collect_referenced_symbols (pure AST walk)."""
+
+    def test_metric_call_collects_decoded_name(self):
+        syms = _syms("metric('r.dci.dr.severity', me, arg='Vision') >= 3")
+        self.assertEqual(syms.metrics, {"r.dci.dr.severity"})
+
+    def test_metric_call_escaped_dots_decode_to_same_name(self):
+        # The lexer drops the backslash and keeps the next char, so the escaped
+        # literal decodes to the real accessor -- the bypass the regex missed.
+        syms = _syms(r"metric('r\.dci\.dr\.severity', me, arg='Vision') >= 3")
+        self.assertEqual(syms.metrics, {"r.dci.dr.severity"})
+
+    def test_raw_called_dotted_accessor_is_a_metric(self):
+        syms = _syms("r.dci.dr.severity('Vision') >= 3")
+        self.assertEqual(syms.metrics, {"r.dci.dr.severity"})
+
+    def test_raw_bare_dotted_accessor_is_a_metric(self):
+        syms = _syms("r.dci.sr.household_size >= 5")
+        self.assertEqual(syms.metrics, {"r.dci.sr.household_size"})
+
+    def test_me_rooted_accessor_canonicalised_to_r(self):
+        syms = _syms("me.dci.dr.severity('Vision') >= 3")
+        self.assertEqual(syms.metrics, {"r.dci.dr.severity"})
+
+    def test_fields_and_functions(self):
+        syms = _syms("r.gender == 'female' && age_years(r.birthdate) >= 18")
+        self.assertEqual(syms.fields, {"gender", "birthdate"})
+        self.assertEqual(syms.functions, {"age_years"})
+        self.assertFalse(syms.metrics)
+        self.assertFalse(syms.methods)
+
+    def test_bare_identifier_is_a_field(self):
+        syms = _syms("gender == 'female'")
+        self.assertEqual(syms.fields, {"gender"})
+
+    def test_relation_method_and_child_navigation(self):
+        syms = _syms("enrollments.exists(m, m.partner_id.disability_severity_id == 5)")
+        self.assertIn("enrollments.exists", syms.methods)
+        # The child navigation (rooted at the lambda var, not r/me) is recorded
+        # as a non-allowlisted field path.
+        self.assertIn("m.partner_id.disability_severity_id", syms.fields)
+
+    def test_rhs_field_reference_is_collected(self):
+        syms = _syms("metric('r.dci.sr.x', me) == r.disability_severity_id")
+        self.assertEqual(syms.metrics, {"r.dci.sr.x"})
+        self.assertEqual(syms.fields, {"disability_severity_id"})
+
+    def test_non_literal_metric_name_is_dynamic(self):
+        syms = _syms("metric('r.dci.dr' + '.severity', me) == 2")
+        self.assertIn(DYNAMIC_METRIC, syms.metrics)
+
+
+@tagged("post_install", "-at_install")
+class TestEnforcePredicatePolicy(TransactionCase):
+    """The CEL service default-deny enforcement entry point."""
+
+    def setUp(self):
+        super().setUp()
+        self.cel = self.env["spp.cel.service"]
+        self.policy = {
+            "allowed_fields": {"gender", "birthdate", "name"},
+            "allowed_functions": {"age_years"},
+            "allowed_metric_prefixes": ("r.dci.sr.", "r.dci.ibr."),
+            "allow_relations": False,
+        }
+
+    def _assert_denied(self, expression, needle=None):
+        with self.assertRaises(CELValidationError) as ctx:
+            self.cel._enforce_predicate_policy(expression, self.policy)
+        if needle:
+            self.assertIn(needle, str(ctx.exception))
+
+    def test_allows_safe_fields_functions_and_metrics(self):
+        # Should not raise.
+        self.cel._enforce_predicate_policy(
+            "r.gender == 'female' && age_years(r.birthdate) >= 18 && r.dci.sr.household_size >= 5",
+            self.policy,
+        )
+
+    def test_denies_sensitive_field(self):
+        self._assert_denied("r.disability_severity_id == 5", "disability_severity_id")
+
+    def test_denies_sensitive_metric_even_escaped(self):
+        self._assert_denied(r"metric('r\.dci\.dr\.severity', me, arg='Vision') >= 3", "r.dci.dr.severity")
+
+    def test_denies_relation_traversal(self):
+        self._assert_denied(
+            "enrollments.exists(m, m.partner_id.disability_severity_id == 5)",
+            "enrollments.exists",
+        )
+
+    def test_denies_unknown_function(self):
+        self._assert_denied("disability_severity(r) == 2", "disability_severity")
+
+    def test_denies_dynamic_metric(self):
+        self._assert_denied("metric('r.dci.dr' + '.severity', me) == 2")
+
+    def test_empty_expression_is_noop(self):
+        # Should not raise.
+        self.cel._enforce_predicate_policy("", self.policy)
+        self.cel._enforce_predicate_policy("   ", self.policy)

--- a/spp_dci_server_social/services/search_service.py
+++ b/spp_dci_server_social/services/search_service.py
@@ -2,7 +2,6 @@
 """DCI Social Registry Search Service - Maps Odoo partners to DCI schemas."""
 
 import logging
-import re
 import uuid
 from datetime import UTC, datetime
 from typing import Any
@@ -35,36 +34,44 @@ _ACCEPTED_SOCIAL_REG_TYPES = {
     "social",
 }
 
-# DCI CEL metrics that expose registry-derived facts which are not safe for
-# unauthorised external predicate filtering.  DCI Social Registry search
-# predicates are a caller-supplied oracle (including total_count), so a boolean
-# metric like r.dci.crvs.is_alive == false discloses the value one query at a
-# time even though it never appears in the response schema.  Deny these
-# sensitive metrics before compiling the expression.
+# Positive allowlist for externally-supplied DCI Social Registry predicates.
 #
-# Scope: disability (r.dci.dr.*) and vital/civil-status (r.dci.crvs.*)
-# accessors -- the private-data tier this guard protects.  Lower-risk Social
-# Registry / inter-registry metrics (r.dci.sr.*, r.dci.ibr.*) are intentionally
-# left filterable.
+# A predicate search is a caller-supplied oracle: it returns total_count and
+# pageable matches, so letting a sender filter on sensitive data discloses the
+# value one query at a time even when it never appears in the response schema
+# (e.g. r.disability_severity_id == 5, or r.dci.dr.severity('Vision') == 2).
+# Rather than denylisting known-sensitive symbols (which fails open as new
+# fields/metrics are added, and is bypassable via source obfuscation), we allow
+# only an explicit safe set and reject everything else (default-deny).
 #
-# Keep this list local instead of importing spp_dci_indicators: that addon is
-# optional and is not a dependency of the DCI Social Registry server.
-_DCI_PREDICATE_DENIED_METRICS = frozenset(
+# Fields: the person attributes legitimate SPDCI senders filter on, mirroring
+# _condition_to_domain's attribute_map (resolved Odoo field names).
+_PREDICATE_ALLOWED_FIELDS = frozenset(
     (
-        # Disability registry (functional severity + disability flags)
-        "r.dci.dr.severity",
-        "r.dci.dr.has_disability",
-        "r.dci.dr.assessed",
-        "r.dci.dr.vision_severe",
-        "r.dci.dr.hearing_severe",
-        "r.dci.dr.mobility_severe",
-        # CRVS (vital events / civil status)
-        "r.dci.crvs.has_event",
-        "r.dci.crvs.is_alive",
-        "r.dci.crvs.birth_verified",
-        "r.dci.crvs.is_married",
+        "name",
+        "given_name",
+        "family_name",
+        "birthdate",
+        "gender",
+        "phone",
+        "email",
+        "city",
+        "state_id.name",
+        "country_id.code",
     )
 )
+
+# Functions: pure scalar/date helpers only.  Excludes anything that reads
+# sensitive data (disability/CRVS helpers) or traverses relations.
+_PREDICATE_ALLOWED_FUNCTIONS = frozenset(("age_years", "date", "today", "now"))
+
+# DCI metrics: only the lower-risk Social Registry / inter-registry tiers are
+# filterable; disability (r.dci.dr.*) and vital/civil-status (r.dci.crvs.*)
+# metrics are not.  Prefix match covers future SR/IBR metrics automatically.
+_PREDICATE_ALLOWED_METRIC_PREFIXES = ("r.dci.sr.", "r.dci.ibr.")
+
+# Profile the Social Registry predicate path compiles against (individuals).
+_PREDICATE_PROFILE = "registry_individuals"
 
 
 class DCISocialSearchService:
@@ -398,20 +405,18 @@ class DCISocialSearchService:
         if not expression or not expression.strip():
             return []
 
-        self._validate_external_predicate_expression(expression)
-
-        # Use CEL service to compile expression to domain
+        # Use CEL service to compile expression to domain.  The predicate_policy
+        # enforces a positive allowlist on the resolved expression before it is
+        # translated or executed, so a sender cannot use the search as an oracle
+        # for sensitive fields/metrics (see _external_predicate_policy).
         cel_service = self.env["spp.cel.service"]
-
-        # Determine profile based on query context (individuals vs groups)
-        # Default to registry_individuals for Social Registry
-        profile = "registry_individuals"
 
         result = cel_service.compile_expression(
             expression,
-            profile=profile,
+            profile=_PREDICATE_PROFILE,
             base_domain=[],  # No additional base domain
             limit=0,  # We only need the domain, not IDs
+            predicate_policy=self._external_predicate_policy(),
         )
 
         if not result.get("valid"):
@@ -421,26 +426,22 @@ class DCISocialSearchService:
 
         return result.get("domain", [])
 
-    def _validate_external_predicate_expression(self, expression: str) -> None:
-        """Reject sensitive DCI metrics in sender-supplied predicates.
+    def _external_predicate_policy(self) -> dict:
+        """Positive allowlist passed to the CEL service for sender predicates.
 
         DCI predicate searches return counts and pageable matches, so allowing
-        callers to filter on raw DCI indicator cache values can disclose the
-        value by repeated queries even when the value is not present in the
-        response schema.  Internal CEL use can still compile these metrics; this
-        guard only applies to external Social Registry predicate search.
+        callers to filter on sensitive data discloses it by repeated queries
+        even when the value never appears in the response schema.  The CEL
+        service enforces this allowlist on the resolved expression before
+        translation/execution (default-deny).  Internal CEL use is unaffected --
+        only this external Social Registry predicate path supplies the policy.
         """
-        for accessor in _DCI_PREDICATE_DENIED_METRICS:
-            # Match the accessor as a dotted member path in any spelling that
-            # resolves to the metric: bare (r.dci.dr.has_disability), called
-            # (r.dci.dr.severity('Vision')), or quoted inside metric('...').
-            # CEL ignores whitespace around member-selection dots, so allow it
-            # (`r . dci . dr . severity`).  The boundaries reject a denied name
-            # that is only a prefix/substring of a longer identifier
-            # (r.dci.dr.severity_score, my_r.dci..., r.dci.crvs.is_alive_x).
-            accessor_pattern = r"\s*\.\s*".join(map(re.escape, accessor.split(".")))
-            if re.search(rf"(?<![\w.]){accessor_pattern}(?![\w.])", expression):
-                raise ValueError(_("Predicate searches cannot filter on sensitive DCI metric '%s'.") % accessor)
+        return {
+            "allowed_fields": _PREDICATE_ALLOWED_FIELDS,
+            "allowed_functions": _PREDICATE_ALLOWED_FUNCTIONS,
+            "allowed_metric_prefixes": _PREDICATE_ALLOWED_METRIC_PREFIXES,
+            "allow_relations": False,
+        }
 
     def _parse_expression(self, expression) -> list:
         """

--- a/spp_dci_server_social/services/search_service.py
+++ b/spp_dci_server_social/services/search_service.py
@@ -547,6 +547,14 @@ class DCISocialSearchService:
 
         field = attribute_map.get(attribute, attribute)
 
+        # Default-deny: an expression search is the same caller-supplied oracle
+        # as a predicate search, so it must not filter on attributes outside the
+        # safe person-field allowlist (e.g. disability_severity_id, has_disability).
+        # The resolved Odoo field is checked, so DCI aliases (surname, sex, ...)
+        # that map onto allowed fields are still accepted.
+        if field not in _PREDICATE_ALLOWED_FIELDS:
+            raise ValueError(_("Search cannot filter on attribute '%s'.") % attribute)
+
         # Map DCI operators to Odoo operators
         operator_map = {
             "=": "=",

--- a/spp_dci_server_social/tests/test_search_service.py
+++ b/spp_dci_server_social/tests/test_search_service.py
@@ -713,6 +713,36 @@ class TestDCISocialSearchService(DCISocialServerCommon):
         # Should return at least our test individuals
         self.assertGreaterEqual(response_item.pagination.total_count, 3)
 
+    def test_search_expression_rejects_sensitive_field(self):
+        """An expression-type search must not oracle sensitive partner fields.
+
+        The structured expression path is the same caller-supplied oracle as a
+        CEL predicate; filtering on a disability field must be rejected rather
+        than disclosed via total_count/pagination.
+        """
+        criteria = SearchCriteria(
+            reg_type="SOCIAL_REGISTRY",
+            reg_event_type="ACTIVE",
+            query_type="expression",
+            query={"seq": [{"attribute": "disability_severity_id", "operator": "=", "value": 5}]},
+        )
+        search_req = SearchRequestItem(
+            reference_id="test-ref-010e",
+            timestamp=datetime.now(UTC),
+            search_criteria=criteria,
+        )
+        request = SearchRequest(
+            transaction_id="test-txn-010e",
+            search_request=[search_req],
+        )
+        self.env.user.write({"group_ids": [(4, self.env.ref("spp_registry.group_registry_viewer").id)]})
+
+        response = self.search_service.execute_search(request)
+
+        response_item = response.search_response[0]
+        self.assertEqual(response_item.status, "rjct")
+        self.assertEqual(response_item.status_reason_code, "rjct.filter.invalid")
+
     def test_search_cursor_pagination(self):
         """Test cursor-based pagination for efficient large dataset traversal."""
         # First request without cursor

--- a/spp_dci_server_social/tests/test_search_service_internals.py
+++ b/spp_dci_server_social/tests/test_search_service_internals.py
@@ -41,9 +41,22 @@ class TestSearchServiceInternals(DCISocialServerCommon):
             field, _op, _val = self.service._condition_to_domain(dci_attr, "=", "x")
             self.assertEqual(field, odoo_field)
 
-    def test_condition_unknown_attribute_passthrough(self):
-        field, _, _ = self.service._condition_to_domain("custom_field", "=", "x")
-        self.assertEqual(field, "custom_field")
+    def test_condition_unknown_attribute_rejected(self):
+        # Default-deny: an attribute outside the safe person-field allowlist is
+        # rejected (previously it passed through as a raw field name, which let
+        # expression searches oracle sensitive partner fields).
+        with self.assertRaises(ValueError):
+            self.service._condition_to_domain("custom_field", "=", "x")
+
+    def test_condition_rejects_sensitive_partner_fields(self):
+        for attribute in (
+            "disability_severity_id",
+            "has_disability",
+            "disability_review_category",
+            "has_unmet_device_need",
+        ):
+            with self.assertRaises(ValueError):
+                self.service._condition_to_domain(attribute, "=", "x")
 
     def test_condition_operator_mapping(self):
         cases = {"==": "=", "contains": "ilike", "like": "ilike", ">=": ">="}

--- a/spp_dci_server_social/tests/test_search_service_internals.py
+++ b/spp_dci_server_social/tests/test_search_service_internals.py
@@ -12,6 +12,8 @@ from unittest.mock import patch
 
 from odoo.tests import tagged
 
+from odoo.addons.spp_cel_domain.exceptions import CELValidationError
+
 from ..services.search_service import DCISocialSearchService
 from .common import DCISocialServerCommon
 
@@ -92,6 +94,10 @@ class TestSearchServiceInternals(DCISocialServerCommon):
             "r.dci.crvs.has_event('death') == true",
             "metric('r.dci.dr.severity', me, arg='Vision') >= 3",
             'metric("r.dci.crvs.has_event", me, arg="death") == true',
+            # Backslash-escaped dots: the lexer decodes \. -> . so the metric
+            # still resolves; the AST guard sees the decoded name (the regex
+            # denylist this replaced did not).
+            r"metric('r\.dci\.dr\.severity', me, arg='Vision') >= 3",
             # Non-parameterized disability flags (boolean oracles)
             "r.dci.dr.has_disability == true",
             "r.dci.dr.vision_severe == true",
@@ -103,26 +109,58 @@ class TestSearchServiceInternals(DCISocialServerCommon):
         ]
         for expression in blocked:
             # Through _parse_predicate so the test also pins that the guard is
-            # wired in ahead of CEL compilation (it raises before the compiler).
+            # wired in ahead of CEL execution (it rejects before the query runs).
             with self.assertRaises(ValueError) as ctx:
                 self.service._parse_predicate(expression)
-            self.assertIn("sensitive DCI metric", str(ctx.exception))
+            self.assertIn("not permitted in external searches", str(ctx.exception))
 
-    def test_validate_external_predicate_allows_benign_and_lower_risk_metrics(self):
-        # The guard must not over-match: benign registry predicates, identifiers
-        # that merely contain a denied name as a substring, and the intentionally
-        # allowed lower-risk SR/IBR metrics all pass validation untouched.
+    def test_parse_predicate_rejects_sensitive_partner_fields(self):
+        # The disability data is also reachable via plain partner field paths
+        # (stored on res.partner) and disability CEL functions -- not just DCI
+        # metrics. Default-deny rejects these too.
+        blocked = [
+            "r.disability_severity_id == 5",
+            "r.has_disability == true",
+            "r.disability_review_category == 'high'",
+            "r.has_unmet_device_need == true",
+            "disability_severity(r) == 2",
+            "is_severe_disability(r) == true",
+            # Relation traversal that navigates back to the root partner's
+            # disability via a child predicate.
+            "enrollments.exists(m, m.partner_id.disability_severity_id == 5)",
+        ]
+        for expression in blocked:
+            with self.assertRaises(ValueError) as ctx:
+                self.service._parse_predicate(expression)
+            self.assertIn("not permitted in external searches", str(ctx.exception))
+
+    def test_external_predicate_policy_allows_benign_and_lower_risk_metrics(self):
+        # The allowlist must permit benign person predicates, safe scalar
+        # functions, and the intentionally-allowed lower-risk SR/IBR metrics.
+        policy = self.service._external_predicate_policy()
+        cel = self.env["spp.cel.service"]
         allowed = [
             "r.gender == 'female'",
+            "r.name == 'John'",
             "age_years(r.birthdate) >= 18",
-            "r.dci.dr.severity_score >= 3",  # not a call, different accessor
-            "my_r.dci.dr.severity('Vision') >= 3",  # prefixed identifier
             "r.dci.sr.household_size >= 5",
             "r.dci.ibr.has_duplicate == true",
         ]
         for expression in allowed:
             # Should not raise.
-            self.service._validate_external_predicate_expression(expression)
+            cel._enforce_predicate_policy(expression, policy)
+
+    def test_external_predicate_policy_denies_disability_namespace_and_fields(self):
+        # Behaviour change vs the old regex: anything in the disability metric
+        # namespace, and any non-allowlisted partner field, is now denied.
+        policy = self.service._external_predicate_policy()
+        cel = self.env["spp.cel.service"]
+        for expression in (
+            "r.dci.dr.severity_score >= 3",  # disability namespace
+            "r.poverty_score >= 50",  # arbitrary non-allowlisted field
+        ):
+            with self.assertRaises(CELValidationError):
+                cel._enforce_predicate_policy(expression, policy)
 
     # --- _to_dci_member ------------------------------------------------------
 


### PR DESCRIPTION
## Summary

External DCI Social Registry searches accept sender-supplied filters and compile them against `res.partner` with no restriction on which symbols/attributes a sender may reference. Because a search returns `total_count` and pageable matches, this turned the endpoint into an **oracle** for sensitive data (disability severity, vital/civil status) one query at a time — even though those values never appear in the response body.

The prior fix (#235) denylisted sensitive DCI metric accessors via a **regex over the raw predicate text**. This PR replaces that with a positive, default-deny **allowlist**, and closes the same oracle across **both** sender-controlled query paths.

## Why the denylist was insufficient

- **Bypassable.** The CEL lexer decodes `\.` → `.`, so `metric('r\.dci\.dr\.severity', me, arg='Vision') == 2` evaded the regex but still resolved to the metric.
- **Fail-open.** Every new sensitive metric had to be remembered in a denylist living in a *different, optional* module.
- **Predicate-only, and metric-only.** The same disability data is reachable without any CEL metric:
  - plain partner field paths — `r.disability_severity_id == 5`, `r.has_disability == true`;
  - relation traversal — `enrollments.exists(m, m.partner_id.disability_severity_id == 5)`;
  - the structured **`expression`** query type — `{"seq":[{"attribute":"disability_severity_id","operator":"=","value":5}]}`, which `_condition_to_domain` passed straight through as a raw field.

## The fix

A positive, default-deny allowlist applied to **both** external query paths.

**1. CEL `predicate` path** — checked on the **resolved CEL AST** (robust to source obfuscation and to domain rewriting like `_smart_op_domain`), gated **inside `compile_expression`** after variable resolution but before translation/execution, so the check operates on the exact expression that runs (no time-of-check/time-of-use gap).
- `spp_cel_domain/services/cel_predicate_guard.py` — `collect_referenced_symbols` walks the AST and classifies field paths, function calls, relation/namespaced methods, and DCI metric accessors. DCI accessors are recognised both as expanded `metric('r.dci.…', me)` calls and as raw dotted accessors, so the guard is independent of which indicator variables are seeded.
- `spp_cel_domain/models/cel_service.py` — `compile_expression(…, predicate_policy=None)` + `_enforce_predicate_policy`. **Keyword-only, default `None`** → all other callers (internal eligibility/scoring CEL that legitimately uses `r.dci.*` accessors) are unaffected.

**2. Structured `expression` path** — `spp_dci_server_social` `_condition_to_domain` now rejects any attribute whose resolved Odoo field is not in the allowlist (the single chokepoint for both `seq` and `or` conditions).

**Allowlist (`spp_dci_server_social`):** person fields (`name`, `given_name`, `family_name`, `birthdate`, `gender`, `phone`, `email`, `city`, `state_id.name`, `country_id.code`), safe scalar functions (`age_years`, `date`, `today`, `now`), and `r.dci.sr.*` / `r.dci.ibr.*` metrics. `idtype-value` is unaffected (it only touches `reg_ids`).

### Scope / non-impact
- **No change to `spp_dci_indicators`.** The DCI metric accessors, fetchers, resolver, and remote-server calls are untouched. This PR only restricts what an **inbound external sender** can filter on; OpenSPP's own **outbound** CEL (program eligibility/scoring referencing `r.dci.dr.severity`, which fetches from remote DCI servers) is unaffected.

### Behaviour change (fail-closed)
Disability/CRVS fields & metrics, relation traversal, disability CEL functions, and any other partner field or non-DCI metric are now **denied** in external searches. A field a legitimate sender needs is a one-line allowlist addition — never a silent leak.

## Tests

- `spp_cel_domain`: AST walker units + `_enforce_predicate_policy` allow/deny units.
- `spp_dci_server_social`: regressions for escaped-dot metric bypass, plain partner-field leak (predicate path), disability functions, relation traversal, and the **`expression`-type** disability filter; plus the allow-path for benign person predicates and SR/IBR metrics.

All green: **`spp_dci_server_social` 74/74 · `spp_cel_domain` 616/616 · `spp_dci_indicators` 81/81**. Lint-clean (ruff/ruff-format/semgrep/bandit/OpenSPP hooks).
